### PR TITLE
Expand the Playgrounds sidebar sub-menu by default

### DIFF
--- a/webapp/src/app/components/sidebar/sidebar.component.ts
+++ b/webapp/src/app/components/sidebar/sidebar.component.ts
@@ -17,7 +17,7 @@ export class SidebarComponent extends BaseComponent implements OnInit {
   routeEnum!: RouteEnum;
   currentTheme$;
   isDocsExpanded = false;
-  isPlaygroundsExpanded = false;
+  isPlaygroundsExpanded = true;
 
   constructor(@Inject(DOCUMENT) document: Document,
               @Inject(PLATFORM_ID) private platformId: Object,


### PR DESCRIPTION
## Summary

The Playgrounds section of the sidebar started collapsed, so the playground links were hidden unless the user was already on a `/playgrounds` route. This flips the default to expanded.

One-line change in `webapp/src/app/components/sidebar/sidebar.component.ts`:

```diff
-  isPlaygroundsExpanded = false;
+  isPlaygroundsExpanded = true;
```

## Behaviour

- Playground links are now visible on first load.
- `togglePlaygrounds()` still collapses/expands as before.
- The `ngOnInit` route check that force-expands the section on `/playgrounds` routes is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)