### PR TITLE
Add Semantic Embedder playground

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -146,6 +146,7 @@ import { RewriterPlaygroundPage } from './pages/playgrounds/rewriter/rewriter.pa
 import { TranslatorPlaygroundPage } from './pages/playgrounds/translator/translator.page';
 import { LanguageDetectorPlaygroundPage } from './pages/playgrounds/language-detector/language-detector.page';
 import { ProofreaderPlaygroundPage } from './pages/playgrounds/proofreader/proofreader.page';
+import { SemanticEmbedderPlaygroundPage } from './pages/playgrounds/semantic-embedder/semantic-embedder.page';
 import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-speech.page';
 
 @NgModule({
@@ -189,6 +190,7 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     TranslatorPlaygroundPage,
     LanguageDetectorPlaygroundPage,
     ProofreaderPlaygroundPage,
+    SemanticEmbedderPlaygroundPage,
     WebSpeechPlaygroundPage,
     DemoLayoutComponent,
     SafeHtmlPipe,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -58,6 +58,7 @@ import { RewriterPlaygroundPage } from './pages/playgrounds/rewriter/rewriter.pa
 import { TranslatorPlaygroundPage } from './pages/playgrounds/translator/translator.page';
 import { LanguageDetectorPlaygroundPage } from './pages/playgrounds/language-detector/language-detector.page';
 import { ProofreaderPlaygroundPage } from './pages/playgrounds/proofreader/proofreader.page';
+import { SemanticEmbedderPlaygroundPage } from './pages/playgrounds/semantic-embedder/semantic-embedder.page';
 import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-speech.page';
 
 const routes: Routes = [
@@ -238,6 +239,13 @@ const routes: Routes = [
         component: ProofreaderPlaygroundPage,
         data: {
           route: RouteEnum.PlaygroundsProofreader
+        }
+      },
+      {
+        path: "playgrounds/semantic-embedder",
+        component: SemanticEmbedderPlaygroundPage,
+        data: {
+          route: RouteEnum.PlaygroundsSemanticEmbedder
         }
       },
       {

--- a/webapp/src/app/components/sidebar/sidebar.component.html
+++ b/webapp/src/app/components/sidebar/sidebar.component.html
@@ -393,6 +393,16 @@
               <span>Proofreader API</span>
             </a>
 
+            <!-- Semantic Embedder API -->
+            <a [routerLink]="getRouterLink(RouteEnum.PlaygroundsSemanticEmbedder)"
+               class="!no-underline group flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 cursor-pointer relative"
+               [ngClass]="routeEnum === RouteEnum.PlaygroundsSemanticEmbedder ? 'bg-slate-100 dark:bg-zinc-800/80 !text-slate-900 dark:!text-white shadow-sm ring-1 ring-slate-200/50 dark:ring-zinc-700/50' : '!text-slate-500 dark:!text-slate-400 hover:bg-slate-100/50 dark:hover:bg-zinc-800/40 hover:!text-slate-800 dark:hover:!text-slate-200'">
+              @if (routeEnum === RouteEnum.PlaygroundsSemanticEmbedder) {
+                <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
+              }
+              <span>Semantic Embedder API</span>
+            </a>
+
             <!-- Web Speech API -->
             <a [routerLink]="getRouterLink(RouteEnum.PlaygroundsWebSpeech)"
                class="!no-underline group flex items-center justify-between px-3 py-2 rounded-lg text-sm font-medium transition-all duration-150 cursor-pointer relative"

--- a/webapp/src/app/components/sidebar/sidebar.component.ts
+++ b/webapp/src/app/components/sidebar/sidebar.component.ts
@@ -104,6 +104,7 @@ export class SidebarComponent extends BaseComponent implements OnInit {
       RouteEnum.PlaygroundsTranslator,
       RouteEnum.PlaygroundsLanguageDetector,
       RouteEnum.PlaygroundsProofreader,
+      RouteEnum.PlaygroundsSemanticEmbedder,
       RouteEnum.PlaygroundsWebSpeech
     ].includes(this.routeEnum);
   }
@@ -129,6 +130,7 @@ export class SidebarComponent extends BaseComponent implements OnInit {
       else if (pathname.includes('translator')) this.routeEnum = RouteEnum.PlaygroundsTranslator;
       else if (pathname.includes('language-detector')) this.routeEnum = RouteEnum.PlaygroundsLanguageDetector;
       else if (pathname.includes('proofreader')) this.routeEnum = RouteEnum.PlaygroundsProofreader;
+      else if (pathname.includes('semantic-embedder')) this.routeEnum = RouteEnum.PlaygroundsSemanticEmbedder;
       else if (pathname.includes('web-speech')) this.routeEnum = RouteEnum.PlaygroundsWebSpeech;
       return;
     }

--- a/webapp/src/app/enums/route.enum.ts
+++ b/webapp/src/app/enums/route.enum.ts
@@ -34,5 +34,6 @@ export enum RouteEnum {
   PlaygroundsTranslator = "/playgrounds/translator",
   PlaygroundsLanguageDetector = "/playgrounds/language-detector",
   PlaygroundsProofreader = "/playgrounds/proofreader",
+  PlaygroundsSemanticEmbedder = "/playgrounds/semantic-embedder",
   PlaygroundsWebSpeech = "/playgrounds/web-speech",
 }

--- a/webapp/src/app/pages/docs/apis/semantic-embedder-api.page.ts
+++ b/webapp/src/app/pages/docs/apis/semantic-embedder-api.page.ts
@@ -20,8 +20,8 @@ import { Component } from '@angular/core';
                 <h1 class="text-4xl font-extrabold text-slate-900 dark:text-white tracking-tight">
                   Semantic Embedder API
                 </h1>
-                <span class="px-2 py-0.5 rounded text-[10px] font-bold bg-violet-100 dark:bg-violet-500/20 text-violet-700 dark:text-violet-400 uppercase tracking-wider border border-violet-200 dark:border-violet-500/30">
-                  Explainer
+                <span class="px-2 py-0.5 rounded text-[10px] font-bold bg-amber-100 dark:bg-amber-500/20 text-amber-700 dark:text-amber-400 uppercase tracking-wider border border-amber-200 dark:border-amber-500/30">
+                  Dev Trial
                 </span>
               </div>
             </div>
@@ -34,6 +34,9 @@ import { Component } from '@angular/core';
               <a href="https://github.com/explainers-by-googlers/semantic-embedder-api/issues" target="_blank" class="!no-underline px-3 py-1.5 rounded-lg text-xs font-semibold bg-slate-100 dark:bg-zinc-800 text-slate-700 dark:text-slate-300 hover:bg-slate-200 dark:hover:bg-zinc-700 transition-colors border border-slate-200 dark:border-zinc-700 flex items-center gap-2">
                 <i class="bi bi-bug"></i> File an issue
               </a>
+              <a routerLink="/playgrounds/semantic-embedder" class="!no-underline px-3 py-1.5 rounded-lg text-xs font-semibold bg-indigo-600 text-white hover:bg-indigo-700 transition-colors border border-indigo-600 flex items-center gap-2">
+                <i class="bi bi-play-circle"></i> Playground
+              </a>
             </div>
           </div>
 
@@ -41,11 +44,11 @@ import { Component } from '@angular/core';
             The Semantic Embedder API generates high-dimensional vector representations (embeddings) of text directly on the user's device. It unlocks semantic search, retrieval-augmented generation, and real-time content intelligence without the latency, cost, and privacy trade-offs of cloud embedding services — or the storage bloat of every site shipping its own model.
           </p>
 
-          <!-- Proposal Notice -->
-          <div class="mt-6 p-4 bg-violet-50 dark:bg-violet-900/10 border border-violet-200 dark:border-violet-900/30 rounded-xl text-violet-800 dark:text-violet-300 text-sm leading-relaxed max-w-4xl flex gap-3">
-            <i class="bi bi-lightbulb-fill text-lg mt-0.5"></i>
+          <!-- Dev Trial Notice -->
+          <div class="mt-6 p-4 bg-amber-50 dark:bg-amber-900/10 border border-amber-200 dark:border-amber-900/30 rounded-xl text-amber-800 dark:text-amber-300 text-sm leading-relaxed max-w-4xl flex gap-3">
+            <i class="bi bi-exclamation-triangle-fill text-lg mt-0.5"></i>
             <div>
-              <strong>Early proposal:</strong> This is a design sketch by the Chrome Built-in AI team to describe the problem and solicit feedback. It has <strong>not been approved to ship in Chrome</strong>, no <code class="bg-violet-100 dark:bg-violet-900/30 px-1 py-0.5 rounded text-xs font-mono">chrome://flags</code> entry exists yet, and the shape of the API — including the <code class="bg-violet-100 dark:bg-violet-900/30 px-1 py-0.5 rounded text-xs font-mono">SemanticEmbedder</code> name itself — is still an open question.
+              <strong>Developer Trial:</strong> This API is in an early developer trial. To use it, run <strong>Chrome Canary</strong> and enable the <strong>#semantic-embedder-api</strong> flag in <code class="bg-amber-100 dark:bg-amber-900/30 px-1 py-0.5 rounded text-xs font-mono">chrome://flags</code>. It has not yet been approved to ship, and the shape of the API — including the <code class="bg-amber-100 dark:bg-amber-900/30 px-1 py-0.5 rounded text-xs font-mono">SemanticEmbedder</code> name itself — is still an open question.
             </div>
           </div>
         </div>

--- a/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.html
+++ b/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.html
@@ -1,0 +1,327 @@
+<div class="w-full font-sans pb-24 bg-slate-50 dark:bg-[#0a0a0a] min-h-full">
+  <!-- Hero Header -->
+  <div class="h-28 bg-white/80 dark:bg-[#121212]/80 backdrop-blur-md border-b border-slate-200 dark:border-zinc-800 flex items-center justify-between px-6 md:px-8 sticky top-0 z-20 flex-shrink-0 shadow-sm">
+    <div class="max-w-4xl mx-auto flex items-center justify-between gap-4 w-full">
+      <div class="flex items-center gap-3 text-left">
+        <div class="rounded-md w-8 h-8 bg-indigo-50 dark:bg-indigo-500/10 border border-indigo-100 dark:border-indigo-500/20 flex items-center justify-center text-indigo-600 dark:text-indigo-400 shrink-0">
+          <i class="bi bi-diagram-3 text-2xl"></i>
+        </div>
+        <div>
+          <h1 class="text-xl font-semibold text-slate-800 dark:text-white">Semantic Embedder</h1>
+          <p class="text-sm font-medium text-slate-500 dark:text-slate-400 mt-0.5">Turn text into on-device vectors and compare their meaning.</p>
+        </div>
+      </div>
+      <div class="flex items-center gap-2">
+        <button type="button" (click)="sharePlayground()" class="rounded-lg hidden sm:inline-flex items-center gap-2 px-4 py-2 bg-indigo-50 hover:bg-indigo-100 dark:bg-indigo-500/10 dark:hover:bg-indigo-500/20 text-indigo-700 dark:text-indigo-400 text-sm font-bold shadow-sm transition-colors border border-indigo-200 dark:border-indigo-500/30 shrink-0">
+          <i class="bi" [ngClass]="shareText === 'Copied!' ? 'bi-check2' : 'bi-share'"></i> {{shareText}}
+        </button>
+        <a routerLink="/docs/semantic-embedder" class="rounded-lg hidden sm:inline-flex items-center gap-2 px-4 py-2 bg-white hover:bg-slate-50 dark:bg-zinc-900 dark:hover:bg-zinc-800 text-indigo-600 dark:text-indigo-400 text-sm font-bold shadow-sm transition-colors border border-indigo-100 dark:border-indigo-500/30 shrink-0" style="text-decoration: none;">
+          <i class="bi bi-book"></i> Read the docs
+        </a>
+      </div>
+    </div>
+  </div>
+
+  <div class="max-w-4xl mx-auto p-8 space-y-8">
+
+    <!-- Flag notice -->
+    <div class="p-4 bg-violet-50 dark:bg-violet-900/10 border border-violet-200 dark:border-violet-900/30 rounded-xl text-violet-800 dark:text-violet-300 text-sm leading-relaxed flex gap-3">
+      <i class="bi bi-flag-fill text-lg mt-0.5"></i>
+      <div>
+        This API is in an early developer trial. Use <strong>Chrome Canary</strong> and enable <code class="bg-violet-100 dark:bg-violet-900/30 px-1 py-0.5 rounded text-xs font-mono">#semantic-embedder-api</code> in <code class="bg-violet-100 dark:bg-violet-900/30 px-1 py-0.5 rounded text-xs font-mono">chrome://flags</code>. The shape of the API may still change.
+      </div>
+    </div>
+
+    <form [formGroup]="playgroundForm" class="space-y-8">
+
+      <!-- 1. Configuration -->
+      <div class="bg-white dark:bg-[#121212] rounded-xl shadow-sm border border-slate-200 dark:border-zinc-800 overflow-hidden">
+        <div class="border-b border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 px-6 py-3 flex items-center gap-3">
+          <div class="flex items-center justify-center w-6 h-6 rounded-full bg-slate-200 dark:bg-zinc-700 text-slate-700 dark:text-slate-300 text-xs font-bold">1</div>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-0">Configuration</h2>
+        </div>
+        <div class="p-6 space-y-6">
+
+          <div>
+            <div class="flex justify-between items-center mb-2">
+              <label class="block text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider pl-1">Task Type Hint</label>
+              <span class="text-[10px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400">Under discussion</span>
+            </div>
+            <select formControlName="taskType" class="w-full text-sm bg-white dark:bg-[#121212] border border-slate-200 dark:border-zinc-700 rounded-lg px-4 py-2.5 shadow-sm focus:outline-none focus:ring-2 focus:ring-indigo-500 text-slate-700 dark:text-slate-300 font-medium">
+              <option *ngFor="let t of taskTypes" [value]="t.value">{{t.label}}</option>
+            </select>
+            <p class="text-xs text-slate-500 dark:text-slate-400 mt-2 pl-1 font-medium">
+              An optional hint to optimize embedding quality for a use case. Browsers may safely ignore it.
+            </p>
+          </div>
+
+          <details class="group bg-slate-50 dark:bg-zinc-900 rounded-lg border border-slate-200 dark:border-zinc-800 overflow-hidden mt-3">
+            <summary class="px-5 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-100 dark:hover:bg-zinc-800/50 cursor-pointer list-none transition-colors [&::-webkit-details-marker]:hidden">
+              <div class="flex items-center justify-between w-full">
+                <span class="flex items-center gap-2"><i class="bi bi-gear text-slate-400"></i> Advanced Session Configuration</span>
+                <i class="bi bi-chevron-down text-slate-400 group-open:rotate-180 transition-transform"></i>
+              </div>
+            </summary>
+            <div class="p-3 border-t border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 space-y-3">
+              <div class="flex items-center gap-3 mt-3 bg-white dark:bg-zinc-800 p-3 rounded-lg border border-slate-200 dark:border-zinc-700 shadow-sm">
+                <input type="checkbox" formControlName="useAbortSignal" class="w-5 h-5 rounded text-indigo-600 focus:ring-indigo-500 dark:bg-zinc-900 dark:border-zinc-600 cursor-pointer">
+                <span class="text-sm font-semibold text-slate-700 dark:text-slate-300">Use Abort Signal for Cancellations</span>
+              </div>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- 2. Check Availability -->
+      <div class="bg-white dark:bg-[#121212] rounded-xl shadow-sm border border-slate-200 dark:border-zinc-800 relative overflow-hidden">
+        <div class="border-b border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 px-6 py-3 flex items-center gap-3">
+          <div class="flex items-center justify-center w-6 h-6 rounded-full bg-slate-200 dark:bg-zinc-700 text-slate-700 dark:text-slate-300 text-xs font-bold">2</div>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-0">Check Availability</h2>
+        </div>
+        <div class="p-6 space-y-6">
+          <div class="flex flex-col sm:flex-row sm:items-center gap-4">
+            <button type="button" (click)="checkAvailability()" class="rounded-lg px-6 py-2.5 bg-slate-900 dark:bg-white text-white dark:text-slate-900 text-sm font-medium shadow-sm hover:bg-slate-800 dark:hover:bg-slate-200 transition-colors flex items-center gap-2 w-fit">
+              <i class="bi bi-activity"></i> Check Availability
+            </button>
+            <div *ngIf="availabilityStatus" class="flex items-center gap-2">
+              <span class="text-sm font-medium text-slate-500 dark:text-slate-400">Status:</span>
+              <span class="rounded-lg px-3 py-1.5 text-xs font-mono font-bold tracking-wide border shadow-sm"
+                    [ngClass]="{'bg-emerald-50 text-emerald-700 border-emerald-200 dark:bg-emerald-500/10 dark:text-emerald-400 dark:border-emerald-500/20': availabilityStatus === 'available', 'bg-amber-50 text-amber-700 border-amber-200 dark:bg-amber-500/10 dark:text-amber-400 dark:border-amber-500/20': availabilityStatus !== 'available'}">
+                {{availabilityStatus}}
+              </span>
+              <span *ngIf="availabilityTimeMs !== null" class="text-xs font-medium text-slate-500 dark:text-slate-400 font-mono">
+                {{availabilityTimeMs}}ms
+              </span>
+            </div>
+          </div>
+          <details class="group bg-white dark:bg-[#121212] rounded-lg border border-slate-200 dark:border-zinc-800 overflow-hidden mt-3">
+            <summary class="px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-zinc-800/50 cursor-pointer list-none transition-colors [&::-webkit-details-marker]:hidden">
+              <div class="flex items-center justify-between w-full">
+                <span class="flex items-center gap-2"><i class="bi bi-code text-slate-400"></i> View Initialization Code</span>
+                <i class="bi bi-chevron-down text-slate-400 group-open:rotate-180 transition-transform"></i>
+              </div>
+            </summary>
+            <div class="h-[300px] min-h-[200px] resize-y border-t border-slate-200 dark:border-zinc-800 overflow-auto relative bg-slate-100 dark:bg-[#0d1117]">
+              <app-code-editor [code]="codeAvailability" [language]="'javascript'" [height]="'100%'" [readOnly]="true"></app-code-editor>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- 3. Create Session -->
+      <div class="bg-white dark:bg-[#121212] rounded-xl shadow-sm border border-slate-200 dark:border-zinc-800 overflow-hidden">
+        <div class="border-b border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 px-6 py-3 flex items-center gap-3">
+          <div class="flex items-center justify-center w-6 h-6 rounded-full bg-slate-200 dark:bg-zinc-700 text-slate-700 dark:text-slate-300 text-xs font-bold">3</div>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-0">Create Session</h2>
+        </div>
+        <div class="p-6 space-y-6">
+
+          <p class="text-slate-600 dark:text-slate-400 text-sm font-medium mb-4">Initialize the embedder with the configuration defined above. The model downloads on first use.</p>
+
+          <div class="flex flex-col items-center gap-3">
+            <div *ngIf="!session && !isCreating" class="w-full flex justify-center">
+              <button type="button" (click)="createSession()" class="rounded-lg group relative px-6 py-3 w-full bg-indigo-600 text-white text-sm font-semibold shadow-md hover:bg-indigo-700 transition-colors flex items-center justify-center gap-2">
+                <i class="bi bi-play-circle text-lg"></i> Create Semantic Embedder
+              </button>
+            </div>
+
+            <div *ngIf="isCreating" class="rounded-lg px-5 py-2 bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-400 font-bold text-sm border border-indigo-100 dark:border-indigo-500/20 shadow-sm flex flex-col items-center justify-center gap-2 w-full sm:w-auto min-w-[280px]">
+              <div class="flex items-center gap-2"><i class="bi bi-arrow-repeat animate-spin text-lg"></i> Initializing Session... <span *ngIf="sessionCreationTimeMs !== null" class="text-xs font-mono ml-1">{{sessionCreationTimeMs}}ms</span></div>
+              <div *ngIf="isDownloading" class="w-full bg-indigo-200 dark:bg-indigo-900/50 h-1.5 mt-1 overflow-hidden shadow-inner" style="border-radius: 9999px !important;">
+                <div class="bg-indigo-600 dark:bg-indigo-400 h-1.5 transition-all duration-300 ease-out" style="border-radius: 9999px !important;" [style.width]="downloadProgress + '%'"></div>
+              </div>
+              <button *ngIf="isDownloading" type="button" (click)="abortCreation()" class="text-xs font-bold underline hover:no-underline">Abort</button>
+            </div>
+
+            <div *ngIf="session" class="flex flex-col sm:flex-row items-center gap-3 w-full justify-center">
+              <div class="rounded-lg px-5 py-2 bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 font-bold text-sm border border-emerald-100 dark:border-emerald-500/20 shadow-sm flex items-center justify-center gap-2 w-full sm:w-auto">
+                <i class="bi bi-check-circle-fill"></i> Session Active <span *ngIf="sessionCreationTimeMs !== null" class="text-xs font-mono ml-1">{{sessionCreationTimeMs}}ms</span>
+              </div>
+              <button type="button" (click)="destroySession()" [disabled]="isEmbedding" class="rounded-md px-3 py-2 bg-white dark:bg-zinc-800 text-red-500 dark:text-red-400 font-bold text-sm border border-slate-200 dark:border-zinc-700 hover:bg-red-50 dark:hover:bg-zinc-700 transition-all flex items-center justify-center disabled:opacity-50 hover:border-red-200 dark:hover:border-red-900/50 shadow-sm" title="Destroy Session">
+                <i class="bi bi-trash3 text-lg"></i>
+              </button>
+            </div>
+          </div>
+
+          <details class="group bg-white dark:bg-[#121212] rounded-lg border border-slate-200 dark:border-zinc-800 overflow-hidden mt-6">
+            <summary class="px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-zinc-800/50 cursor-pointer list-none transition-colors [&::-webkit-details-marker]:hidden">
+              <div class="flex items-center justify-between w-full">
+                <span class="flex items-center gap-2"><i class="bi bi-code text-slate-400"></i> View Session Creation Code</span>
+                <i class="bi bi-chevron-down text-slate-400 group-open:rotate-180 transition-transform"></i>
+              </div>
+            </summary>
+            <div class="h-[300px] min-h-[200px] resize-y border-t border-slate-200 dark:border-zinc-800 overflow-auto relative bg-slate-100 dark:bg-[#0d1117]">
+              <app-code-editor [code]="codeSession" [language]="'javascript'" [height]="'100%'" [readOnly]="true"></app-code-editor>
+            </div>
+          </details>
+        </div>
+      </div>
+
+      <!-- 4. Input -->
+      <div class="bg-white dark:bg-[#121212] rounded-xl shadow-sm border border-slate-200 dark:border-zinc-800 relative overflow-hidden">
+        <div class="border-b border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 px-6 py-3 flex items-center gap-3">
+          <div class="flex items-center justify-center w-6 h-6 rounded-full bg-slate-200 dark:bg-zinc-700 text-slate-700 dark:text-slate-300 text-xs font-bold">4</div>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-0">The Input</h2>
+        </div>
+        <div class="p-6 space-y-6">
+
+          <div class="flex justify-between items-center mb-2">
+            <label class="block text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider pl-1">Passages to embed</label>
+            <span class="text-xs font-medium text-slate-500 dark:text-slate-400">{{inputs.length}} input(s)</span>
+          </div>
+
+          <p class="text-xs text-slate-500 dark:text-slate-400 pl-1 font-medium -mt-3">
+            One input embeds a single string; two or more are sent as a batch in a single <code class="font-mono">embed()</code> call. The API does not chunk for you — keep each passage within the model's token limit.
+          </p>
+
+          <div formArrayName="inputs" class="space-y-3">
+            <div *ngFor="let control of inputs.controls; let i = index" class="flex gap-2 items-start">
+              <div class="mt-3 w-6 h-6 shrink-0 rounded-full bg-slate-100 dark:bg-zinc-800 text-slate-600 dark:text-slate-400 text-xs font-bold flex items-center justify-center">{{i + 1}}</div>
+              <textarea [formControlName]="i" class="w-full p-3 text-slate-700 dark:text-slate-300 bg-white dark:bg-[#121212] border border-slate-200 dark:border-zinc-700 rounded-lg focus:ring-2 focus:ring-indigo-500/20 focus:border-indigo-500 resize-y min-h-[70px] leading-relaxed text-sm outline-none placeholder-slate-400 dark:placeholder-zinc-600 font-medium transition-all shadow-sm" placeholder="A passage to embed..."></textarea>
+              <button type="button" (click)="removeInput(i)" [disabled]="inputs.length === 1" class="mt-2 rounded-md px-2.5 py-2 bg-white dark:bg-zinc-800 text-red-500 dark:text-red-400 text-sm border border-slate-200 dark:border-zinc-700 hover:bg-red-50 dark:hover:bg-zinc-700 transition-all disabled:opacity-30 disabled:pointer-events-none shadow-sm shrink-0" title="Remove input">
+                <i class="bi bi-x-lg"></i>
+              </button>
+            </div>
+          </div>
+
+          <button type="button" (click)="addInput()" class="rounded-lg px-4 py-2 bg-slate-100 dark:bg-zinc-800 text-slate-700 dark:text-slate-300 text-sm font-semibold hover:bg-slate-200 dark:hover:bg-zinc-700 transition-colors flex items-center gap-2 border border-slate-200 dark:border-zinc-700">
+            <i class="bi bi-plus-lg"></i> Add passage
+          </button>
+        </div>
+      </div>
+
+      <!-- 5. Execution -->
+      <div class="bg-white dark:bg-[#121212] rounded-xl shadow-sm border border-slate-200 dark:border-zinc-800 overflow-hidden">
+        <div class="border-b border-slate-100 dark:border-zinc-800 bg-slate-50/50 dark:bg-zinc-900/50 px-6 py-3 flex items-center gap-3">
+          <div class="flex items-center justify-center w-6 h-6 rounded-full bg-slate-200 dark:bg-zinc-700 text-slate-700 dark:text-slate-300 text-xs font-bold">5</div>
+          <h2 class="text-sm font-semibold text-slate-800 dark:text-slate-200 mb-0">Execution</h2>
+        </div>
+        <div class="p-6 space-y-6">
+
+          <div class="py-4 flex flex-col items-center gap-3">
+            <div class="flex flex-col sm:flex-row items-center gap-3 w-full justify-center transition-all" [class.opacity-50]="!session" [class.pointer-events-none]="!session">
+              <div class="flex flex-wrap items-center justify-center gap-3 w-full bg-slate-50/50 dark:bg-zinc-900/30 p-4 rounded-xl border border-slate-200 dark:border-zinc-800">
+                <button type="button" (click)="runPrompt()" [disabled]="isEmbedding" class="rounded-lg flex-1 sm:flex-none px-6 py-2.5 bg-slate-800 dark:bg-white text-white dark:text-slate-900 font-semibold text-sm shadow-sm hover:shadow-md transition-all overflow-hidden disabled:opacity-50">
+                  <span class="flex items-center justify-center gap-2"><i class="bi bi-diagram-3 text-lg" [ngClass]="isEmbedding ? 'animate-pulse' : ''"></i> {{ isEmbedding ? 'Embedding...' : 'Generate Embeddings' }}</span>
+                </button>
+                <button *ngIf="isEmbedding" type="button" (click)="abortPrompt()" class="rounded-lg px-5 py-2.5 bg-white dark:bg-zinc-800 text-red-500 dark:text-red-400 font-semibold text-sm border border-slate-200 dark:border-zinc-700 hover:bg-red-50 dark:hover:bg-zinc-700 transition-all shadow-sm">
+                  <span class="flex items-center justify-center gap-2"><i class="bi bi-stop-circle"></i> Abort</span>
+                </button>
+              </div>
+            </div>
+          </div>
+
+          <details class="group bg-white dark:bg-[#121212] rounded-lg border border-slate-200 dark:border-zinc-800 overflow-hidden mt-6">
+            <summary class="px-4 py-3 text-sm font-medium text-slate-700 dark:text-slate-300 hover:bg-slate-50 dark:hover:bg-zinc-800/50 cursor-pointer list-none transition-colors [&::-webkit-details-marker]:hidden">
+              <div class="flex items-center justify-between w-full">
+                <span class="flex items-center gap-2"><i class="bi bi-code text-slate-400"></i> View Execution Code</span>
+                <i class="bi bi-chevron-down text-slate-400 group-open:rotate-180 transition-transform"></i>
+              </div>
+            </summary>
+            <div class="h-[600px] min-h-[400px] resize-y border-t border-slate-200 dark:border-zinc-800 overflow-auto relative bg-slate-100 dark:bg-[#0d1117]">
+              <app-code-editor [code]="codeExecution" [language]="'javascript'" [height]="'100%'" [readOnly]="true"></app-code-editor>
+            </div>
+          </details>
+
+          <!-- Output -->
+          <div id="output-section" class="bg-white dark:bg-zinc-900 rounded-lg shadow-sm border border-slate-200 dark:border-zinc-800 overflow-hidden relative transition-all mt-6" [class.opacity-50]="!session && embeddings.length === 0 && !errorMessage">
+            <div class="px-5 py-3 border-b border-slate-100 dark:border-zinc-800 flex justify-between items-center bg-slate-50/50 dark:bg-zinc-800/50">
+              <div class="flex items-center gap-3">
+                <div class="w-6 h-6 bg-indigo-50 dark:bg-indigo-500/10 flex items-center justify-center text-indigo-500 dark:text-indigo-400 rounded">
+                  <i class="bi bi-stars text-sm"></i>
+                </div>
+                <span class="font-bold text-slate-800 dark:text-slate-200 text-sm">Execution Output</span>
+              </div>
+              <div *ngIf="executionTimeMs !== null" class="text-xs font-medium text-slate-500 dark:text-slate-400 font-mono">
+                {{executionTimeMs}}ms
+              </div>
+            </div>
+
+            <div class="p-6 md:p-8 text-base leading-relaxed text-slate-800 dark:text-slate-200 min-h-[120px] flex flex-col justify-center">
+              <div *ngIf="errorMessage" class="p-3 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 rounded-lg text-sm font-medium border border-red-200 dark:border-red-500/20 mb-3 flex items-start gap-3 shadow-sm">
+                <i class="bi bi-exclamation-triangle-fill text-lg mt-0.5"></i>
+                <div>{{errorMessage}}</div>
+              </div>
+
+              <span *ngIf="embeddings.length === 0 && !isEmbedding && !errorMessage" class="text-slate-400 dark:text-slate-500 italic font-semibold flex items-center justify-center text-sm w-full">Generate embeddings to see the vectors.</span>
+              <span *ngIf="isEmbedding" class="text-indigo-500 dark:text-indigo-400 italic animate-pulse flex items-center justify-center gap-2 text-base font-medium w-full"><i class="bi bi-magic text-xl"></i> Embedding...</span>
+
+              <div *ngIf="embeddings.length > 0" class="space-y-6">
+
+                <!-- Metadata -->
+                <div *ngIf="metadata" class="flex flex-wrap gap-3">
+                  <div class="px-4 py-2 rounded-lg bg-slate-50 dark:bg-[#121212] border border-slate-200 dark:border-zinc-700 shadow-sm">
+                    <div class="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Embedding space</div>
+                    <div class="font-mono font-bold text-sm text-indigo-600 dark:text-indigo-400">{{metadata.embeddingSpace || 'N/A'}}</div>
+                  </div>
+                  <div class="px-4 py-2 rounded-lg bg-slate-50 dark:bg-[#121212] border border-slate-200 dark:border-zinc-700 shadow-sm">
+                    <div class="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Max input tokens</div>
+                    <div class="font-mono font-bold text-sm text-slate-700 dark:text-slate-300">{{metadata.maxInputTokens ?? 'N/A'}}</div>
+                  </div>
+                  <div class="px-4 py-2 rounded-lg bg-slate-50 dark:bg-[#121212] border border-slate-200 dark:border-zinc-700 shadow-sm">
+                    <div class="text-[10px] font-bold uppercase tracking-wider text-slate-500 dark:text-slate-400">Dimensions</div>
+                    <div class="font-mono font-bold text-sm text-slate-700 dark:text-slate-300">{{embeddings[0].dimensions}}</div>
+                  </div>
+                </div>
+
+                <!-- Vectors -->
+                <div>
+                  <h3 class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-3">Vectors</h3>
+                  <ul class="space-y-3">
+                    <li *ngFor="let row of embeddings; let i = index" class="p-4 bg-slate-50 dark:bg-[#121212] rounded-lg border border-slate-200 dark:border-zinc-700 shadow-sm">
+                      <div class="flex items-start justify-between gap-4 mb-2">
+                        <div class="flex items-start gap-3 min-w-0">
+                          <span class="mt-0.5 w-6 h-6 shrink-0 rounded-full bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 text-xs font-bold flex items-center justify-center">{{i + 1}}</span>
+                          <span class="text-sm font-medium text-slate-700 dark:text-slate-300 break-words">{{row.text}}</span>
+                        </div>
+                        <button type="button" (click)="copyVector(row)" class="shrink-0 rounded-md px-2.5 py-1.5 bg-white dark:bg-zinc-800 text-slate-500 dark:text-slate-400 text-xs border border-slate-200 dark:border-zinc-700 hover:bg-slate-100 dark:hover:bg-zinc-700 transition-all shadow-sm" title="Copy full vector as JSON">
+                          <i class="bi bi-clipboard"></i>
+                        </button>
+                      </div>
+                      <div class="flex flex-wrap gap-3 text-xs font-medium text-slate-500 dark:text-slate-400 mb-2 pl-9">
+                        <span><span class="font-mono font-bold text-slate-700 dark:text-slate-300">{{row.dimensions}}</span> dims</span>
+                        <span><span class="font-mono font-bold text-slate-700 dark:text-slate-300">{{row.tokenCount ?? 'N/A'}}</span> tokens</span>
+                        <span *ngIf="row.truncated" class="text-amber-600 dark:text-amber-400 font-bold"><i class="bi bi-scissors"></i> truncated</span>
+                      </div>
+                      <div class="pl-9 overflow-x-auto">
+                        <code class="text-xs font-mono text-slate-500 dark:text-slate-500 whitespace-nowrap">{{previewVector(row.values)}}</code>
+                      </div>
+                    </li>
+                  </ul>
+                </div>
+
+                <!-- Similarity matrix -->
+                <div *ngIf="embeddings.length > 1">
+                  <h3 class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider mb-3">Cosine similarity</h3>
+                  <div class="overflow-x-auto ring-1 ring-slate-200 dark:ring-zinc-700 rounded-lg">
+                    <table class="w-full text-left border-collapse">
+                      <thead>
+                        <tr class="bg-slate-50 dark:bg-zinc-900/50 border-b border-slate-200 dark:border-zinc-700">
+                          <th class="px-4 py-2 text-xs font-semibold text-slate-900 dark:text-white"></th>
+                          <th *ngFor="let row of embeddings; let j = index" class="px-4 py-2 text-xs font-semibold text-slate-900 dark:text-white text-center">{{j + 1}}</th>
+                        </tr>
+                      </thead>
+                      <tbody class="divide-y divide-slate-200 dark:divide-zinc-700 bg-white dark:bg-[#121212]">
+                        <tr *ngFor="let row of embeddings; let i = index">
+                          <th class="px-4 py-2 text-xs font-semibold text-slate-600 dark:text-slate-400 whitespace-nowrap" [title]="row.text">{{i + 1}}. {{truncateLabel(row.text)}}</th>
+                          <td *ngFor="let score of similarityMatrix[i]" class="px-4 py-2 text-center text-xs font-mono font-bold" [ngClass]="similarityClass(score)">
+                            {{score | number:'1.3-3'}}
+                          </td>
+                        </tr>
+                      </tbody>
+                    </table>
+                  </div>
+                  <p class="text-xs text-slate-500 dark:text-slate-400 mt-2 font-medium">
+                    Computed locally from the returned vectors. 1.000 means identical direction — the diagonal is always 1.
+                  </p>
+                </div>
+
+              </div>
+            </div>
+          </div>
+
+        </div>
+      </div>
+    </form>
+  </div>
+</div>

--- a/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.ts
+++ b/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.ts
@@ -1,0 +1,444 @@
+import { Component, OnDestroy, OnInit, NgZone, ChangeDetectorRef } from '@angular/core';
+import { FormArray, FormBuilder, FormGroup } from '@angular/forms';
+import { Router, ActivatedRoute } from '@angular/router';
+
+declare const window: any;
+
+interface EmbeddingRow {
+  text: string;
+  values: Float32Array;
+  dimensions: number;
+  tokenCount: number | null;
+  truncated: boolean | null;
+}
+
+@Component({
+  selector: 'app-semantic-embedder-playground',
+  templateUrl: './semantic-embedder.page.html',
+  standalone: false,
+  host: { class: 'block w-full h-full overflow-y-auto bg-[#ffffff] dark:bg-[#121212]' }
+})
+export class SemanticEmbedderPlaygroundPage implements OnInit, OnDestroy {
+  playgroundForm!: FormGroup;
+
+  availabilityStatus: string | null = null;
+
+  availabilityTimeMs: number | null = null;
+  sessionCreationTimeMs: number | null = null;
+  executionTimeMs: number | null = null;
+
+  private availabilityTimer: any = null;
+  private sessionTimer: any = null;
+  private executionTimer: any = null;
+  session: any = null;
+
+  isCreating = false;
+  isEmbedding = false;
+
+  embeddings: EmbeddingRow[] = [];
+  metadata: { embeddingSpace?: string; maxInputTokens?: number } | null = null;
+  similarityMatrix: number[][] = [];
+
+  errorMessage = '';
+  shareText = 'Share';
+
+  downloadProgress = 0;
+  isDownloading = false;
+
+  codeAvailability = '';
+  codeSession = '';
+  codeExecution = '';
+
+  taskTypes = [
+    { value: '', label: 'None (let the browser decide)' },
+    { value: 'retrieval', label: 'retrieval' },
+    { value: 'classification', label: 'classification' },
+    { value: 'clustering', label: 'clustering' },
+    { value: 'similarity', label: 'similarity' }
+  ];
+
+  private activeAbortController: AbortController | null = null;
+  private creationAbortController: AbortController | null = null;
+
+  constructor(
+    private fb: FormBuilder,
+    private ngZone: NgZone,
+    private cdr: ChangeDetectorRef,
+    private router: Router,
+    private route: ActivatedRoute
+  ) {}
+
+  ngOnInit() {
+    this.initForm();
+
+    const queryParams = this.route.snapshot.queryParams;
+    if (Object.keys(queryParams).length > 0) {
+      this.patchFormFromUrl(queryParams);
+    }
+
+    this.updateGeneratedCode();
+
+    this.playgroundForm.valueChanges.subscribe(val => {
+      this.updateGeneratedCode();
+      this.updateUrl(val);
+    });
+  }
+
+  ngOnDestroy() {
+    this.destroySession();
+    if (this.availabilityTimer) clearInterval(this.availabilityTimer);
+    if (this.sessionTimer) clearInterval(this.sessionTimer);
+    if (this.executionTimer) clearInterval(this.executionTimer);
+  }
+
+  initForm() {
+    this.playgroundForm = this.fb.group({
+      taskType: [''],
+      useAbortSignal: [true],
+      inputs: this.fb.array([
+        this.fb.control('The quick brown fox jumps over the lazy dog.'),
+        this.fb.control('A fast, dark-colored fox leaps over a resting hound.'),
+        this.fb.control('Embeddings are high-dimensional vectors representing semantic meaning.')
+      ])
+    });
+  }
+
+  get inputs(): FormArray {
+    return this.playgroundForm.get('inputs') as FormArray;
+  }
+
+  addInput() {
+    this.inputs.push(this.fb.control(''));
+  }
+
+  removeInput(index: number) {
+    if (this.inputs.length > 1) this.inputs.removeAt(index);
+  }
+
+  updateUrl(val: any) {
+    const queryParamsToSave: any = {};
+    for (const key of Object.keys(val)) {
+      const value = val[key];
+      if (Array.isArray(value)) {
+        if (value.length > 0) queryParamsToSave[key] = JSON.stringify(value);
+      } else if (value !== null && value !== '') {
+        queryParamsToSave[key] = value;
+      }
+    }
+
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: queryParamsToSave,
+      replaceUrl: true
+    });
+  }
+
+  patchFormFromUrl(queryParams: any) {
+    const patchValue: any = {};
+    for (const key of Object.keys(queryParams)) {
+      const value = queryParams[key];
+      const control = this.playgroundForm.get(key);
+      if (control instanceof FormArray) {
+        try {
+          const parsed = JSON.parse(value);
+          if (Array.isArray(parsed)) {
+            control.clear();
+            parsed.forEach((item: any) => control.push(this.fb.control(item)));
+          }
+        } catch (e) {}
+      } else {
+        if (value === 'true') patchValue[key] = true;
+        else if (value === 'false') patchValue[key] = false;
+        else patchValue[key] = value;
+      }
+    }
+    this.playgroundForm.patchValue(patchValue);
+  }
+
+  getSemanticEmbedder() {
+    return (window as any).SemanticEmbedder;
+  }
+
+  getCreateOptions() {
+    const val = this.playgroundForm.value;
+    const options: any = {};
+    if (val.taskType) options.taskType = val.taskType;
+    return options;
+  }
+
+  /** Non-empty inputs, in order. */
+  getInputTexts(): string[] {
+    return this.inputs.value.map((v: string) => (v || '').trim()).filter((v: string) => v.length > 0);
+  }
+
+  async checkAvailability() {
+    const api = this.getSemanticEmbedder();
+    if (!api) {
+      this.availabilityStatus = 'API not found.';
+      return;
+    }
+
+    this.availabilityTimeMs = 0;
+    const startTime = performance.now();
+    this.availabilityTimer = setInterval(() => {
+      this.ngZone.run(() => {
+        this.availabilityTimeMs = Math.floor(performance.now() - startTime);
+        this.cdr.detectChanges();
+      });
+    }, 10);
+
+    try {
+      this.availabilityStatus = 'Checking...';
+      this.availabilityStatus = await api.availability();
+    } catch (e: any) {
+      this.availabilityStatus = 'Error: ' + e.message;
+    } finally {
+      clearInterval(this.availabilityTimer);
+      this.availabilityTimeMs = Math.floor(performance.now() - startTime);
+    }
+  }
+
+  async createSession() {
+    const api = this.getSemanticEmbedder();
+    if (!api) {
+      this.errorMessage = 'SemanticEmbedder is not exposed on this browser. Enable #semantic-embedder-api in Chrome Canary.';
+      return;
+    }
+
+    this.isCreating = true;
+    this.errorMessage = '';
+    this.downloadProgress = 0;
+
+    this.sessionCreationTimeMs = 0;
+    const sessionStartTime = performance.now();
+    this.sessionTimer = setInterval(() => {
+      this.ngZone.run(() => {
+        this.sessionCreationTimeMs = Math.floor(performance.now() - sessionStartTime);
+        this.cdr.detectChanges();
+      });
+    }, 10);
+
+    if (this.playgroundForm.value.useAbortSignal) {
+      this.creationAbortController = new AbortController();
+    }
+
+    try {
+      const options = this.getCreateOptions();
+
+      options.monitor = (m: any) => {
+        m.addEventListener('downloadprogress', (e: any) => {
+          this.ngZone.run(() => {
+            this.isDownloading = true;
+            this.downloadProgress = Math.round(e.loaded * 100);
+            this.cdr.detectChanges();
+          });
+        });
+      };
+
+      if (this.creationAbortController) {
+        options.signal = this.creationAbortController.signal;
+      }
+
+      this.session = await api.create(options);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to create semantic embedder';
+    } finally {
+      clearInterval(this.sessionTimer);
+      this.sessionCreationTimeMs = Math.floor(performance.now() - sessionStartTime);
+      this.isCreating = false;
+      this.isDownloading = false;
+      this.creationAbortController = null;
+    }
+  }
+
+  abortCreation() {
+    if (this.creationAbortController) {
+      this.creationAbortController.abort('User aborted creation');
+    }
+  }
+
+  destroySession() {
+    if (this.session) {
+      if (typeof this.session.destroy === 'function') this.session.destroy();
+      this.session = null;
+    }
+  }
+
+  async runPrompt() {
+    if (!this.session) return;
+
+    const texts = this.getInputTexts();
+    if (texts.length === 0) {
+      this.errorMessage = 'Add at least one non-empty input.';
+      return;
+    }
+
+    this.isEmbedding = true;
+    this.errorMessage = '';
+    this.embeddings = [];
+    this.metadata = null;
+    this.similarityMatrix = [];
+
+    this.executionTimeMs = 0;
+    const execStartTime = performance.now();
+    this.executionTimer = setInterval(() => {
+      this.ngZone.run(() => {
+        this.executionTimeMs = Math.floor(performance.now() - execStartTime);
+        this.cdr.detectChanges();
+      });
+    }, 10);
+
+    if (this.playgroundForm.value.useAbortSignal) {
+      this.activeAbortController = new AbortController();
+    }
+
+    try {
+      // A single string embeds one input; an array embeds the whole batch in one call.
+      const input = texts.length === 1 ? texts[0] : texts;
+      const result = await this.session.embed(input);
+
+      this.embeddings = (result.embeddings || []).map((embedding: any, i: number) => ({
+        text: texts[i],
+        values: embedding.values,
+        dimensions: embedding.values?.length ?? 0,
+        tokenCount: embedding.statistics?.tokenCount ?? null,
+        truncated: embedding.statistics?.truncated ?? null
+      }));
+
+      this.metadata = result.metadata || null;
+      this.similarityMatrix = this.buildSimilarityMatrix(this.embeddings);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Error while embedding';
+    } finally {
+      this.isEmbedding = false;
+      clearInterval(this.executionTimer);
+      this.executionTimeMs = Math.floor(performance.now() - execStartTime);
+      this.activeAbortController = null;
+    }
+  }
+
+  abortPrompt() {
+    if (this.activeAbortController) {
+      this.activeAbortController.abort('User aborted embedding');
+    }
+  }
+
+  buildSimilarityMatrix(rows: EmbeddingRow[]): number[][] {
+    return rows.map(a => rows.map(b => this.cosineSimilarity(a.values, b.values)));
+  }
+
+  cosineSimilarity(vecA: Float32Array, vecB: Float32Array): number {
+    if (!vecA || !vecB || vecA.length !== vecB.length) return NaN;
+    let dotProduct = 0, normA = 0, normB = 0;
+    for (let i = 0; i < vecA.length; i++) {
+      dotProduct += vecA[i] * vecB[i];
+      normA += vecA[i] * vecA[i];
+      normB += vecB[i] * vecB[i];
+    }
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+    return denominator === 0 ? 0 : dotProduct / denominator;
+  }
+
+  /** First few components of a vector, for display. */
+  previewVector(values: Float32Array, count = 8): string {
+    if (!values) return '';
+    const head = Array.from(values.slice(0, count)).map(v => v.toFixed(4));
+    return `[${head.join(', ')}${values.length > count ? ', …' : ''}]`;
+  }
+
+  /** Tailwind background for a similarity cell: warmer = more similar. */
+  similarityClass(score: number): string {
+    if (isNaN(score)) return 'bg-slate-50 dark:bg-zinc-900 text-slate-400 dark:text-slate-500';
+    if (score >= 0.9) return 'bg-emerald-100 dark:bg-emerald-500/20 text-emerald-800 dark:text-emerald-300';
+    if (score >= 0.75) return 'bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-400';
+    if (score >= 0.5) return 'bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400';
+    return 'bg-slate-50 dark:bg-zinc-900 text-slate-600 dark:text-slate-400';
+  }
+
+  truncateLabel(text: string, max = 40): string {
+    return text.length > max ? text.slice(0, max) + '…' : text;
+  }
+
+  copyVector(row: EmbeddingRow) {
+    navigator.clipboard.writeText(JSON.stringify(Array.from(row.values)));
+  }
+
+  sharePlayground() {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      this.shareText = 'Copied!';
+      if (this.cdr) this.cdr.detectChanges();
+      setTimeout(() => {
+        this.shareText = 'Share';
+        if (this.cdr) this.cdr.detectChanges();
+      }, 2000);
+    });
+  }
+
+  updateGeneratedCode() {
+    const val = this.playgroundForm.value;
+    const texts = this.getInputTexts();
+
+    let code = `// Semantic Embedder API Configuration\n\n`;
+    code += `const options = {\n`;
+    if (val.taskType) code += `  taskType: "${val.taskType}",\n`;
+    code += `};\n\n`;
+
+    code += `const availability = await SemanticEmbedder.availability();\n\n`;
+
+    if (val.useAbortSignal) code += `const controller = new AbortController();\noptions.signal = controller.signal;\n`;
+    code += `options.monitor = (m) => m.addEventListener("downloadprogress", e => console.log(e.loaded));\n`;
+    code += `const semanticEmbedder = await SemanticEmbedder.create(options);\n\n`;
+
+    if (texts.length === 1) {
+      code += `const result = await semanticEmbedder.embed(${JSON.stringify(texts[0])});\n`;
+    } else {
+      code += `const passages = [\n${texts.map(t => `  ${JSON.stringify(t)}`).join(',\n')}\n];\n\n`;
+      code += `// Embed the entire batch in one call\n`;
+      code += `const result = await semanticEmbedder.embed(passages);\n`;
+    }
+    code += `\nsemanticEmbedder.destroy();\n\n`;
+
+    code += `console.log(result.metadata.embeddingSpace, result.metadata.maxInputTokens);\n`;
+    code += `for (const embedding of result.embeddings) {\n`;
+    code += `  console.log(embedding.values.length, embedding.values);\n`;
+    code += `}\n\n`;
+
+    if (texts.length > 1) {
+      code += `// Compare the first two inputs\n`;
+      code += `const similarity = cosineSimilarity(\n`;
+      code += `  result.embeddings[0].values,\n`;
+      code += `  result.embeddings[1].values\n`;
+      code += `);\n`;
+      code += `console.log("Similarity score:", similarity);\n\n`;
+      code += `function cosineSimilarity(vecA, vecB) {\n`;
+      code += `  let dotProduct = 0, normA = 0, normB = 0;\n`;
+      code += `  for (let i = 0; i < vecA.length; i++) {\n`;
+      code += `    dotProduct += vecA[i] * vecB[i];\n`;
+      code += `    normA += vecA[i] * vecA[i];\n`;
+      code += `    normB += vecB[i] * vecB[i];\n`;
+      code += `  }\n`;
+      code += `  return dotProduct / (Math.sqrt(normA) * Math.sqrt(normB));\n`;
+      code += `}\n`;
+    }
+
+    // Split the monolithic generated code into step-specific variables
+    let tempCode = code;
+
+    const availabilityMatch = tempCode.match(/([\s\S]*?await [A-Za-z]+\.availability[\s\S]*?\n\n)/);
+    if (availabilityMatch) {
+      this.codeAvailability = availabilityMatch[1].trim();
+      tempCode = tempCode.substring(availabilityMatch[1].length);
+    } else {
+      this.codeAvailability = '// Availability check code not found';
+    }
+
+    const createMatch = tempCode.match(/([\s\S]*?await [A-Za-z]+\.create[\s\S]*?\n\n)/);
+    if (createMatch) {
+      this.codeSession = createMatch[1].trim();
+      this.codeExecution = tempCode.substring(createMatch[1].length).trim();
+    } else {
+      this.codeSession = '// Session creation code not found';
+      this.codeExecution = tempCode.trim();
+    }
+  }
+}


### PR DESCRIPTION
Follow-up to #93, which shipped the docs page. This adds the interactive playground at `/playgrounds/semantic-embedder`.

## Playground

Follows the existing playground pattern — configuration → availability → create session → input → execution, each step with its generated code in a collapsible editor, form state synced to the URL, and a Share button.

Specific to this API:

- **Repeatable input list.** One passage calls `embed(string)`; two or more are sent as a batch in a single `embed(array)` call. The generated code switches shape accordingly.
- **Output** shows the returned `metadata` (embedding space, max input tokens, dimensions), then per vector: token count, truncation flag, a preview of the leading components, and copy-full-vector-as-JSON.
- **Cosine similarity matrix** across all inputs, computed locally from the returned vectors and shaded by score. The default passages are two paraphrases plus an unrelated sentence, so the matrix immediately shows the embeddings carrying meaning.
- `taskType` is exposed but labelled "under discussion", consistent with how the docs page treats it.

## Docs page updates

The API is behind a flag in Canary rather than unimplemented, so the docs page badge becomes **Dev Trial**, the notice points at `#semantic-embedder-api` in Chrome Canary, and a Playground link is added to the header.

## Wiring

`route.enum.ts`, `app-routing-module.ts`, `app-module.ts`, and the sidebar Playgrounds list.

## Testing

`ng build` passes and the playground prerenders to `dist/web-ai.studio/browser/playgrounds/semantic-embedder/index.html`.

Not yet exercised against a live model — the result-shape reads are defensive (`embedding.statistics?.tokenCount ?? null`, rendered as N/A), so two things may need adjusting once run in Canary: whether `statistics` is actually returned, and whether `create()` tolerates an unknown `taskType` option.

🤖 Generated with [Claude Code](https://claude.com/claude-code)