### PR TITLE
Add Semantic Embedder demos

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -120,6 +120,15 @@ import { StructuredJsonDemoComponent } from './pages/demos/features/structured-j
 import { ExtractEntitiesDemoComponent } from './pages/demos/features/extract-entities-demo.component';
 import { ImageAudioQueryDemoComponent } from './pages/demos/features/image-audio-query-demo.component';
 import { ReceiptToJsonDemoComponent } from './pages/demos/features/receipt-to-json-demo.component';
+import { EmbedderStatusComponent } from './pages/demos/components/embedder-status/embedder-status.component';
+import { DocumentChatDemoComponent } from './pages/demos/features/document-chat-demo.component';
+import { SemanticSearchDemoComponent } from './pages/demos/features/semantic-search-demo.component';
+import { SmartTriageDemoComponent } from './pages/demos/features/smart-triage-demo.component';
+import { DuplicateDetectorDemoComponent } from './pages/demos/features/duplicate-detector-demo.component';
+import { ClusterLabelDemoComponent } from './pages/demos/features/cluster-label-demo.component';
+import { SemanticCacheDemoComponent } from './pages/demos/features/semantic-cache-demo.component';
+import { CommandPaletteDemoComponent } from './pages/demos/features/command-palette-demo.component';
+import { SemanticWordGameDemoComponent } from './pages/demos/features/semantic-word-game-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { TrackingDownloadPage } from './pages/docs/tracking-download/tracking-download.page';
@@ -216,6 +225,15 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     ExtractEntitiesDemoComponent,
     ImageAudioQueryDemoComponent,
     ReceiptToJsonDemoComponent,
+    EmbedderStatusComponent,
+    DocumentChatDemoComponent,
+    SemanticSearchDemoComponent,
+    SmartTriageDemoComponent,
+    DuplicateDetectorDemoComponent,
+    ClusterLabelDemoComponent,
+    SemanticCacheDemoComponent,
+    CommandPaletteDemoComponent,
+    SemanticWordGameDemoComponent,
     AutoScrollDirective,
     CortexPage,
     CortexInsightsPage,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -37,6 +37,14 @@ import { StructuredJsonDemoComponent } from './pages/demos/features/structured-j
 import { ExtractEntitiesDemoComponent } from './pages/demos/features/extract-entities-demo.component';
 import { ImageAudioQueryDemoComponent } from './pages/demos/features/image-audio-query-demo.component';
 import { ReceiptToJsonDemoComponent } from './pages/demos/features/receipt-to-json-demo.component';
+import { DocumentChatDemoComponent } from './pages/demos/features/document-chat-demo.component';
+import { SemanticSearchDemoComponent } from './pages/demos/features/semantic-search-demo.component';
+import { SmartTriageDemoComponent } from './pages/demos/features/smart-triage-demo.component';
+import { DuplicateDetectorDemoComponent } from './pages/demos/features/duplicate-detector-demo.component';
+import { ClusterLabelDemoComponent } from './pages/demos/features/cluster-label-demo.component';
+import { SemanticCacheDemoComponent } from './pages/demos/features/semantic-cache-demo.component';
+import { CommandPaletteDemoComponent } from './pages/demos/features/command-palette-demo.component';
+import { SemanticWordGameDemoComponent } from './pages/demos/features/semantic-word-game-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { DocsErrorsPage } from './pages/docs/errors/errors.page';
@@ -448,6 +456,62 @@ const routes: Routes = [
       {
         path: "demos/receipt-to-json",
         component: ReceiptToJsonDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/document-chat",
+        component: DocumentChatDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/semantic-search",
+        component: SemanticSearchDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/smart-triage",
+        component: SmartTriageDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/duplicate-detector",
+        component: DuplicateDetectorDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/cluster-and-label",
+        component: ClusterLabelDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/semantic-cache",
+        component: SemanticCacheDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/command-palette",
+        component: CommandPaletteDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/semantic-word-game",
+        component: SemanticWordGameDemoComponent,
         data: {
           route: RouteEnum.Demos
         }

--- a/webapp/src/app/core/models/demo.interface.ts
+++ b/webapp/src/app/core/models/demo.interface.ts
@@ -1,7 +1,7 @@
 import {PromptRunOptions} from './prompt-run.options';
 import {AttachmentTypeEnum} from '../enums/attachment-type.enum';
 
-export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match';
+export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match' | 'Embeddings';
 
 export interface DemoExample {
   id: string;

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -2,6 +2,228 @@ import { DemoExample } from '../models/demo.interface';
 import { AttachmentTypeEnum } from '../enums/attachment-type.enum';
 
 export const DEMOS_DATA: DemoExample[] = [
+  // EMBEDDINGS
+  {
+    id: 'document-chat',
+    title: 'Chat With Your Document',
+    description: 'Fully local RAG: retrieve the relevant passages with embeddings, then answer with the Prompt API — citations included.',
+    category: 'Embeddings',
+    icon: 'bi-chat-left-quote',
+    onDeviceReason: 'The entire RAG pipeline — chunking, embedding, retrieval, and generation — runs on-device. Your document is never uploaded and no vector database is required.',
+    codeSnippet: `// 1. Index: chunk the document and embed every chunk in one batch
+const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+const chunks = documentText.split(/\\n\\s*\\n/);
+const { embeddings } = await embedder.embed(chunks);
+
+// 2. Retrieve: embed the question and rank chunks by cosine similarity
+const query = await embedder.embed(question);
+const top3 = embeddings
+  .map((e, i) => ({ i, score: cosineSimilarity(query.embeddings[0].values, e.values) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 3);
+
+// 3. Generate: ground the Prompt API in the retrieved passages
+const session = await LanguageModel.create({
+  systemPrompt: "Answer using ONLY the provided context."
+});
+const context = top3.map(t => chunks[t.i]).join("\\n\\n");
+const stream = session.promptStreaming(\`Context:\\n\${context}\\n\\nQuestion: \${question}\`);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'semantic-search',
+    title: 'Semantic vs. Keyword Search',
+    description: 'Search a help center by meaning, side by side with keyword search — and watch keywords miss what embeddings find.',
+    category: 'Embeddings',
+    icon: 'bi-search-heart',
+    onDeviceReason: 'On-device embeddings cost nothing per query, so you can afford to search on every keystroke — no network round trip, no per-call billing, and queries stay private.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+
+// Index the help center once (a single batched call)
+const { embeddings } = await embedder.embed(helpCenterEntries);
+
+// On every keystroke: embed the query and rank by cosine similarity
+const result = await embedder.embed(searchQuery);
+const queryVector = result.embeddings[0].values;
+
+const ranked = embeddings
+  .map((e, i) => ({ entry: helpCenterEntries[i], score: cosineSimilarity(queryVector, e.values) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 5);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'smart-triage',
+    title: 'Smart Triage',
+    description: 'A zero-shot classifier: route incoming messages to categories defined only by a few example phrases.',
+    category: 'Embeddings',
+    icon: 'bi-signpost-split',
+    onDeviceReason: 'Classify support messages, feedback, or emails locally with no training step and no data leaving the device — and "retrain" instantly by editing the example phrases.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "classification" });
+
+// Each category is defined by a few example phrases
+const categories = {
+  "Billing": ["I was charged twice", "How do I update my card?"],
+  "Bug Report": ["The app crashes on launch", "Uploads fail with an error"]
+};
+
+// A category's centroid is the mean of its example vectors
+const centroids = {};
+for (const [name, examples] of Object.entries(categories)) {
+  const { embeddings } = await embedder.embed(examples);
+  centroids[name] = meanVector(embeddings.map(e => e.values));
+}
+
+// Classify: nearest centroid by cosine similarity
+const { embeddings: [msg] } = await embedder.embed(incomingMessage);
+const best = Object.entries(centroids)
+  .map(([name, c]) => ({ name, score: cosineSimilarity(msg.values, c) }))
+  .sort((a, b) => b.score - a.score)[0];`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'duplicate-detector',
+    title: 'Duplicate Detector',
+    description: 'Catch near-duplicate bug reports before they are filed, even when they share no words with the original.',
+    category: 'Embeddings',
+    icon: 'bi-files',
+    onDeviceReason: 'Deduplication runs while the user is still typing, because every similarity check is a local vector comparison — no server calls per keystroke.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+
+// Embed the existing issues once
+const { embeddings } = await embedder.embed(existingIssueTitles);
+
+// As the user types a new issue, look for semantic near-duplicates
+const draft = await embedder.embed(newIssueTitle);
+const draftVector = draft.embeddings[0].values;
+
+const duplicates = embeddings
+  .map((e, i) => ({ title: existingIssueTitles[i], score: cosineSimilarity(draftVector, e.values) }))
+  .filter(d => d.score >= 0.60) // similarity threshold
+  .sort((a, b) => b.score - a.score);
+
+if (duplicates.length > 0) showWarning(duplicates);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'cluster-and-label',
+    title: 'Cluster & Label',
+    description: 'Group raw user feedback into themes with k-means over embeddings, then let the Prompt API name each cluster.',
+    category: 'Embeddings',
+    icon: 'bi-bounding-box-circles',
+    onDeviceReason: 'Topic discovery over private feedback, notes, or tickets happens entirely locally — the embeddings power the math, the Prompt API writes the labels.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "clustering" });
+
+// Embed all feedback items in one batch
+const { embeddings } = await embedder.embed(feedbackItems);
+const vectors = embeddings.map(e => e.values);
+
+// Standard k-means over the vectors
+const assignments = kMeans(vectors, 4);
+
+// Let the on-device LLM name each cluster
+const session = await LanguageModel.create();
+for (let c = 0; c < 4; c++) {
+  const members = feedbackItems.filter((_, i) => assignments[i] === c);
+  const label = await session.prompt(
+    "Reply with a 2-4 word theme label for this feedback:\\n- " + members.join("\\n- ")
+  );
+  console.log(\`Cluster \${c}: \${label}\`);
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'semantic-cache',
+    title: 'Semantic Cache',
+    description: 'Serve instant answers for paraphrased questions by caching LLM responses under their embeddings.',
+    category: 'Embeddings',
+    icon: 'bi-lightning-charge',
+    onDeviceReason: 'A production pattern made visible: skip re-running the language model when a semantically equivalent question was already answered — saving seconds and tokens.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+const cache = []; // { vector, question, answer }
+
+async function ask(question) {
+  const { embeddings: [q] } = await embedder.embed(question);
+
+  // Cache hit: a semantically equivalent question was already answered
+  const best = cache
+    .map(entry => ({ entry, score: cosineSimilarity(q.values, entry.vector) }))
+    .sort((a, b) => b.score - a.score)[0];
+  if (best && best.score >= 0.85) return best.entry.answer; // instant
+
+  // Cache miss: generate with the Prompt API, then store
+  const session = await LanguageModel.create();
+  const answer = await session.prompt(question);
+  cache.push({ vector: q.values, question, answer });
+  return answer;
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'command-palette',
+    title: 'Semantic Command Palette',
+    description: 'A ⌘K palette that understands intent: describe what you want in your own words and the right action lights up.',
+    category: 'Embeddings',
+    icon: 'bi-command',
+    onDeviceReason: 'Intent matching on every keystroke is only viable when embedding is free, instant, and private — exactly what an on-device embedder provides.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+
+const actions = [
+  { label: "Toggle dark mode", description: "Switch between light and dark appearance" },
+  { label: "Export as PDF", description: "Download the current page as a PDF file" },
+  { label: "Mute notifications", description: "Silence all alerts and badges" }
+];
+
+// Embed the action descriptions once
+const { embeddings } = await embedder.embed(
+  actions.map(a => \`\${a.label} — \${a.description}\`)
+);
+
+// On every keystroke, rank actions against the typed intent
+const query = await embedder.embed("make it easier on my eyes at night");
+const ranked = actions
+  .map((a, i) => ({ ...a, score: cosineSimilarity(query.embeddings[0].values, embeddings[i].values) }))
+  .sort((a, b) => b.score - a.score);
+// → "Toggle dark mode" wins with zero shared words`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'semantic-word-game',
+    title: 'Hot or Cold',
+    description: 'Guess the secret word: every guess is embedded on-device and scored by how semantically close it lands.',
+    category: 'Embeddings',
+    icon: 'bi-thermometer-half',
+    onDeviceReason: 'A whole word game with zero backend: scoring is a local cosine similarity, so it is instant, free to run, and works offline.',
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+
+const secretWord = "volcano";
+const { embeddings: [secret] } = await embedder.embed(secretWord);
+
+async function guess(word) {
+  const { embeddings: [g] } = await embedder.embed(word);
+  const score = cosineSimilarity(secret.values, g.values);
+
+  if (word.toLowerCase() === secretWord) return "🎉 You got it!";
+  if (score >= 0.80) return "🔥 Scorching";
+  if (score >= 0.70) return "Hot";
+  if (score >= 0.60) return "Warm";
+  if (score >= 0.50) return "Cool";
+  return "🧊 Freezing";
+}
+
+await guess("mountain"); // Hot — semantically close to a volcano
+await guess("banana");   // Freezing`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+
   // TEXT INPUT
   {
     id: 'translation',

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -11,12 +11,13 @@ export const DEMOS_DATA: DemoExample[] = [
     icon: 'bi-chat-left-quote',
     onDeviceReason: 'The entire RAG pipeline — chunking, embedding, retrieval, and generation — runs on-device. Your document is never uploaded and no vector database is required.',
     codeSnippet: `// 1. Index: chunk the document and embed every chunk in one batch
-const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
 const chunks = documentText.split(/\\n\\s*\\n/);
-const { embeddings } = await embedder.embed(chunks);
+const { embeddings } = await docEmbedder.embed(chunks);
 
-// 2. Retrieve: embed the question and rank chunks by cosine similarity
-const query = await embedder.embed(question);
+// 2. Retrieve: embed the question with the query task type, rank chunks by cosine similarity
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const query = await queryEmbedder.embed(question);
 const top3 = embeddings
   .map((e, i) => ({ i, score: cosineSimilarity(query.embeddings[0].values, e.values) }))
   .sort((a, b) => b.score - a.score)
@@ -38,13 +39,13 @@ const stream = session.promptStreaming(\`Context:\\n\${context}\\n\\nQuestion: \
     category: 'Embeddings',
     icon: 'bi-search-heart',
     onDeviceReason: 'On-device embeddings cost nothing per query, so you can afford to search on every keystroke — no network round trip, no per-call billing, and queries stay private.',
-    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+    codeSnippet: `// Index the help center once (a single batched call)
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+const { embeddings } = await docEmbedder.embed(helpCenterEntries);
 
-// Index the help center once (a single batched call)
-const { embeddings } = await embedder.embed(helpCenterEntries);
-
-// On every keystroke: embed the query and rank by cosine similarity
-const result = await embedder.embed(searchQuery);
+// On every keystroke: embed the query with the query task type and rank by cosine similarity
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const result = await queryEmbedder.embed(searchQuery);
 const queryVector = result.embeddings[0].values;
 
 const ranked = embeddings
@@ -91,7 +92,7 @@ const best = Object.entries(centroids)
     category: 'Embeddings',
     icon: 'bi-files',
     onDeviceReason: 'Deduplication runs while the user is still typing, because every similarity check is a local vector comparison — no server calls per keystroke.',
-    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 
 // Embed the existing issues once
 const { embeddings } = await embedder.embed(existingIssueTitles);
@@ -144,7 +145,7 @@ for (let c = 0; c < 4; c++) {
     category: 'Embeddings',
     icon: 'bi-lightning-charge',
     onDeviceReason: 'A production pattern made visible: skip re-running the language model when a semantically equivalent question was already answered — saving seconds and tokens.',
-    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 const cache = []; // { vector, question, answer }
 
 async function ask(question) {
@@ -172,21 +173,21 @@ async function ask(question) {
     category: 'Embeddings',
     icon: 'bi-command',
     onDeviceReason: 'Intent matching on every keystroke is only viable when embedding is free, instant, and private — exactly what an on-device embedder provides.',
-    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
-
-const actions = [
+    codeSnippet: `const actions = [
   { label: "Toggle dark mode", description: "Switch between light and dark appearance" },
   { label: "Export as PDF", description: "Download the current page as a PDF file" },
   { label: "Mute notifications", description: "Silence all alerts and badges" }
 ];
 
 // Embed the action descriptions once
-const { embeddings } = await embedder.embed(
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+const { embeddings } = await docEmbedder.embed(
   actions.map(a => \`\${a.label} — \${a.description}\`)
 );
 
 // On every keystroke, rank actions against the typed intent
-const query = await embedder.embed("make it easier on my eyes at night");
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const query = await queryEmbedder.embed("make it easier on my eyes at night");
 const ranked = actions
   .map((a, i) => ({ ...a, score: cosineSimilarity(query.embeddings[0].values, embeddings[i].values) }))
   .sort((a, b) => b.score - a.score);
@@ -201,7 +202,7 @@ const ranked = actions
     category: 'Embeddings',
     icon: 'bi-thermometer-half',
     onDeviceReason: 'A whole word game with zero backend: scoring is a local cosine similarity, so it is instant, free to run, and works offline.',
-    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 
 const secretWord = "volcano";
 const { embeddings: [secret] } = await embedder.embed(secretWord);

--- a/webapp/src/app/core/services/semantic-embedder.service.ts
+++ b/webapp/src/app/core/services/semantic-embedder.service.ts
@@ -1,7 +1,12 @@
 import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
 import { isPlatformBrowser } from '@angular/common';
 
-export type SemanticEmbedderTaskType = 'retrieval' | 'classification' | 'clustering' | 'similarity';
+export type SemanticEmbedderTaskType =
+  | 'semantic-similarity'
+  | 'retrieval-query'
+  | 'retrieval-document'
+  | 'classification'
+  | 'clustering';
 
 export interface ScoredResult {
   index: number;

--- a/webapp/src/app/core/services/semantic-embedder.service.ts
+++ b/webapp/src/app/core/services/semantic-embedder.service.ts
@@ -1,0 +1,116 @@
+import { Injectable, Inject, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+export type SemanticEmbedderTaskType = 'retrieval' | 'classification' | 'clustering' | 'similarity';
+
+export interface ScoredResult {
+  index: number;
+  score: number;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+export class SemanticEmbedderService {
+  private isBrowser: boolean;
+
+  /** One live embedder per task type, kept for the lifetime of the session. */
+  private embedders = new Map<string, any>();
+
+  /** Vectors cached per (taskType, text) so re-embedding the same corpus is free. */
+  private vectorCache = new Map<string, Float32Array>();
+
+  constructor(@Inject(PLATFORM_ID) platformId: Object) {
+    this.isBrowser = isPlatformBrowser(platformId);
+  }
+
+  isSupported(): boolean {
+    return this.isBrowser && 'SemanticEmbedder' in (window as any);
+  }
+
+  async availability(): Promise<string> {
+    if (!this.isSupported()) return 'unavailable';
+    try {
+      return await (window as any).SemanticEmbedder.availability();
+    } catch {
+      return 'unavailable';
+    }
+  }
+
+  async getEmbedder(
+    taskType?: SemanticEmbedderTaskType,
+    onDownloadProgress?: (loaded: number) => void
+  ): Promise<any> {
+    const key = taskType ?? 'default';
+    const existing = this.embedders.get(key);
+    if (existing) return existing;
+
+    const options: any = {
+      monitor: (m: any) =>
+        m.addEventListener('downloadprogress', (e: any) => onDownloadProgress?.(e.loaded))
+    };
+    if (taskType) options.taskType = taskType;
+
+    const embedder = await (window as any).SemanticEmbedder.create(options);
+    this.embedders.set(key, embedder);
+    return embedder;
+  }
+
+  /** Embeds a batch of texts in a single call, returning one vector per input, in order. */
+  async embed(
+    texts: string[],
+    taskType?: SemanticEmbedderTaskType,
+    onDownloadProgress?: (loaded: number) => void
+  ): Promise<Float32Array[]> {
+    if (texts.length === 0) return [];
+
+    const cacheKey = (text: string) => `${taskType ?? 'default'}\u0000${text}`;
+    const missing = [...new Set(texts.filter(t => !this.vectorCache.has(cacheKey(t))))];
+
+    if (missing.length > 0) {
+      const embedder = await this.getEmbedder(taskType, onDownloadProgress);
+      const result = await embedder.embed(missing.length === 1 ? missing[0] : missing);
+      (result.embeddings || []).forEach((embedding: any, i: number) => {
+        this.vectorCache.set(cacheKey(missing[i]), embedding.values);
+      });
+    }
+
+    return texts.map(t => this.vectorCache.get(cacheKey(t))!);
+  }
+
+  async embedOne(text: string, taskType?: SemanticEmbedderTaskType): Promise<Float32Array> {
+    const [vector] = await this.embed([text], taskType);
+    return vector;
+  }
+
+  cosineSimilarity(vecA: Float32Array, vecB: Float32Array): number {
+    if (!vecA || !vecB || vecA.length !== vecB.length) return NaN;
+    let dotProduct = 0, normA = 0, normB = 0;
+    for (let i = 0; i < vecA.length; i++) {
+      dotProduct += vecA[i] * vecB[i];
+      normA += vecA[i] * vecA[i];
+      normB += vecB[i] * vecB[i];
+    }
+    const denominator = Math.sqrt(normA) * Math.sqrt(normB);
+    return denominator === 0 ? 0 : dotProduct / denominator;
+  }
+
+  /** Ranks every vector against the query and returns the k best as {index, score}. */
+  topK(query: Float32Array, vectors: Float32Array[], k: number, minScore = -1): ScoredResult[] {
+    return vectors
+      .map((vector, index) => ({ index, score: this.cosineSimilarity(query, vector) }))
+      .filter(result => result.score >= minScore)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, k);
+  }
+
+  /** Mean of a set of vectors — the centroid used for nearest-centroid classification. */
+  meanVector(vectors: Float32Array[]): Float32Array {
+    const mean = new Float32Array(vectors[0].length);
+    for (const vector of vectors) {
+      for (let i = 0; i < mean.length; i++) mean[i] += vector[i];
+    }
+    for (let i = 0; i < mean.length; i++) mean[i] /= vectors.length;
+    return mean;
+  }
+}

--- a/webapp/src/app/pages/demos/components/base-demo/base-embedder-demo.component.ts
+++ b/webapp/src/app/pages/demos/components/base-demo/base-embedder-demo.component.ts
@@ -1,0 +1,30 @@
+import { Directive, inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from './base-demo.component';
+import { SemanticEmbedderService } from '../../../../core/services/semantic-embedder.service';
+
+@Directive()
+export abstract class BaseEmbedderDemoComponent extends BaseDemoComponent {
+  protected readonly semanticEmbedder = inject(SemanticEmbedderService);
+
+  embedderStatus: string = 'loading...';
+  errorMessage = '';
+
+  downloadProgress = 0;
+  isDownloading = false;
+
+  async checkEmbedderAvailability() {
+    if (isPlatformServer(this.platformId)) return;
+    this.embedderStatus = await this.semanticEmbedder.availability();
+  }
+
+  get embedderUsable(): boolean {
+    return this.embedderStatus === 'available' || this.embedderStatus === 'downloadable' || this.embedderStatus === 'downloading';
+  }
+
+  protected onDownloadProgress = (loaded: number) => {
+    this.isDownloading = loaded < 1;
+    this.downloadProgress = Math.round(loaded * 100);
+    if (loaded >= 1) this.embedderStatus = 'available';
+  };
+}

--- a/webapp/src/app/pages/demos/components/embedder-status/embedder-status.component.html
+++ b/webapp/src/app/pages/demos/components/embedder-status/embedder-status.component.html
@@ -1,0 +1,52 @@
+<div class="mb-4 flex flex-col gap-3">
+  <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+    <div class="text-sm font-medium text-slate-600 dark:text-slate-400 flex items-center gap-2">
+      Semantic Embedder:
+      @if (embedderStatus === 'available') {
+        <span class="text-emerald-600 dark:text-emerald-400 flex items-center gap-1"><i class="bi bi-check-circle-fill"></i> Available</span>
+      } @else if (embedderStatus === 'unavailable') {
+        <span class="text-red-600 dark:text-red-400 flex items-center gap-1"><i class="bi bi-x-circle-fill"></i> Unavailable</span>
+      } @else if (embedderStatus === 'loading...') {
+        <span class="text-slate-600 dark:text-slate-400 flex items-center gap-1"><i class="bi bi-hourglass-split"></i> Loading...</span>
+      } @else if (embedderStatus === 'downloading') {
+        <span class="text-amber-600 dark:text-amber-400 flex items-center gap-1"><i class="bi bi-arrow-down-circle-fill"></i> Downloading...</span>
+      } @else {
+        <span class="text-amber-600 dark:text-amber-400 flex items-center gap-1"><i class="bi bi-arrow-down-circle-fill"></i> Download Required</span>
+      }
+    </div>
+
+    @if (showPromptApi) {
+      <div class="text-sm font-medium text-slate-600 dark:text-slate-400 flex items-center gap-2">
+        Prompt API:
+        @if (promptApiStatus === 'available') {
+          <span class="text-emerald-600 dark:text-emerald-400 flex items-center gap-1"><i class="bi bi-check-circle-fill"></i> Available</span>
+        } @else if (promptApiStatus === 'unavailable') {
+          <span class="text-red-600 dark:text-red-400 flex items-center gap-1"><i class="bi bi-x-circle-fill"></i> Unavailable</span>
+        } @else if (promptApiStatus === 'loading...') {
+          <span class="text-slate-600 dark:text-slate-400 flex items-center gap-1"><i class="bi bi-hourglass-split"></i> Loading...</span>
+        } @else {
+          <span class="text-amber-600 dark:text-amber-400 flex items-center gap-1"><i class="bi bi-arrow-down-circle-fill"></i> Download Required</span>
+        }
+      </div>
+    }
+
+    @if (isDownloading) {
+      <div class="flex items-center gap-2 text-sm font-medium text-indigo-600 dark:text-indigo-400">
+        <div class="w-32 h-2 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+          <div class="h-full bg-indigo-500 rounded-full transition-all" [style.width.%]="downloadProgress"></div>
+        </div>
+        {{ downloadProgress }}%
+      </div>
+    }
+  </div>
+
+  @if (embedderStatus === 'unavailable') {
+    <div class="bg-amber-50 border border-amber-200 dark:bg-amber-900/10 dark:border-amber-900/30 rounded-2xl p-4 text-sm text-amber-900 dark:text-amber-100/90 flex items-start gap-3">
+      <i class="bi bi-exclamation-triangle-fill text-amber-500 text-lg"></i>
+      <div>
+        <span class="font-semibold">SemanticEmbedder is not exposed in this browser.</span>
+        Use Chrome Canary and enable <code class="font-mono text-xs bg-amber-100 dark:bg-amber-900/30 px-1.5 py-0.5 rounded">chrome://flags/#semantic-embedder-api</code>, then restart the browser.
+      </div>
+    </div>
+  }
+</div>

--- a/webapp/src/app/pages/demos/components/embedder-status/embedder-status.component.ts
+++ b/webapp/src/app/pages/demos/components/embedder-status/embedder-status.component.ts
@@ -1,0 +1,18 @@
+import { Component, Input } from '@angular/core';
+
+/**
+ * Availability header shared by the Semantic Embedder demos: status pills for the
+ * embedder (and optionally the Prompt API), plus the Canary flag hint when unavailable.
+ */
+@Component({
+  selector: 'app-embedder-status',
+  templateUrl: './embedder-status.component.html',
+  standalone: false
+})
+export class EmbedderStatusComponent {
+  @Input() embedderStatus: string = 'loading...';
+  @Input() showPromptApi = false;
+  @Input() promptApiStatus: string = 'loading...';
+  @Input() isDownloading = false;
+  @Input() downloadProgress = 0;
+}

--- a/webapp/src/app/pages/demos/demos.page.ts
+++ b/webapp/src/app/pages/demos/demos.page.ts
@@ -13,7 +13,7 @@ import { DemoExample, DemoCategory } from '../../core/models/demo.interface';
 })
 export class DemosPage extends BasePage implements OnInit {
   demos: DemoExample[] = DEMOS_DATA;
-  categories: DemoCategory[] = ['Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
+  categories: DemoCategory[] = ['Embeddings', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
 
   constructor(
     @Inject(DOCUMENT) document: Document,

--- a/webapp/src/app/pages/demos/features/cluster-label-demo.component.html
+++ b/webapp/src/app/pages/demos/features/cluster-label-demo.component.html
@@ -1,0 +1,145 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [showPromptApi]="true"
+      [promptApiStatus]="languageModelAvailability"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6">
+
+      <!-- Input -->
+      <div class="lg:flex-[2] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[420px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-chat-square-text text-indigo-500"></i> Raw Feedback
+          </span>
+          <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ itemCount }} items, one per line</span>
+        </div>
+        <textarea
+          class="w-full flex-grow bg-transparent border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 placeholder-slate-400 resize-none p-5 leading-relaxed text-sm min-h-[280px]"
+          [(ngModel)]="feedbackText"
+          placeholder="Paste feedback items, one per line..."></textarea>
+        <div class="p-4 border-t border-slate-100 dark:border-zinc-700/50 flex items-center justify-between gap-3 flex-wrap">
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">Clusters (k)</span>
+            <select [(ngModel)]="k"
+                    class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-1.5 text-sm font-semibold text-slate-700 dark:text-slate-300 outline-none cursor-pointer">
+              @for (option of kOptions; track option) {
+                <option [ngValue]="option">{{ option }}</option>
+              }
+            </select>
+          </div>
+          <button
+            class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+            (click)="cluster()"
+            [disabled]="itemCount < k || isClustering || !embedderUsable">
+            @if (isClustering) {
+              <i class="bi bi-arrow-repeat animate-spin text-lg"></i> Clustering...
+            } @else {
+              <i class="bi bi-bounding-box-circles text-lg"></i> Cluster
+            }
+          </button>
+        </div>
+      </div>
+
+      <!-- Map -->
+      <div class="lg:flex-[3] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center gap-3 flex-wrap">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-graph-up text-indigo-500"></i> Semantic Map
+          </span>
+          <div class="flex items-center gap-3">
+            @if (clusteringTimeMs !== null) {
+              <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                embedded + clustered in {{ clusteringTimeMs }}ms
+              </span>
+            }
+            @if (hasClustered && languageModelAvailability !== 'unavailable') {
+              <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-amber-500 hover:bg-amber-600 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="labelClusters()">
+                <i class="bi bi-stars"></i> Name Clusters with AI
+              </button>
+            }
+          </div>
+        </div>
+
+        <div class="flex-grow flex flex-col p-4">
+          @if (!hasClustered) {
+            <div class="m-auto text-center p-8">
+              <i class="bi bi-bounding-box-circles text-4xl text-slate-200 dark:text-zinc-700"></i>
+              <p class="text-sm text-slate-400 dark:text-slate-500 mt-3 font-light max-w-xs mx-auto">
+                Each item becomes a point in embedding space, projected to 2D. Similar feedback lands close together.
+              </p>
+            </div>
+          } @else {
+            <svg [attr.viewBox]="'0 0 ' + width + ' ' + height" class="w-full h-auto select-none">
+              <!-- Subtle grid -->
+              @for (line of [1, 2, 3]; track line) {
+                <line [attr.x1]="0" [attr.y1]="(height / 4) * line" [attr.x2]="width" [attr.y2]="(height / 4) * line"
+                      class="stroke-slate-100 dark:stroke-zinc-800" stroke-width="1" />
+                <line [attr.x1]="(width / 4) * line" [attr.y1]="0" [attr.x2]="(width / 4) * line" [attr.y2]="height"
+                      class="stroke-slate-100 dark:stroke-zinc-800" stroke-width="1" />
+              }
+              @for (point of points; track $index) {
+                <circle
+                  [attr.cx]="point.x"
+                  [attr.cy]="point.y"
+                  [attr.r]="hoveredIndex === $index ? 11 : 7"
+                  [attr.fill]="clusterColor(point.cluster)"
+                  [attr.fill-opacity]="hoveredIndex === null || hoveredIndex === $index ? 0.85 : 0.35"
+                  class="cursor-pointer transition-all duration-150 stroke-white dark:stroke-zinc-900"
+                  stroke-width="1.5"
+                  (mouseenter)="hoveredIndex = $index"
+                  (mouseleave)="hoveredIndex = null" />
+              }
+            </svg>
+
+            <!-- Hover caption -->
+            <div class="min-h-[44px] mt-1 px-4 py-2.5 rounded-xl bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 flex items-center gap-2.5">
+              @if (hoveredPoint) {
+                <span class="w-2.5 h-2.5 rounded-full shrink-0" [style.background]="clusterColor(hoveredPoint.cluster)"></span>
+                <span class="text-xs text-slate-700 dark:text-slate-300">{{ hoveredPoint.text }}</span>
+              } @else {
+                <span class="text-xs text-slate-400 dark:text-slate-500 font-light">Hover a point to read the feedback behind it.</span>
+              }
+            </div>
+
+            <!-- Legend -->
+            <div class="flex flex-wrap gap-2 mt-3">
+              @for (cluster of clusters; track cluster.index) {
+                <div class="flex items-center gap-2 px-3 py-1.5 rounded-full bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700">
+                  <span class="w-2.5 h-2.5 rounded-full" [style.background]="cluster.color"></span>
+                  <span class="text-xs font-semibold text-slate-700 dark:text-slate-300">
+                    @if (cluster.isLabeling) {
+                      <i class="bi bi-arrow-repeat animate-spin"></i> naming...
+                    } @else {
+                      {{ cluster.label }}
+                    }
+                  </span>
+                  <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">{{ cluster.count }}</span>
+                </div>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/cluster-label-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/cluster-label-demo.component.ts
@@ -1,0 +1,307 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageModel: any;
+
+interface ClusterPoint {
+  text: string;
+  cluster: number;
+  x: number; // SVG coordinates
+  y: number;
+}
+
+interface ClusterInfo {
+  index: number;
+  color: string;
+  count: number;
+  label: string;
+  isLabeling: boolean;
+}
+
+const CLUSTER_COLORS = ['#6366f1', '#10b981', '#f59e0b', '#f43f5e', '#0ea5e9', '#a855f7'];
+
+const SAMPLE_FEEDBACK = `The app takes forever to load on my phone
+Scrolling the feed is janky and slow
+Search results take more than ten seconds to appear
+Startup time has gotten noticeably worse lately
+The editor lags badly once documents get long
+Syncing large projects is painfully slow
+The subscription is way too expensive for students
+I wish there was a cheaper personal plan
+The free tier is too limited to properly evaluate
+Annual billing should come with a bigger discount
+The price went up twice this year, not okay
+Team pricing does not scale for small nonprofits
+The new sidebar layout is confusing to navigate
+Buttons are too small to tap on mobile
+I can never find the settings I am looking for
+The onboarding flow has way too many steps
+Dark mode contrast makes the text hard to read
+The icons are unclear without any labels
+Support took five days to answer my ticket
+The help articles are outdated and unhelpful
+Live chat agents keep transferring me around
+I never got a reply about my refund request
+Phone support is impossible to reach
+The community forum is full of unanswered questions`;
+
+@Component({
+  selector: 'app-cluster-label-demo',
+  templateUrl: './cluster-label-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ClusterLabelDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'cluster-and-label')!;
+
+  feedbackText = SAMPLE_FEEDBACK;
+  k = 4;
+  kOptions = [2, 3, 4, 5, 6];
+
+  points: ClusterPoint[] = [];
+  clusters: ClusterInfo[] = [];
+  hoveredIndex: number | null = null;
+
+  isClustering = false;
+  clusteringTimeMs: number | null = null;
+  hasClustered = false;
+
+  // SVG canvas dimensions (viewBox units)
+  readonly width = 640;
+  readonly height = 400;
+  readonly padding = 40;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability();
+  }
+
+  get itemCount(): number {
+    return this.parseItems().length;
+  }
+
+  get hoveredPoint(): ClusterPoint | null {
+    return this.hoveredIndex !== null ? this.points[this.hoveredIndex] : null;
+  }
+
+  private parseItems(): string[] {
+    return this.feedbackText.split('\n').map(l => l.trim()).filter(l => l.length > 0);
+  }
+
+  async cluster() {
+    const items = this.parseItems();
+    if (items.length < this.k || this.isClustering) return;
+
+    this.isClustering = true;
+    this.errorMessage = '';
+    this.hoveredIndex = null;
+    const start = performance.now();
+
+    try {
+      const vectors = await this.semanticEmbedder.embed(items, 'clustering', this.onDownloadProgress);
+      const normalized = vectors.map(v => this.normalize(v));
+      const assignments = this.kMeans(normalized, this.k);
+      const coords = this.pca2d(normalized);
+      this.points = this.toSvgPoints(items, assignments, coords);
+      this.clusters = Array.from({ length: this.k }, (_, index) => ({
+        index,
+        color: CLUSTER_COLORS[index % CLUSTER_COLORS.length],
+        count: assignments.filter(a => a === index).length,
+        label: `Cluster ${index + 1}`,
+        isLabeling: false
+      }));
+      this.clusteringTimeMs = Math.round(performance.now() - start);
+      this.hasClustered = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Clustering failed.';
+    } finally {
+      this.isClustering = false;
+    }
+  }
+
+  /** Names every cluster with the Prompt API, one short label per cluster. */
+  async labelClusters() {
+    if (!this.hasClustered || this.languageModelAvailability === 'unavailable') return;
+
+    this.clusters.forEach(c => (c.isLabeling = true));
+    try {
+      const session = await LanguageModel.create({
+        systemPrompt: 'You label groups of user feedback. Reply with ONLY a short theme label of 2 to 4 words. No punctuation, no quotes, no explanations.'
+      });
+      for (const cluster of this.clusters) {
+        const members = this.points.filter(p => p.cluster === cluster.index).map(p => p.text);
+        try {
+          const label = await session.prompt(`Feedback items:\n- ${members.join('\n- ')}\n\nTheme label:`);
+          cluster.label = label.trim().replace(/^["']|["']$/g, '').split('\n')[0];
+        } finally {
+          cluster.isLabeling = false;
+        }
+      }
+      session.destroy?.();
+    } catch (e: any) {
+      this.clusters.forEach(c => (c.isLabeling = false));
+      this.errorMessage = e.message || 'Labeling failed.';
+    }
+  }
+
+  clusterColor(clusterIndex: number): string {
+    return CLUSTER_COLORS[clusterIndex % CLUSTER_COLORS.length];
+  }
+
+  private normalize(vector: Float32Array): Float32Array {
+    let norm = 0;
+    for (let i = 0; i < vector.length; i++) norm += vector[i] * vector[i];
+    norm = Math.sqrt(norm) || 1;
+    const result = new Float32Array(vector.length);
+    for (let i = 0; i < vector.length; i++) result[i] = vector[i] / norm;
+    return result;
+  }
+
+  private squaredDistance(a: Float32Array, b: Float32Array): number {
+    let sum = 0;
+    for (let i = 0; i < a.length; i++) {
+      const diff = a[i] - b[i];
+      sum += diff * diff;
+    }
+    return sum;
+  }
+
+  /** Lloyd's algorithm with k-means++ initialization over normalized vectors. */
+  private kMeans(vectors: Float32Array[], k: number): number[] {
+    const n = vectors.length;
+    const dims = vectors[0].length;
+
+    // k-means++ seeding: pick each next centroid proportionally to squared distance
+    const centroids: Float32Array[] = [vectors[Math.floor(Math.random() * n)]];
+    while (centroids.length < k) {
+      const distances = vectors.map(v => Math.min(...centroids.map(c => this.squaredDistance(v, c))));
+      const total = distances.reduce((s, d) => s + d, 0);
+      let r = Math.random() * total;
+      let picked = 0;
+      for (let i = 0; i < n; i++) {
+        r -= distances[i];
+        if (r <= 0) { picked = i; break; }
+      }
+      centroids.push(vectors[picked]);
+    }
+
+    let assignments = new Array(n).fill(0);
+    for (let iteration = 0; iteration < 30; iteration++) {
+      const next = vectors.map(v => {
+        let best = 0, bestDistance = Infinity;
+        centroids.forEach((c, ci) => {
+          const distance = this.squaredDistance(v, c);
+          if (distance < bestDistance) { bestDistance = distance; best = ci; }
+        });
+        return best;
+      });
+
+      if (next.every((a, i) => a === assignments[i]) && iteration > 0) break;
+      assignments = next;
+
+      for (let ci = 0; ci < k; ci++) {
+        const members = vectors.filter((_, i) => assignments[i] === ci);
+        if (members.length === 0) {
+          // Re-seed an empty cluster with a random point
+          centroids[ci] = vectors[Math.floor(Math.random() * n)];
+          continue;
+        }
+        const mean = new Float32Array(dims);
+        for (const m of members) for (let d = 0; d < dims; d++) mean[d] += m[d];
+        for (let d = 0; d < dims; d++) mean[d] /= members.length;
+        centroids[ci] = mean;
+      }
+    }
+    return assignments;
+  }
+
+  /**
+   * Projects high-dimensional vectors to 2D via PCA. Uses the Gram-matrix trick:
+   * with n items, the top eigenvectors of the n×n Gram matrix give the PCA scores
+   * directly, avoiding any work in the full embedding dimension.
+   */
+  private pca2d(vectors: Float32Array[]): [number, number][] {
+    const n = vectors.length;
+    const dims = vectors[0].length;
+
+    const mean = new Float32Array(dims);
+    for (const v of vectors) for (let d = 0; d < dims; d++) mean[d] += v[d];
+    for (let d = 0; d < dims; d++) mean[d] /= n;
+    const centered = vectors.map(v => {
+      const row = new Float32Array(dims);
+      for (let d = 0; d < dims; d++) row[d] = v[d] - mean[d];
+      return row;
+    });
+
+    const gram: number[][] = Array.from({ length: n }, (_, i) =>
+      Array.from({ length: n }, (_, j) => {
+        let sum = 0;
+        for (let d = 0; d < dims; d++) sum += centered[i][d] * centered[j][d];
+        return sum;
+      })
+    );
+
+    const components: number[][] = [];
+    let matrix = gram.map(row => [...row]);
+    for (let c = 0; c < 2; c++) {
+      let vec = Array.from({ length: n }, () => Math.random() - 0.5);
+      for (let iteration = 0; iteration < 100; iteration++) {
+        const next = matrix.map(row => row.reduce((s, value, j) => s + value * vec[j], 0));
+        const norm = Math.sqrt(next.reduce((s, v) => s + v * v, 0)) || 1;
+        vec = next.map(v => v / norm);
+      }
+      const eigenvalue = vec.reduce((s, vi, i) => s + vi * matrix[i].reduce((ss, value, j) => ss + value * vec[j], 0), 0);
+      components.push(vec.map(v => v * Math.sqrt(Math.abs(eigenvalue))));
+      matrix = matrix.map((row, i) => row.map((value, j) => value - eigenvalue * vec[i] * vec[j]));
+    }
+
+    return Array.from({ length: n }, (_, i) => [components[0][i], components[1][i]]);
+  }
+
+  private toSvgPoints(items: string[], assignments: number[], coords: [number, number][]): ClusterPoint[] {
+    const xs = coords.map(c => c[0]);
+    const ys = coords.map(c => c[1]);
+    const minX = Math.min(...xs), maxX = Math.max(...xs);
+    const minY = Math.min(...ys), maxY = Math.max(...ys);
+    const spanX = maxX - minX || 1;
+    const spanY = maxY - minY || 1;
+
+    return items.map((text, i) => ({
+      text,
+      cluster: assignments[i],
+      x: this.padding + ((coords[i][0] - minX) / spanX) * (this.width - 2 * this.padding),
+      y: this.padding + ((coords[i][1] - minY) / spanY) * (this.height - 2 * this.padding)
+    }));
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const embedder = await SemanticEmbedder.create({ taskType: "clustering" });
+
+// Embed all ${this.itemCount} feedback items in one batched call
+const { embeddings } = await embedder.embed(feedbackItems);
+const vectors = embeddings.map(e => e.values);
+
+// Group them with standard k-means (k = ${this.k})
+const assignments = kMeans(vectors, ${this.k});
+
+// Project to 2D with PCA for the scatter plot
+const coords = pca2d(vectors);
+
+// Let the on-device LLM name each cluster
+const session = await LanguageModel.create({
+  systemPrompt: "Reply with ONLY a 2-4 word theme label."
+});
+for (let c = 0; c < ${this.k}; c++) {
+  const members = feedbackItems.filter((_, i) => assignments[i] === c);
+  const label = await session.prompt(
+    "Feedback items:\\n- " + members.join("\\n- ") + "\\n\\nTheme label:"
+  );
+  console.log(\`Cluster \${c + 1}: \${label}\`);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/command-palette-demo.component.html
+++ b/webapp/src/app/pages/demos/features/command-palette-demo.component.html
@@ -1,0 +1,156 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (!indexReady && embedderStatus !== 'unavailable') {
+      <div class="mb-4 bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/10 dark:border-indigo-900/30 rounded-2xl p-4 flex items-center justify-between gap-4">
+        <span class="text-sm text-indigo-900 dark:text-indigo-200 flex items-center gap-2">
+          @if (isIndexing) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Embedding {{ actions.length }} actions on-device...
+          } @else {
+            <i class="bi bi-command"></i> The palette embeds its {{ actions.length }} actions once, then ranks them on every keystroke.
+          }
+        </span>
+        @if (!isIndexing) {
+          <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none whitespace-nowrap"
+                  (click)="buildIndex()">
+            Prepare Palette
+          </button>
+        }
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Palette -->
+      <div class="lg:flex-[3] w-full">
+        <div class="bg-[#ffffff] dark:bg-[#18181b] rounded-3xl shadow-xl border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <!-- Input -->
+          <div class="flex items-center gap-3 px-5 py-4 border-b border-slate-100 dark:border-zinc-800">
+            <i class="bi bi-command text-lg text-slate-400"></i>
+            <input
+              type="text"
+              class="flex-grow bg-transparent border-none outline-none focus:ring-0 text-lg text-slate-800 dark:text-slate-200 placeholder-slate-400"
+              [(ngModel)]="query"
+              (ngModelChange)="onQueryChanged($event)"
+              (keydown)="onKeydown($event)"
+              [disabled]="!indexReady"
+              placeholder="Describe what you want to do..." />
+            @if (isRanking) {
+              <i class="bi bi-arrow-repeat animate-spin text-indigo-400"></i>
+            } @else if (rankLatencyMs !== null && ranked.length > 0) {
+              <span class="text-[10px] font-semibold px-2 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40 whitespace-nowrap">
+                {{ rankLatencyMs }}ms
+              </span>
+            }
+          </div>
+
+          <!-- Results -->
+          <div class="p-2 min-h-[280px] flex flex-col">
+            @if (!query.trim()) {
+              @for (action of actions; track action.id) {
+                <button class="flex items-center gap-3 px-4 py-2.5 rounded-xl text-left bg-transparent border-none hover:bg-slate-50 dark:hover:bg-zinc-800/70 transition-colors group"
+                        (click)="execute(action)">
+                  <i class="bi {{ action.icon }} text-slate-400 dark:text-slate-500 group-hover:text-indigo-500"></i>
+                  <span class="text-sm font-medium text-slate-700 dark:text-slate-300">{{ action.label }}</span>
+                  <span class="text-xs text-slate-400 dark:text-slate-600 truncate hidden sm:inline">{{ action.description }}</span>
+                </button>
+              }
+            } @else if (ranked.length === 0) {
+              <p class="text-sm text-slate-400 dark:text-slate-500 m-auto font-light">Ranking...</p>
+            } @else {
+              @for (result of ranked; track result.action.id; let i = $index) {
+                <button class="flex items-center gap-3 px-4 py-3 rounded-xl text-left border-none transition-all"
+                        [ngClass]="i === selectedIndex ? 'bg-indigo-50 dark:bg-indigo-900/20 ring-1 ring-indigo-200 dark:ring-indigo-800' : 'bg-transparent hover:bg-slate-50 dark:hover:bg-zinc-800/70'"
+                        (mouseenter)="selectedIndex = i"
+                        (click)="execute(result.action)">
+                  <i class="bi {{ result.action.icon }} text-lg"
+                     [ngClass]="i === selectedIndex ? 'text-indigo-600 dark:text-indigo-400' : 'text-slate-400 dark:text-slate-500'"></i>
+                  <div class="flex-grow min-w-0">
+                    <div class="flex items-center gap-2">
+                      <span class="text-sm font-semibold" [ngClass]="i === selectedIndex ? 'text-indigo-700 dark:text-indigo-300' : 'text-slate-700 dark:text-slate-300'">
+                        {{ result.action.label }}
+                      </span>
+                      @if (i === 0 && result.keywordOverlap === 0) {
+                        <span class="text-[9px] font-bold px-1.5 py-0.5 rounded bg-indigo-600 text-white uppercase tracking-wider whitespace-nowrap"
+                              title="This match shares no words with your query — pure semantic matching.">
+                          0 shared words
+                        </span>
+                      }
+                    </div>
+                    <span class="text-xs text-slate-400 dark:text-slate-500 truncate block">{{ result.action.description }}</span>
+                  </div>
+                  <div class="w-14 h-1.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden shrink-0">
+                    <div class="h-full bg-indigo-500 rounded-full" [style.width.%]="result.score * 100"></div>
+                  </div>
+                  <span class="text-[10px] font-mono font-semibold text-slate-400 dark:text-slate-500 shrink-0">{{ result.score.toFixed(3) }}</span>
+                  @if (i === selectedIndex) {
+                    <span class="text-[9px] font-bold text-slate-400 dark:text-slate-500 border border-slate-300 dark:border-zinc-600 rounded px-1 py-0.5 shrink-0">↵</span>
+                  }
+                </button>
+              }
+            }
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-2 mt-4">
+          <span class="text-xs text-slate-400 dark:text-slate-500 self-center mr-1">Try an intent:</span>
+          @for (sample of sampleIntents; track sample) {
+            <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                    [disabled]="!indexReady"
+                    (click)="useSample(sample)">
+              "{{ sample }}"
+            </button>
+          }
+        </div>
+      </div>
+
+      <!-- Execution log -->
+      <div class="lg:flex-[2] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[200px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-terminal text-indigo-500"></i> Executed
+          </span>
+        </div>
+        <div class="p-4 flex flex-col gap-2 flex-grow">
+          @if (executedLog.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light px-4">
+              Press <span class="font-semibold">Enter</span> or click an action to run it.<br />
+              <span class="text-xs">"Toggle dark mode" really toggles this site's theme.</span>
+            </p>
+          }
+          @for (entry of executedLog; track $index) {
+            <div class="flex items-center gap-2.5 px-3.5 py-2.5 rounded-xl bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700">
+              <i class="bi bi-check-circle-fill text-emerald-500"></i>
+              <i class="bi {{ entry.icon }} text-slate-400"></i>
+              <span class="text-sm text-slate-700 dark:text-slate-300 font-medium">{{ entry.label }}</span>
+              @if (entry.real) {
+                <span class="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded bg-emerald-600 text-white uppercase tracking-wider">For real</span>
+              } @else {
+                <span class="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded bg-slate-300 dark:bg-zinc-700 text-slate-600 dark:text-slate-300 uppercase tracking-wider">Simulated</span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
@@ -1,0 +1,204 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Subject, debounceTime } from 'rxjs';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { ThemeService } from '../../../core/services/theme.service';
+
+interface PaletteAction {
+  id: string;
+  label: string;
+  description: string;
+  icon: string;
+  vector?: Float32Array;
+}
+
+interface RankedAction {
+  action: PaletteAction;
+  score: number;
+  keywordOverlap: number;
+}
+
+const ACTIONS: PaletteAction[] = [
+  { id: 'toggle-theme', label: 'Toggle dark mode', description: 'Switch between the light and dark appearance', icon: 'bi-moon-stars' },
+  { id: 'new-doc', label: 'Create new document', description: 'Start a blank document in the editor', icon: 'bi-file-earmark-plus' },
+  { id: 'export-pdf', label: 'Export as PDF', description: 'Download the current page as a PDF file', icon: 'bi-file-earmark-pdf' },
+  { id: 'share-link', label: 'Copy share link', description: 'Copy a public link to this page to the clipboard', icon: 'bi-link-45deg' },
+  { id: 'mute', label: 'Mute notifications', description: 'Silence all alerts and badges for a while', icon: 'bi-bell-slash' },
+  { id: 'font-size', label: 'Increase font size', description: 'Make the text larger and easier to read', icon: 'bi-zoom-in' },
+  { id: 'shortcuts', label: 'View keyboard shortcuts', description: 'Show the list of available hotkeys', icon: 'bi-keyboard' },
+  { id: 'clear-cache', label: 'Clear local cache', description: 'Free up storage used by offline data', icon: 'bi-trash3' },
+  { id: 'invite', label: 'Invite a teammate', description: 'Send a collaboration invitation by email', icon: 'bi-person-plus' },
+  { id: 'sign-out', label: 'Sign out', description: 'Log out of your account securely', icon: 'bi-box-arrow-right' },
+  { id: 'print', label: 'Print this page', description: 'Send the current view to a printer', icon: 'bi-printer' },
+  { id: 'focus', label: 'Enter focus mode', description: 'Hide side panels and distractions while writing', icon: 'bi-fullscreen' },
+  { id: 'language', label: 'Change language', description: 'Switch the interface to another language', icon: 'bi-globe2' },
+  { id: 'history', label: 'View version history', description: 'Browse and restore earlier versions of this document', icon: 'bi-clock-history' }
+];
+
+@Component({
+  selector: 'app-command-palette-demo',
+  templateUrl: './command-palette-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  private readonly themeService = inject(ThemeService);
+
+  demo = DEMOS_DATA.find(d => d.id === 'command-palette')!;
+
+  actions = ACTIONS;
+  query = '';
+  ranked: RankedAction[] = [];
+  selectedIndex = 0;
+
+  sampleIntents = [
+    'make it easier on my eyes at night',
+    'I want to work without distractions',
+    'get this document onto paper',
+    'let my colleague see this page',
+    'the letters are too tiny for me'
+  ];
+
+  isIndexing = false;
+  indexReady = false;
+  isRanking = false;
+  rankLatencyMs: number | null = null;
+
+  executedLog: { label: string; icon: string; real: boolean }[] = [];
+
+  private query$ = new Subject<string>();
+  private rankToken = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+
+    this.subscriptions.push(
+      this.query$.pipe(debounceTime(200)).subscribe(q => this.rank(q))
+    );
+
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    if (this.embedderStatus === 'available') {
+      await this.buildIndex();
+    }
+  }
+
+  async buildIndex() {
+    if (this.isIndexing || this.indexReady) return;
+    this.isIndexing = true;
+    this.errorMessage = '';
+    try {
+      const texts = this.actions.map(a => `${a.label} — ${a.description}`);
+      const vectors = await this.semanticEmbedder.embed(texts, 'retrieval', this.onDownloadProgress);
+      this.actions.forEach((action, i) => (action.vector = vectors[i]));
+      this.indexReady = true;
+      if (this.query.trim()) this.rank(this.query);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to embed the actions.';
+    } finally {
+      this.isIndexing = false;
+    }
+  }
+
+  onQueryChanged(value: string) {
+    this.query$.next(value);
+  }
+
+  useSample(sample: string) {
+    this.query = sample;
+    this.rank(sample);
+  }
+
+  onKeydown(event: KeyboardEvent) {
+    if (this.ranked.length === 0) return;
+    if (event.key === 'ArrowDown') {
+      event.preventDefault();
+      this.selectedIndex = (this.selectedIndex + 1) % this.ranked.length;
+    } else if (event.key === 'ArrowUp') {
+      event.preventDefault();
+      this.selectedIndex = (this.selectedIndex - 1 + this.ranked.length) % this.ranked.length;
+    } else if (event.key === 'Enter') {
+      event.preventDefault();
+      this.execute(this.ranked[this.selectedIndex]?.action);
+    }
+  }
+
+  execute(action: PaletteAction | undefined) {
+    if (!action) return;
+    const real = action.id === 'toggle-theme';
+    if (real) {
+      const isDark = this.document.documentElement.getAttribute('data-bs-theme') === 'dark';
+      this.themeService.setTheme(isDark ? 'light' : 'dark');
+    }
+    this.executedLog.unshift({ label: action.label, icon: action.icon, real });
+    if (this.executedLog.length > 6) this.executedLog.pop();
+  }
+
+  private tokenize(text: string): Set<string> {
+    return new Set(text.toLowerCase().split(/[^a-z0-9']+/).filter(t => t.length > 2));
+  }
+
+  async rank(rawQuery: string) {
+    const query = rawQuery.trim();
+    const token = ++this.rankToken;
+
+    if (!query || !this.indexReady) {
+      this.ranked = [];
+      this.selectedIndex = 0;
+      return;
+    }
+
+    this.isRanking = true;
+    try {
+      const start = performance.now();
+      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval');
+      const latency = Math.round(performance.now() - start);
+      if (token !== this.rankToken) return;
+
+      this.rankLatencyMs = latency;
+      const queryTokens = this.tokenize(query);
+      this.ranked = this.actions
+        .map(action => ({
+          action,
+          score: this.semanticEmbedder.cosineSimilarity(queryVector, action.vector!),
+          keywordOverlap: [...this.tokenize(action.label)].filter(t => queryTokens.has(t)).length
+        }))
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 6);
+      this.selectedIndex = 0;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Ranking failed.';
+    } finally {
+      if (token === this.rankToken) this.isRanking = false;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const q = this.query.trim() || this.sampleIntents[0];
+    const top = this.ranked[0]?.action.label ?? 'Toggle dark mode';
+    return `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+
+const actions = [
+  { label: "Toggle dark mode", description: "Switch between the light and dark appearance" },
+  { label: "Export as PDF", description: "Download the current page as a PDF file" },
+  // ... ${this.actions.length} actions total
+];
+
+// Embed every action once
+const { embeddings } = await embedder.embed(
+  actions.map(a => \`\${a.label} — \${a.description}\`)
+);
+
+// On every keystroke, rank the actions against the typed intent
+const query = await embedder.embed(${JSON.stringify(q)});
+const queryVector = query.embeddings[0].values;
+
+const ranked = actions
+  .map((a, i) => ({ ...a, score: cosineSimilarity(queryVector, embeddings[i].values) }))
+  .sort((a, b) => b.score - a.score);
+
+console.log(ranked[0].label); // "${top}"`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
@@ -91,7 +91,7 @@ export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent imple
     this.errorMessage = '';
     try {
       const texts = this.actions.map(a => `${a.label} — ${a.description}`);
-      const vectors = await this.semanticEmbedder.embed(texts, 'retrieval', this.onDownloadProgress);
+      const vectors = await this.semanticEmbedder.embed(texts, 'retrieval-document', this.onDownloadProgress);
       this.actions.forEach((action, i) => (action.vector = vectors[i]));
       this.indexReady = true;
       if (this.query.trim()) this.rank(this.query);
@@ -153,7 +153,7 @@ export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent imple
     this.isRanking = true;
     try {
       const start = performance.now();
-      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval');
+      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval-query');
       const latency = Math.round(performance.now() - start);
       if (token !== this.rankToken) return;
 
@@ -178,21 +178,21 @@ export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent imple
   get dynamicCodeSnippet(): string {
     const q = this.query.trim() || this.sampleIntents[0];
     const top = this.ranked[0]?.action.label ?? 'Toggle dark mode';
-    return `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
-
-const actions = [
+    return `const actions = [
   { label: "Toggle dark mode", description: "Switch between the light and dark appearance" },
   { label: "Export as PDF", description: "Download the current page as a PDF file" },
   // ... ${this.actions.length} actions total
 ];
 
 // Embed every action once
-const { embeddings } = await embedder.embed(
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+const { embeddings } = await docEmbedder.embed(
   actions.map(a => \`\${a.label} — \${a.description}\`)
 );
 
 // On every keystroke, rank the actions against the typed intent
-const query = await embedder.embed(${JSON.stringify(q)});
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const query = await queryEmbedder.embed(${JSON.stringify(q)});
 const queryVector = query.embeddings[0].values;
 
 const ranked = actions

--- a/webapp/src/app/pages/demos/features/document-chat-demo.component.html
+++ b/webapp/src/app/pages/demos/features/document-chat-demo.component.html
@@ -1,0 +1,149 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [showPromptApi]="true"
+      [promptApiStatus]="languageModelAvailability"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    <div class="flex flex-col lg:flex-row gap-6">
+
+      <!-- Document panel -->
+      <div class="lg:flex-[2] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[420px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 flex justify-between items-center bg-slate-50/50 dark:bg-[#161616]/50">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-file-earmark-text text-indigo-500"></i> Your Document
+          </span>
+          @if (indexed) {
+            <span class="text-xs font-semibold text-emerald-600 dark:text-emerald-400 flex items-center gap-1.5">
+              <i class="bi bi-check-circle-fill"></i> {{ chunks.length }} chunks indexed in {{ indexingTimeMs }}ms
+            </span>
+          }
+        </div>
+        <textarea
+          class="w-full flex-grow bg-transparent border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 placeholder-slate-400 resize-none p-5 leading-relaxed text-sm min-h-[300px]"
+          [(ngModel)]="documentText"
+          (ngModelChange)="onDocumentChanged()"
+          placeholder="Paste any document here, then index it..."></textarea>
+        <div class="p-4 border-t border-slate-100 dark:border-zinc-700/50 flex items-center justify-between gap-3">
+          <span class="text-xs text-slate-400 dark:text-slate-500">Paragraphs become retrieval chunks.</span>
+          <button
+            class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+            (click)="indexDocument()"
+            [disabled]="!documentText.trim() || isIndexing || !embedderUsable">
+            @if (isIndexing) {
+              <i class="bi bi-arrow-repeat animate-spin text-lg"></i> Indexing...
+            } @else if (indexed) {
+              <i class="bi bi-arrow-clockwise text-lg"></i> Re-index
+            } @else {
+              <i class="bi bi-diagram-3 text-lg"></i> Index Document
+            }
+          </button>
+        </div>
+      </div>
+
+      <!-- Q&A panel -->
+      <div class="lg:flex-[3] flex flex-col gap-4">
+
+        <!-- Question input -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5">
+          <div class="flex gap-3">
+            <input
+              type="text"
+              class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40 text-sm"
+              [(ngModel)]="question"
+              (keydown.enter)="ask()"
+              [disabled]="!indexed"
+              placeholder="{{ indexed ? 'Ask anything about the document...' : 'Index the document first...' }}" />
+            @if (state === 'Inferencing') {
+              <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                      (click)="onCancel()">
+                <i class="bi bi-stop-fill"></i> Stop
+              </button>
+            } @else {
+              <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                      (click)="ask()"
+                      [disabled]="!canAsk || !question.trim()">
+                <i class="bi bi-send"></i> Ask
+              </button>
+            }
+          </div>
+          <div class="flex flex-wrap gap-2 mt-3">
+            @for (sample of sampleQuestions; track sample) {
+              <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                      [disabled]="!canAsk"
+                      (click)="askSample(sample)">
+                {{ sample }}
+              </button>
+            }
+          </div>
+        </div>
+
+        @if (errorMessage) {
+          <div class="bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+            {{ errorMessage }}
+          </div>
+        }
+
+        <!-- Retrieved passages -->
+        @if (retrieved.length > 0) {
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5">
+            <div class="flex items-center justify-between mb-3">
+              <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                <i class="bi bi-crosshair text-indigo-500"></i> Retrieved Passages
+              </span>
+              @if (retrievalTimeMs !== null) {
+                <span class="text-xs font-semibold text-indigo-600 dark:text-indigo-400">retrieved in {{ retrievalTimeMs }}ms</span>
+              }
+            </div>
+            <div class="flex flex-col gap-2.5">
+              @for (chunk of retrieved; track $index) {
+                <div class="rounded-xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-3.5">
+                  <div class="flex items-center gap-3 mb-1.5">
+                    <span class="text-[10px] font-bold px-2 py-0.5 rounded-md bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300">[{{ $index + 1 }}]</span>
+                    <div class="flex-grow h-1.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+                      <div class="h-full bg-indigo-500 rounded-full" [style.width.%]="chunk.score * 100"></div>
+                    </div>
+                    <span class="text-xs font-mono font-semibold text-slate-500 dark:text-slate-400">{{ chunk.score.toFixed(3) }}</span>
+                  </div>
+                  <p class="text-xs text-slate-600 dark:text-slate-400 m-0 leading-relaxed line-clamp-3">{{ chunk.text }}</p>
+                </div>
+              }
+            </div>
+          </div>
+        }
+
+        <!-- Answer -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col flex-grow min-h-[160px] overflow-hidden">
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-stars text-amber-500"></i> Grounded Answer
+            </span>
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+          </div>
+          <div class="p-5 text-slate-800 dark:text-slate-200 leading-relaxed text-[15px] whitespace-pre-wrap flex-grow">
+            @if (answer) {
+              {{ answer }}
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">The answer, grounded in the retrieved passages, will appear here...</span>
+            }
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/document-chat-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/document-chat-demo.component.ts
@@ -1,0 +1,200 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+interface DocumentChunk {
+  text: string;
+  vector: Float32Array;
+}
+
+interface RetrievedChunk {
+  text: string;
+  score: number;
+}
+
+const SAMPLE_DOCUMENT = `Aurora One — Owner's Manual
+
+Welcome to your Aurora One electric bike. This manual covers charging, range, maintenance, and warranty. Please read the safety section before your first ride and keep this document for future reference.
+
+Charging the battery: connect the supplied 4A fast charger to the port under the top tube. A full charge from empty takes about 3.5 hours, and an 80% charge takes just under 2 hours. The battery indicator pulses green while charging and turns solid green when complete. Only use the official Aurora charger; third-party chargers void the battery warranty.
+
+Range and riding modes: in Eco mode the Aurora One reaches up to 95 km on a single charge. Sport mode delivers stronger acceleration but reduces range to roughly 60 km. Range varies with rider weight, terrain, tire pressure, and outside temperature — cold weather below 0°C can temporarily reduce range by up to 25%.
+
+Water and weather: the Aurora One is rated IP65. Riding in rain is perfectly fine, but avoid submerging the bike, riding through deep standing water, or cleaning it with a pressure washer, as high-pressure jets can force water past the seals and damage the motor controller.
+
+Pairing the app: download the Aurora Ride app, enable Bluetooth, and hold the power button for five seconds until the display shows a pairing code. Enter the code in the app to link your phone. The app provides GPS ride tracking, over-the-air firmware updates, and an anti-theft alarm that triggers if the bike is moved while locked.
+
+Maintenance schedule: check tire pressure weekly (recommended 3.5 bar front, 4.0 bar rear). Clean and lightly oil the chain every 250 km. Have the brake pads inspected every 1,000 km. A full service at an authorized dealer is recommended once a year or every 3,000 km, whichever comes first.
+
+Battery care and storage: for long-term storage, keep the battery charged between 40% and 60% and store it indoors between 10°C and 25°C. Never leave the battery in a parked car in summer. The battery retains at least 80% of its capacity after 800 full charge cycles under normal conditions.
+
+Warranty: the frame is covered for 5 years, the battery and motor for 2 years or 15,000 km, and electronic components for 2 years. The warranty does not cover wear parts such as tires, brake pads, and the chain, nor damage caused by unauthorized modifications, racing, or use of non-official chargers.`;
+
+@Component({
+  selector: 'app-document-chat-demo',
+  templateUrl: './document-chat-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class DocumentChatDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'document-chat')!;
+
+  documentText = SAMPLE_DOCUMENT;
+  question = '';
+  sampleQuestions = [
+    'How long does a full charge take?',
+    'Can I ride it in heavy rain?',
+    'How do I connect my phone?',
+    'Is my chain covered by the warranty?'
+  ];
+
+  chunks: DocumentChunk[] = [];
+  isIndexing = false;
+  indexed = false;
+  indexingTimeMs: number | null = null;
+
+  retrieved: RetrievedChunk[] = [];
+  retrievalTimeMs: number | null = null;
+  answer = '';
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability();
+  }
+
+  onDocumentChanged() {
+    this.indexed = false;
+    this.chunks = [];
+    this.retrieved = [];
+    this.answer = '';
+  }
+
+  private chunkDocument(text: string): string[] {
+    return text
+      .split(/\n\s*\n/)
+      .map(p => p.trim().replace(/\s+/g, ' '))
+      .filter(p => p.length > 0);
+  }
+
+  async indexDocument() {
+    const parts = this.chunkDocument(this.documentText);
+    if (parts.length === 0 || this.isIndexing) return;
+
+    this.isIndexing = true;
+    this.indexed = false;
+    this.errorMessage = '';
+    this.retrieved = [];
+    this.answer = '';
+    const start = performance.now();
+
+    try {
+      const vectors = await this.semanticEmbedder.embed(parts, 'retrieval', this.onDownloadProgress);
+      this.chunks = parts.map((text, i) => ({ text, vector: vectors[i] }));
+      this.indexingTimeMs = Math.round(performance.now() - start);
+      this.indexed = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to index the document.';
+    } finally {
+      this.isIndexing = false;
+    }
+  }
+
+  get canAsk(): boolean {
+    return this.indexed
+      && this.state !== PromptInputStateEnum.Inferencing
+      && this.languageModelAvailability !== 'unavailable';
+  }
+
+  askSample(sample: string) {
+    this.question = sample;
+    this.ask();
+  }
+
+  async ask() {
+    const q = this.question.trim();
+    if (!q || !this.canAsk) return;
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.answer = '';
+    this.retrieved = [];
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.retrievalTimeMs = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      // Retrieval: embed the question and rank the chunks
+      const queryVector = await this.semanticEmbedder.embedOne(q, 'retrieval');
+      const top = this.semanticEmbedder.topK(queryVector, this.chunks.map(c => c.vector), 3);
+      this.retrieved = top.map(r => ({ text: this.chunks[r.index].text, score: r.score }));
+      this.retrievalTimeMs = Math.round(performance.now() - startTime);
+
+      // Generation: ground the Prompt API in the retrieved passages
+      const context = this.retrieved.map((c, i) => `[${i + 1}] ${c.text}`).join('\n\n');
+      const session = await LanguageModel.create({
+        systemPrompt: 'You answer questions about a document. Use ONLY the numbered context passages provided. Cite the passage numbers you used, like [1]. If the context does not contain the answer, say you cannot find it in the document. Be concise.'
+      });
+
+      const stream = session.promptStreaming(`Context passages:\n${context}\n\nQuestion: ${q}`, {
+        signal: this.abortController.signal
+      });
+
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - startTime);
+        }
+        this.answer += chunk;
+      }
+
+      this.totalTime = Math.round(performance.now() - startTime);
+      session.destroy?.();
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Failed to answer the question.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const q = this.question.trim() || 'How long does a full charge take?';
+    return `// 1. Index: chunk the document and embed every chunk in one batch
+const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+const chunks = documentText.split(/\\n\\s*\\n/); // ${this.chunks.length || 'N'} chunks
+const { embeddings } = await embedder.embed(chunks);
+
+// 2. Retrieve: embed the question, rank chunks by cosine similarity
+const query = await embedder.embed(${JSON.stringify(q)});
+const queryVector = query.embeddings[0].values;
+const top3 = embeddings
+  .map((e, i) => ({ i, score: cosineSimilarity(queryVector, e.values) }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 3);
+
+// 3. Generate: ground the on-device LLM in the retrieved passages
+const session = await LanguageModel.create({
+  systemPrompt: "Answer using ONLY the numbered context passages. Cite them like [1]."
+});
+const context = top3.map((t, n) => \`[\${n + 1}] \${chunks[t.i]}\`).join("\\n\\n");
+const stream = session.promptStreaming(
+  \`Context passages:\\n\${context}\\n\\nQuestion: ${q.replace(/`/g, '')}\`
+);
+for await (const chunk of stream) {
+  console.log(chunk);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/document-chat-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/document-chat-demo.component.ts
@@ -95,7 +95,7 @@ export class DocumentChatDemoComponent extends BaseEmbedderDemoComponent impleme
     const start = performance.now();
 
     try {
-      const vectors = await this.semanticEmbedder.embed(parts, 'retrieval', this.onDownloadProgress);
+      const vectors = await this.semanticEmbedder.embed(parts, 'retrieval-document', this.onDownloadProgress);
       this.chunks = parts.map((text, i) => ({ text, vector: vectors[i] }));
       this.indexingTimeMs = Math.round(performance.now() - start);
       this.indexed = true;
@@ -135,7 +135,7 @@ export class DocumentChatDemoComponent extends BaseEmbedderDemoComponent impleme
 
     try {
       // Retrieval: embed the question and rank the chunks
-      const queryVector = await this.semanticEmbedder.embedOne(q, 'retrieval');
+      const queryVector = await this.semanticEmbedder.embedOne(q, 'retrieval-query');
       const top = this.semanticEmbedder.topK(queryVector, this.chunks.map(c => c.vector), 3);
       this.retrieved = top.map(r => ({ text: this.chunks[r.index].text, score: r.score }));
       this.retrievalTimeMs = Math.round(performance.now() - startTime);
@@ -173,12 +173,13 @@ export class DocumentChatDemoComponent extends BaseEmbedderDemoComponent impleme
   get dynamicCodeSnippet(): string {
     const q = this.question.trim() || 'How long does a full charge take?';
     return `// 1. Index: chunk the document and embed every chunk in one batch
-const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
 const chunks = documentText.split(/\\n\\s*\\n/); // ${this.chunks.length || 'N'} chunks
-const { embeddings } = await embedder.embed(chunks);
+const { embeddings } = await docEmbedder.embed(chunks);
 
-// 2. Retrieve: embed the question, rank chunks by cosine similarity
-const query = await embedder.embed(${JSON.stringify(q)});
+// 2. Retrieve: embed the question with the query task type, rank chunks by cosine similarity
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const query = await queryEmbedder.embed(${JSON.stringify(q)});
 const queryVector = query.embeddings[0].values;
 const top3 = embeddings
   .map((e, i) => ({ i, score: cosineSimilarity(queryVector, e.values) }))

--- a/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.html
+++ b/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.html
@@ -1,0 +1,159 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (!indexReady && embedderStatus !== 'unavailable') {
+      <div class="mb-4 bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/10 dark:border-indigo-900/30 rounded-2xl p-4 flex items-center justify-between gap-4">
+        <span class="text-sm text-indigo-900 dark:text-indigo-200 flex items-center gap-2">
+          @if (isIndexing) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Embedding the issue tracker on-device...
+          } @else {
+            <i class="bi bi-database"></i> The tracker's existing issues need to be embedded before duplicate detection can run.
+          }
+        </span>
+        @if (!isIndexing) {
+          <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none whitespace-nowrap"
+                  (click)="buildIndex()">
+            Build Index
+          </button>
+        }
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6">
+
+      <!-- New issue form -->
+      <div class="lg:flex-[3] flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-bug text-indigo-500"></i> Report an Issue
+            </span>
+            @if (checkLatencyMs !== null && hasChecked) {
+              <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                <i class="bi bi-cpu"></i> checked in {{ checkLatencyMs }}ms
+              </span>
+            }
+          </div>
+          <div class="p-5 flex flex-col gap-4">
+            <input
+              type="text"
+              class="w-full bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-xl px-4 py-3 text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40 text-base"
+              [(ngModel)]="draftTitle"
+              (ngModelChange)="onDraftChanged()"
+              [disabled]="!indexReady"
+              placeholder="Issue title — duplicates are checked while you type..." />
+
+            <div class="flex flex-wrap gap-2">
+              @for (sample of sampleDrafts; track sample) {
+                <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                        [disabled]="!indexReady"
+                        (click)="useSample(sample)">
+                  {{ sample }}
+                </button>
+              }
+            </div>
+
+            <!-- Duplicate warnings -->
+            @if (hasChecked && draftTitle.trim()) {
+              @if (duplicates.length > 0) {
+                <div class="bg-amber-50 border border-amber-200 dark:bg-amber-900/10 dark:border-amber-900/30 rounded-2xl p-4">
+                  <div class="flex items-center gap-2 mb-3">
+                    <i class="bi bi-exclamation-triangle-fill text-amber-500"></i>
+                    <span class="text-sm font-bold text-amber-800 dark:text-amber-300">
+                      {{ duplicates.length }} possible {{ duplicates.length === 1 ? 'duplicate' : 'duplicates' }} found
+                    </span>
+                  </div>
+                  <div class="flex flex-col gap-2">
+                    @for (match of duplicates; track match.issue.id) {
+                      <div class="flex items-center gap-3 bg-[#ffffff] dark:bg-zinc-800/80 rounded-xl border border-amber-200/60 dark:border-amber-900/30 px-3.5 py-2.5">
+                        <span class="text-[10px] font-mono font-bold text-slate-400 dark:text-slate-500">#{{ match.issue.id }}</span>
+                        <span class="text-sm text-slate-700 dark:text-slate-300 flex-grow">{{ match.issue.title }}</span>
+                        <div class="w-16 h-1.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden shrink-0">
+                          <div class="h-full bg-amber-500 rounded-full" [style.width.%]="match.score * 100"></div>
+                        </div>
+                        <span class="text-xs font-mono font-semibold text-amber-700 dark:text-amber-400 shrink-0">{{ (match.score * 100).toFixed(0) }}%</span>
+                      </div>
+                    }
+                  </div>
+                </div>
+              } @else {
+                <div class="bg-emerald-50 border border-emerald-200 dark:bg-emerald-900/10 dark:border-emerald-900/30 rounded-2xl p-4 flex items-center gap-2 text-sm text-emerald-800 dark:text-emerald-300">
+                  <i class="bi bi-check-circle-fill text-emerald-500"></i>
+                  No similar issues above the threshold — this looks like a new problem.
+                </div>
+              }
+            }
+
+            @if (submittedMessage) {
+              <div class="bg-emerald-50 border border-emerald-200 dark:bg-emerald-900/10 dark:border-emerald-900/30 rounded-2xl p-4 flex items-center gap-2 text-sm text-emerald-800 dark:text-emerald-300">
+                <i class="bi bi-send-check-fill text-emerald-500"></i> {{ submittedMessage }}
+              </div>
+            }
+
+            <!-- Threshold + submit -->
+            <div class="flex flex-col sm:flex-row sm:items-center gap-4 pt-1">
+              <div class="flex items-center gap-3 flex-grow">
+                <span class="text-xs font-semibold text-slate-500 dark:text-slate-400 whitespace-nowrap">Similarity threshold</span>
+                <input type="range" min="0.3" max="0.9" step="0.05"
+                       class="flex-grow accent-indigo-600"
+                       [(ngModel)]="threshold"
+                       (ngModelChange)="onThresholdChanged()" />
+                <span class="text-xs font-mono font-bold text-indigo-600 dark:text-indigo-400 w-10">{{ threshold.toFixed(2) }}</span>
+              </div>
+              <button class="flex items-center justify-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                      (click)="submitIssue()"
+                      [disabled]="!draftTitle.trim() || !indexReady || isChecking">
+                <i class="bi bi-send"></i> File Issue
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <!-- Existing issues -->
+      <div class="lg:flex-[2] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col max-h-[560px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-list-task text-indigo-500"></i> Open Issues
+          </span>
+          <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ issues.length }}</span>
+        </div>
+        <div class="overflow-y-auto flex-grow p-3 flex flex-col gap-1.5">
+          @if (issues.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light p-6">Issues appear here once the index is built.</p>
+          }
+          @for (issue of issues; track issue.id) {
+            <div class="flex items-center gap-2.5 px-3 py-2 rounded-lg transition-colors"
+                 [ngClass]="issue.isNew ? 'bg-emerald-50 dark:bg-emerald-900/15 border border-emerald-200 dark:border-emerald-900/40' : 'hover:bg-slate-50 dark:hover:bg-zinc-800'">
+              <span class="text-[10px] font-mono font-bold shrink-0"
+                    [ngClass]="issue.isNew ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400 dark:text-slate-500'">#{{ issue.id }}</span>
+              <span class="text-xs text-slate-600 dark:text-slate-400 leading-snug">{{ issue.title }}</span>
+              @if (issue.isNew) {
+                <span class="ml-auto text-[9px] font-bold px-1.5 py-0.5 rounded bg-emerald-600 text-white uppercase shrink-0">New</span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.ts
@@ -1,0 +1,199 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Subject, debounceTime } from 'rxjs';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+interface TrackedIssue {
+  id: number;
+  title: string;
+  vector: Float32Array;
+  isNew?: boolean;
+}
+
+interface DuplicateMatch {
+  issue: TrackedIssue;
+  score: number;
+}
+
+const EXISTING_ISSUES: string[] = [
+  'Google OAuth sign-in returns a 500 error',
+  'Dark mode colors flicker when switching tabs',
+  'CSV export drops rows containing commas',
+  'Push notifications arrive twice on Android',
+  'Profile photo upload fails for files over 5 MB',
+  'Search results ignore the selected date filter',
+  'Password reset email never arrives',
+  'Dashboard charts overlap on small screens',
+  'Keyboard shortcuts stop working after closing a modal',
+  'Session expires while actively typing a comment',
+  'Drag-and-drop reordering breaks in Firefox',
+  'Emoji in team names break the invitation email',
+  'Billing page shows the wrong currency for EU accounts',
+  'Two-factor authentication QR code does not render',
+  'Autosave overwrites edits made on another device',
+  'Calendar sync duplicates recurring events',
+  'PDF invoices render blank in Safari',
+  'App freezes when uploading more than 20 images',
+  'Mentions are not highlighted in comment threads',
+  'Timezone offset is wrong during daylight saving time',
+  'Archived projects still send email digests',
+  'Table sorting resets after a page refresh',
+  'Video call audio cuts out after screen sharing',
+  'Offline mode loses drafts created without a connection'
+];
+
+@Component({
+  selector: 'app-duplicate-detector-demo',
+  templateUrl: './duplicate-detector-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class DuplicateDetectorDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'duplicate-detector')!;
+
+  issues: TrackedIssue[] = [];
+  draftTitle = '';
+  threshold = 0.6;
+
+  sampleDrafts = [
+    'Can\'t log in with my Google account — server error',
+    'Exported CSV file is missing some of the lines',
+    'The password reset link email is not coming through',
+    'Meeting invites show the wrong time after clocks changed'
+  ];
+
+  isIndexing = false;
+  indexReady = false;
+  isChecking = false;
+  hasChecked = false;
+  checkLatencyMs: number | null = null;
+  duplicates: DuplicateMatch[] = [];
+  submittedMessage = '';
+
+  private draft$ = new Subject<string>();
+  private checkToken = 0;
+  private nextIssueId = 1;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+
+    this.subscriptions.push(
+      this.draft$.pipe(debounceTime(300)).subscribe(() => this.checkForDuplicates())
+    );
+
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    if (this.embedderStatus === 'available') {
+      await this.buildIndex();
+    }
+  }
+
+  async buildIndex() {
+    if (this.isIndexing || this.indexReady) return;
+    this.isIndexing = true;
+    this.errorMessage = '';
+    try {
+      const vectors = await this.semanticEmbedder.embed(EXISTING_ISSUES, 'similarity', this.onDownloadProgress);
+      this.issues = EXISTING_ISSUES.map((title, i) => ({
+        id: this.nextIssueId++,
+        title,
+        vector: vectors[i]
+      }));
+      this.indexReady = true;
+      if (this.draftTitle.trim()) this.checkForDuplicates();
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to embed the existing issues.';
+    } finally {
+      this.isIndexing = false;
+    }
+  }
+
+  onDraftChanged() {
+    this.submittedMessage = '';
+    this.draft$.next(this.draftTitle);
+  }
+
+  onThresholdChanged() {
+    if (this.hasChecked) this.checkForDuplicates();
+  }
+
+  useSample(sample: string) {
+    this.draftTitle = sample;
+    this.checkForDuplicates();
+  }
+
+  async checkForDuplicates() {
+    const title = this.draftTitle.trim();
+    const token = ++this.checkToken;
+
+    if (!title || !this.indexReady) {
+      this.duplicates = [];
+      this.hasChecked = false;
+      return;
+    }
+
+    this.isChecking = true;
+    try {
+      const start = performance.now();
+      const draftVector = await this.semanticEmbedder.embedOne(title, 'similarity');
+      const latency = Math.round(performance.now() - start);
+      if (token !== this.checkToken) return;
+
+      this.checkLatencyMs = latency;
+      this.duplicates = this.issues
+        .map(issue => ({ issue, score: this.semanticEmbedder.cosineSimilarity(draftVector, issue.vector) }))
+        .filter(match => match.score >= this.threshold)
+        .sort((a, b) => b.score - a.score)
+        .slice(0, 5);
+      this.hasChecked = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Duplicate check failed.';
+    } finally {
+      if (token === this.checkToken) this.isChecking = false;
+    }
+  }
+
+  async submitIssue() {
+    const title = this.draftTitle.trim();
+    if (!title || !this.indexReady) return;
+
+    try {
+      const vector = await this.semanticEmbedder.embedOne(title, 'similarity');
+      this.issues.forEach(i => (i.isNew = false));
+      const issue: TrackedIssue = { id: this.nextIssueId++, title, vector, isNew: true };
+      this.issues.unshift(issue);
+      this.submittedMessage = `Issue #${issue.id} filed. It is now part of the index — try typing it again!`;
+      this.draftTitle = '';
+      this.duplicates = [];
+      this.hasChecked = false;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to file the issue.';
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const draft = this.draftTitle.trim() || this.sampleDrafts[0];
+    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+
+// Embed the ${this.issues.length || EXISTING_ISSUES.length} existing issue titles once (single batched call)
+const { embeddings } = await embedder.embed(existingIssueTitles);
+
+// As the reporter types, check the draft against every known issue
+const draft = ${JSON.stringify(draft)};
+const { embeddings: [d] } = await embedder.embed(draft);
+
+const duplicates = embeddings
+  .map((e, i) => ({
+    title: existingIssueTitles[i],
+    score: cosineSimilarity(d.values, e.values)
+  }))
+  .filter(match => match.score >= ${this.threshold.toFixed(2)}) // similarity threshold
+  .sort((a, b) => b.score - a.score);
+
+if (duplicates.length > 0) {
+  showWarning("Possible duplicates:", duplicates);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/duplicate-detector-demo.component.ts
@@ -95,7 +95,7 @@ export class DuplicateDetectorDemoComponent extends BaseEmbedderDemoComponent im
     this.isIndexing = true;
     this.errorMessage = '';
     try {
-      const vectors = await this.semanticEmbedder.embed(EXISTING_ISSUES, 'similarity', this.onDownloadProgress);
+      const vectors = await this.semanticEmbedder.embed(EXISTING_ISSUES, 'semantic-similarity', this.onDownloadProgress);
       this.issues = EXISTING_ISSUES.map((title, i) => ({
         id: this.nextIssueId++,
         title,
@@ -137,7 +137,7 @@ export class DuplicateDetectorDemoComponent extends BaseEmbedderDemoComponent im
     this.isChecking = true;
     try {
       const start = performance.now();
-      const draftVector = await this.semanticEmbedder.embedOne(title, 'similarity');
+      const draftVector = await this.semanticEmbedder.embedOne(title, 'semantic-similarity');
       const latency = Math.round(performance.now() - start);
       if (token !== this.checkToken) return;
 
@@ -160,7 +160,7 @@ export class DuplicateDetectorDemoComponent extends BaseEmbedderDemoComponent im
     if (!title || !this.indexReady) return;
 
     try {
-      const vector = await this.semanticEmbedder.embedOne(title, 'similarity');
+      const vector = await this.semanticEmbedder.embedOne(title, 'semantic-similarity');
       this.issues.forEach(i => (i.isNew = false));
       const issue: TrackedIssue = { id: this.nextIssueId++, title, vector, isNew: true };
       this.issues.unshift(issue);
@@ -175,7 +175,7 @@ export class DuplicateDetectorDemoComponent extends BaseEmbedderDemoComponent im
 
   get dynamicCodeSnippet(): string {
     const draft = this.draftTitle.trim() || this.sampleDrafts[0];
-    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    return `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 
 // Embed the ${this.issues.length || EXISTING_ISSUES.length} existing issue titles once (single batched call)
 const { embeddings } = await embedder.embed(existingIssueTitles);

--- a/webapp/src/app/pages/demos/features/semantic-cache-demo.component.html
+++ b/webapp/src/app/pages/demos/features/semantic-cache-demo.component.html
@@ -1,0 +1,192 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [showPromptApi]="true"
+      [promptApiStatus]="languageModelAvailability"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Scoreboard -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Cache Hits</div>
+        <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{{ hits }}</div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Cache Misses</div>
+        <div class="text-2xl font-bold text-slate-700 dark:text-slate-300">{{ misses }}</div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Hit vs Generation</div>
+        <div class="text-2xl font-bold text-slate-800 dark:text-slate-200">
+          {{ averageHitMs !== null ? averageHitMs + 'ms' : 'N/A' }}
+          <span class="text-sm font-medium text-slate-400 dark:text-slate-500">vs {{ averageGenerationMs !== null ? averageGenerationMs + 'ms' : 'N/A' }}</span>
+        </div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Est. Tokens Saved</div>
+        <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">≈{{ tokensSaved }}</div>
+      </div>
+    </div>
+
+    <div class="flex flex-col lg:flex-row gap-6">
+
+      <!-- Ask panel -->
+      <div class="lg:flex-[3] flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5">
+          <div class="flex gap-3">
+            <input
+              type="text"
+              class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40 text-sm"
+              [(ngModel)]="question"
+              (keydown.enter)="ask()"
+              placeholder="Ask a question..." />
+            @if (state === 'Inferencing') {
+              <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                      (click)="onCancel()">
+                <i class="bi bi-stop-fill"></i> Stop
+              </button>
+            } @else {
+              <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                      (click)="ask()"
+                      [disabled]="!canAsk || !question.trim()">
+                <i class="bi bi-send"></i> Ask
+              </button>
+            }
+          </div>
+
+          <div class="mt-3 flex flex-col gap-1.5">
+            @for (pair of samplePairs; track pair.first) {
+              <div class="flex flex-wrap items-center gap-2 text-xs">
+                <button class="px-3 py-1.5 rounded-full font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                        (click)="useSample(pair.first)">
+                  1. {{ pair.first }}
+                </button>
+                <i class="bi bi-arrow-right text-slate-300 dark:text-zinc-600"></i>
+                <button class="px-3 py-1.5 rounded-full font-medium bg-indigo-50 hover:bg-indigo-100 dark:bg-indigo-900/20 dark:hover:bg-indigo-900/40 text-indigo-600 dark:text-indigo-400 border border-indigo-200 dark:border-indigo-900/40 transition-colors"
+                        (click)="useSample(pair.paraphrase)">
+                  2. {{ pair.paraphrase }}
+                </button>
+              </div>
+            }
+            <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-1">Ask 1 first (generates), then 2 — the paraphrase hits the cache instantly.</p>
+          </div>
+        </div>
+
+        <!-- Outcome banner -->
+        @if (lastOutcome) {
+          @if (lastOutcome.type === 'hit') {
+            <div class="bg-emerald-50 border-2 border-emerald-300 dark:bg-emerald-900/15 dark:border-emerald-700 rounded-2xl p-4">
+              <div class="flex items-center gap-2 text-emerald-700 dark:text-emerald-300 font-bold text-sm uppercase tracking-wider">
+                <i class="bi bi-lightning-charge-fill"></i> Cache Hit — {{ lastOutcome.timeMs }}ms, zero LLM tokens
+              </div>
+              <p class="text-xs text-emerald-800 dark:text-emerald-200/80 m-0 mt-1.5">
+                Matched "{{ lastOutcome.matchedQuestion }}" with similarity {{ lastOutcome.score?.toFixed(3) }} — saved ≈{{ lastOutcome.tokensSaved }} tokens of generation.
+              </p>
+            </div>
+          } @else {
+            <div class="bg-slate-100 border border-slate-200 dark:bg-zinc-800/70 dark:border-zinc-700 rounded-2xl p-4">
+              <div class="flex items-center gap-2 text-slate-600 dark:text-slate-300 font-bold text-sm uppercase tracking-wider">
+                <i class="bi bi-hourglass-split"></i> Cache Miss — generated in {{ lastOutcome.timeMs }}ms
+              </div>
+              <p class="text-xs text-slate-500 dark:text-slate-400 m-0 mt-1.5">
+                The answer is now cached under this question's embedding. Ask a paraphrase to see the difference.
+              </p>
+            </div>
+          }
+        }
+
+        <!-- Answer -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col flex-grow min-h-[140px] overflow-hidden">
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-chat-square-dots text-indigo-500"></i> Answer
+            </span>
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+          </div>
+          <div class="p-5 text-slate-800 dark:text-slate-200 leading-relaxed text-[15px] whitespace-pre-wrap flex-grow">
+            @if (answer) {
+              {{ answer }}
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">Ask a question to see caching in action...</span>
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- Cache contents -->
+      <div class="lg:flex-[2] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col max-h-[600px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center gap-3">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-hdd-stack text-indigo-500"></i> Semantic Cache
+          </span>
+          <div class="flex items-center gap-2">
+            <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ cache.length }} entries</span>
+            @if (cache.length > 0) {
+              <button class="text-xs font-medium text-slate-400 hover:text-red-500 dark:text-slate-500 dark:hover:text-red-400 bg-transparent border-none transition-colors"
+                      (click)="clearCache()">
+                Clear
+              </button>
+            }
+          </div>
+        </div>
+
+        <!-- Threshold -->
+        <div class="px-5 py-3 border-b border-slate-100 dark:border-zinc-700/50 flex items-center gap-3">
+          <span class="text-[11px] font-semibold text-slate-500 dark:text-slate-400 whitespace-nowrap">Hit threshold</span>
+          <input type="range" min="0.7" max="0.95" step="0.01" class="flex-grow accent-indigo-600" [(ngModel)]="threshold" />
+          <span class="text-xs font-mono font-bold text-indigo-600 dark:text-indigo-400 w-10">{{ threshold.toFixed(2) }}</span>
+        </div>
+
+        <div class="overflow-y-auto flex-grow p-3 flex flex-col gap-2">
+          @if (cache.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light p-6">Every generated answer is stored here under its question's embedding.</p>
+          }
+          @for (entry of cache; track entry.question) {
+            <div class="rounded-xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-3 cursor-pointer hover:border-indigo-300 dark:hover:border-indigo-700 transition-colors"
+                 (click)="entry.expanded = !entry.expanded">
+              <div class="flex items-start gap-2">
+                <i class="bi {{ entry.expanded ? 'bi-chevron-down' : 'bi-chevron-right' }} text-[10px] text-slate-400 mt-1"></i>
+                <div class="flex-grow min-w-0">
+                  <p class="text-xs font-semibold text-slate-700 dark:text-slate-300 m-0 leading-snug">{{ entry.question }}</p>
+                  <div class="flex items-center gap-2 mt-1">
+                    <span class="text-[10px] text-slate-400 dark:text-slate-500">generated in {{ entry.generationTimeMs }}ms</span>
+                    @if (entry.lastScore !== null) {
+                      <span class="text-[10px] font-mono px-1.5 py-0.5 rounded"
+                            [ngClass]="entry.lastScore >= threshold ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400' : 'bg-slate-200/70 dark:bg-zinc-800 text-slate-500 dark:text-slate-400'">
+                        last query: {{ entry.lastScore.toFixed(3) }}
+                      </span>
+                    }
+                  </div>
+                  @if (entry.expanded) {
+                    <p class="text-[11px] text-slate-500 dark:text-slate-400 m-0 mt-2 leading-relaxed whitespace-pre-wrap">{{ entry.answer }}</p>
+                  }
+                </div>
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/semantic-cache-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-cache-demo.component.ts
@@ -107,7 +107,7 @@ export class SemanticCacheDemoComponent extends BaseEmbedderDemoComponent implem
 
     try {
       // 1. Embed the question and look for a semantically equivalent cached one
-      const queryVector = await this.semanticEmbedder.embedOne(q, 'similarity');
+      const queryVector = await this.semanticEmbedder.embedOne(q, 'semantic-similarity');
 
       let best: { entry: CacheEntry; score: number } | null = null;
       for (const entry of this.cache) {
@@ -174,7 +174,7 @@ export class SemanticCacheDemoComponent extends BaseEmbedderDemoComponent implem
 
   get dynamicCodeSnippet(): string {
     const q = this.question.trim() || 'Which city is the capital of France?';
-    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    return `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 const cache = []; // { vector, question, answer }
 
 async function ask(question) {

--- a/webapp/src/app/pages/demos/features/semantic-cache-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-cache-demo.component.ts
@@ -1,0 +1,202 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+interface CacheEntry {
+  question: string;
+  answer: string;
+  vector: Float32Array;
+  generationTimeMs: number;
+  lastScore: number | null;
+  expanded: boolean;
+}
+
+interface AskOutcome {
+  type: 'hit' | 'miss';
+  timeMs: number;
+  matchedQuestion?: string;
+  score?: number;
+  tokensSaved?: number;
+}
+
+@Component({
+  selector: 'app-semantic-cache-demo',
+  templateUrl: './semantic-cache-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SemanticCacheDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'semantic-cache')!;
+
+  question = '';
+  answer = '';
+  threshold = 0.85;
+
+  cache: CacheEntry[] = [];
+  lastOutcome: AskOutcome | null = null;
+
+  hits = 0;
+  misses = 0;
+  totalGenerationMs = 0;
+  totalHitMs = 0;
+  tokensSaved = 0;
+
+  /** Pairs: ask the first, then its paraphrase to land a cache hit. */
+  samplePairs: { first: string; paraphrase: string }[] = [
+    { first: 'What is the capital of France?', paraphrase: 'Which city is the capital of France?' },
+    { first: 'Why is the sky blue?', paraphrase: 'What makes the sky look blue?' },
+    { first: 'How does photosynthesis work?', paraphrase: 'How do plants make their own food?' }
+  ];
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability();
+  }
+
+  get canAsk(): boolean {
+    return this.state !== PromptInputStateEnum.Inferencing
+      && this.embedderUsable
+      && this.languageModelAvailability !== 'unavailable';
+  }
+
+  get averageGenerationMs(): number | null {
+    return this.misses > 0 ? Math.round(this.totalGenerationMs / this.misses) : null;
+  }
+
+  get averageHitMs(): number | null {
+    return this.hits > 0 ? Math.round(this.totalHitMs / this.hits) : null;
+  }
+
+  useSample(text: string) {
+    this.question = text;
+    this.ask();
+  }
+
+  clearCache() {
+    this.cache = [];
+    this.lastOutcome = null;
+    this.answer = '';
+    this.hits = 0;
+    this.misses = 0;
+    this.totalGenerationMs = 0;
+    this.totalHitMs = 0;
+    this.tokensSaved = 0;
+  }
+
+  async ask() {
+    const q = this.question.trim();
+    if (!q || !this.canAsk) return;
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.answer = '';
+    this.errorMessage = '';
+    this.lastOutcome = null;
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      // 1. Embed the question and look for a semantically equivalent cached one
+      const queryVector = await this.semanticEmbedder.embedOne(q, 'similarity');
+
+      let best: { entry: CacheEntry; score: number } | null = null;
+      for (const entry of this.cache) {
+        const score = this.semanticEmbedder.cosineSimilarity(queryVector, entry.vector);
+        entry.lastScore = score;
+        if (!best || score > best.score) best = { entry, score };
+      }
+
+      if (best && best.score >= this.threshold) {
+        // 2a. Cache HIT — serve the stored answer instantly, no LLM call
+        const timeMs = Math.round(performance.now() - startTime);
+        this.answer = best.entry.answer;
+        const saved = Math.max(0, Math.round(best.entry.answer.length / 4));
+        this.lastOutcome = {
+          type: 'hit',
+          timeMs,
+          matchedQuestion: best.entry.question,
+          score: best.score,
+          tokensSaved: saved
+        };
+        this.hits++;
+        this.totalHitMs += timeMs;
+        this.tokensSaved += saved;
+        this.ttft = timeMs;
+        this.totalTime = timeMs;
+      } else {
+        // 2b. Cache MISS — generate with the Prompt API and store the result
+        const session = await LanguageModel.create({
+          systemPrompt: 'Answer the question accurately in 2 to 3 concise sentences.'
+        });
+        const stream = session.promptStreaming(q, { signal: this.abortController.signal });
+        for await (const chunk of stream) {
+          if (!firstTokenTime) {
+            firstTokenTime = performance.now();
+            this.ttft = Math.round(firstTokenTime - startTime);
+          }
+          this.answer += chunk;
+        }
+        session.destroy?.();
+
+        const timeMs = Math.round(performance.now() - startTime);
+        this.totalTime = timeMs;
+        this.lastOutcome = { type: 'miss', timeMs };
+        this.misses++;
+        this.totalGenerationMs += timeMs;
+        this.cache.unshift({
+          question: q,
+          answer: this.answer,
+          vector: queryVector,
+          generationTimeMs: timeMs,
+          lastScore: null,
+          expanded: false
+        });
+      }
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Something went wrong while answering.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const q = this.question.trim() || 'Which city is the capital of France?';
+    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+const cache = []; // { vector, question, answer }
+
+async function ask(question) {
+  const { embeddings: [q] } = await embedder.embed(question);
+
+  // Cache hit: a semantically equivalent question was already answered
+  const best = cache
+    .map(entry => ({ entry, score: cosineSimilarity(q.values, entry.vector) }))
+    .sort((a, b) => b.score - a.score)[0];
+
+  if (best && best.score >= ${this.threshold.toFixed(2)}) {
+    return best.entry.answer; // instant — no LLM call, no tokens
+  }
+
+  // Cache miss: generate with the on-device LLM, then store for next time
+  const session = await LanguageModel.create();
+  const answer = await session.prompt(question);
+  cache.push({ vector: q.values, question, answer });
+  return answer;
+}
+
+await ask("What is the capital of France?");   // miss → generates
+await ask(${JSON.stringify(q)}); // hit → instant`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/semantic-search-demo.component.html
+++ b/webapp/src/app/pages/demos/features/semantic-search-demo.component.html
@@ -1,0 +1,146 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    <!-- Index state -->
+    @if (!indexReady && embedderStatus !== 'unavailable') {
+      <div class="mb-4 bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/10 dark:border-indigo-900/30 rounded-2xl p-4 flex items-center justify-between gap-4">
+        <div class="text-sm text-indigo-900 dark:text-indigo-200 flex items-center gap-2">
+          @if (isIndexing) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Embedding {{ corpus.length }} help center entries on-device...
+          } @else {
+            <i class="bi bi-database"></i> The search index embeds all {{ corpus.length }} help center entries locally.
+          }
+        </div>
+        @if (!isIndexing) {
+          <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none whitespace-nowrap"
+                  (click)="buildIndex()">
+            Build Index
+          </button>
+        }
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Search bar -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="relative">
+        <i class="bi bi-search absolute left-5 top-1/2 -translate-y-1/2 text-slate-400 text-lg"></i>
+        <input
+          type="text"
+          class="w-full bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full pl-12 pr-40 py-3.5 text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40 text-base"
+          [(ngModel)]="query"
+          (ngModelChange)="onQueryChanged($event)"
+          placeholder="Search the help center in your own words..." />
+        @if (indexReady && embedLatencyMs !== null && hasSearched) {
+          <span class="absolute right-4 top-1/2 -translate-y-1/2 text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40 whitespace-nowrap">
+            <i class="bi bi-cpu"></i> embedded in {{ embedLatencyMs }}ms
+          </span>
+        }
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        <span class="text-xs text-slate-400 dark:text-slate-500 self-center mr-1">Try a query with no matching keywords:</span>
+        @for (sample of sampleQueries; track sample) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                  (click)="useSample(sample)">
+            "{{ sample }}"
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Results: side by side -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+
+      <!-- Keyword results -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex items-center gap-2">
+          <i class="bi bi-type text-slate-400"></i>
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider">Keyword Search</span>
+        </div>
+        <div class="p-4 flex flex-col gap-2 flex-grow min-h-[220px]">
+          @if (!hasSearched) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light">Matches only entries sharing literal words with the query.</p>
+          } @else if (keywordResults.length === 0) {
+            <div class="m-auto text-center">
+              <i class="bi bi-emoji-neutral text-3xl text-slate-300 dark:text-zinc-600"></i>
+              <p class="text-sm text-slate-500 dark:text-slate-400 mt-2 font-medium">No results — no shared keywords.</p>
+            </div>
+          } @else {
+            @for (result of keywordResults; track result.text) {
+              <div class="rounded-xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-3.5">
+                <p class="text-sm text-slate-700 dark:text-slate-300 m-0 font-medium">{{ result.text }}</p>
+                <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-1">
+                  {{ result.score }} matching {{ result.score === 1 ? 'word' : 'words' }}: {{ result.matchedWords?.join(', ') }}
+                </p>
+              </div>
+            }
+          }
+        </div>
+      </div>
+
+      <!-- Semantic results -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border-2 border-indigo-200 dark:border-indigo-900/50 overflow-hidden flex flex-col">
+        <div class="px-5 py-4 border-b border-indigo-100 dark:border-indigo-900/30 bg-indigo-50/50 dark:bg-indigo-900/10 flex items-center justify-between">
+          <div class="flex items-center gap-2">
+            <i class="bi bi-stars text-indigo-500"></i>
+            <span class="text-sm font-bold text-indigo-700 dark:text-indigo-300 uppercase tracking-wider">Semantic Search</span>
+          </div>
+          @if (isSearching) {
+            <i class="bi bi-arrow-repeat animate-spin text-indigo-400"></i>
+          }
+        </div>
+        <div class="p-4 flex flex-col gap-2 flex-grow min-h-[220px]">
+          @if (!indexReady) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light">Build the index to enable semantic search.</p>
+          } @else if (!hasSearched) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light">Matches entries by meaning, ranked by cosine similarity.</p>
+          } @else if (semanticResults.length === 0) {
+            <p class="text-sm text-slate-500 dark:text-slate-400 m-auto text-center">Type a query to search.</p>
+          } @else {
+            @for (result of semanticResults; track result.text) {
+              <div class="rounded-xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-3.5">
+                <div class="flex items-start justify-between gap-3">
+                  <p class="text-sm text-slate-700 dark:text-slate-300 m-0 font-medium">{{ result.text }}</p>
+                  @if (result.keywordOverlap === 0) {
+                    <span class="shrink-0 text-[10px] font-bold px-2 py-0.5 rounded-md bg-indigo-100 dark:bg-indigo-900/40 text-indigo-700 dark:text-indigo-300 whitespace-nowrap" title="This result shares no words with your query — only meaning.">
+                      0 shared words
+                    </span>
+                  }
+                </div>
+                <div class="flex items-center gap-2 mt-2">
+                  <div class="flex-grow h-1.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+                    <div class="h-full bg-indigo-500 rounded-full" [style.width.%]="result.score * 100"></div>
+                  </div>
+                  <span class="text-[11px] font-mono font-semibold text-slate-500 dark:text-slate-400">{{ result.score.toFixed(3) }}</span>
+                </div>
+              </div>
+            }
+          }
+        </div>
+        @if (indexReady && indexTimeMs !== null) {
+          <div class="px-5 py-2.5 border-t border-indigo-100 dark:border-indigo-900/30 text-[11px] text-slate-400 dark:text-slate-500">
+            {{ corpus.length }} entries embedded locally in {{ indexTimeMs }}ms
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/semantic-search-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-search-demo.component.ts
@@ -136,7 +136,7 @@ export class SemanticSearchDemoComponent extends BaseEmbedderDemoComponent imple
     this.errorMessage = '';
     const start = performance.now();
     try {
-      this.corpusVectors = await this.semanticEmbedder.embed(this.corpus, 'retrieval', this.onDownloadProgress);
+      this.corpusVectors = await this.semanticEmbedder.embed(this.corpus, 'retrieval-document', this.onDownloadProgress);
       this.indexTimeMs = Math.round(performance.now() - start);
       this.indexReady = true;
       if (this.query.trim()) this.search(this.query);
@@ -192,7 +192,7 @@ export class SemanticSearchDemoComponent extends BaseEmbedderDemoComponent imple
     this.isSearching = true;
     try {
       const start = performance.now();
-      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval');
+      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval-query');
       const latency = Math.round(performance.now() - start);
       if (token !== this.searchToken) return; // a newer query superseded this one
 
@@ -214,13 +214,13 @@ export class SemanticSearchDemoComponent extends BaseEmbedderDemoComponent imple
 
   get dynamicCodeSnippet(): string {
     const q = this.query.trim() || 'my parcel never showed up';
-    return `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
-
-// Index the ${this.corpus.length} help center entries once, in a single batched call
-const { embeddings } = await embedder.embed(helpCenterEntries);
+    return `// Index the ${this.corpus.length} help center entries once, in a single batched call
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+const { embeddings } = await docEmbedder.embed(helpCenterEntries);
 
 // On every keystroke: embed the query on-device and rank by cosine similarity
-const result = await embedder.embed(${JSON.stringify(q)});
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const result = await queryEmbedder.embed(${JSON.stringify(q)});
 const queryVector = result.embeddings[0].values;
 
 const topResults = embeddings

--- a/webapp/src/app/pages/demos/features/semantic-search-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-search-demo.component.ts
@@ -1,0 +1,237 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Subject, debounceTime } from 'rxjs';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+interface SearchResult {
+  text: string;
+  score: number;
+  matchedWords?: string[];
+  keywordOverlap?: number;
+}
+
+const HELP_CENTER: string[] = [
+  // Orders & shipping
+  'How do I track my order?',
+  'Where is my package right now?',
+  'My delivery is late, what should I do?',
+  'Can I change my shipping address after ordering?',
+  'Do you ship internationally?',
+  'How much does express shipping cost?',
+  'What happens if nobody is home for the delivery?',
+  'My order arrived damaged, how do I report it?',
+  // Returns & refunds
+  'How do I return an item?',
+  'What is your refund policy?',
+  'How long does a refund take to appear?',
+  'Can I exchange an item for a different size?',
+  'Do I have to pay for return shipping?',
+  'My return was rejected, what are my options?',
+  'Can I return a product without the original box?',
+  'How do I print a return label?',
+  // Billing & payments
+  'Why was my card charged twice?',
+  'Which payment methods do you accept?',
+  'How do I update my credit card details?',
+  'Can I get an invoice for my purchase?',
+  'Why did my payment fail?',
+  'How do I redeem a gift card or promo code?',
+  'When will my subscription renew?',
+  'How do I cancel my subscription?',
+  // Account
+  'How do I reset my password?',
+  'I cannot log into my account, what should I do?',
+  'How do I change my email address?',
+  'How do I delete my account permanently?',
+  'Why am I not receiving your emails?',
+  'How do I enable two-factor authentication?',
+  'Can I merge two accounts into one?',
+  'How do I update my notification preferences?',
+  // Product
+  'Is this product available in other colors?',
+  'When will an out-of-stock item be available again?',
+  'Where can I find the product size guide?',
+  'Does the product come with a warranty?',
+  'How do I register my product for warranty coverage?',
+  'Are replacement parts available for purchase?',
+  'Is there a user manual I can download?',
+  'What is the difference between the standard and pro models?',
+  // Security & privacy
+  'How is my personal data used?',
+  'How do I report a suspicious email pretending to be you?',
+  'Is my payment information stored securely?',
+  'How do I request a copy of my data?',
+  'Someone used my account without permission, what now?',
+  'How do I sign out of all devices at once?',
+  'Do you sell my data to third parties?',
+  'How do I report a security vulnerability?'
+];
+
+const STOP_WORDS = new Set(['the', 'a', 'an', 'is', 'are', 'do', 'does', 'i', 'my', 'me', 'to', 'of', 'in', 'for', 'on', 'it', 'what', 'how', 'can', 'and', 'or', 'with', 'was', 'be']);
+
+@Component({
+  selector: 'app-semantic-search-demo',
+  templateUrl: './semantic-search-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SemanticSearchDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'semantic-search')!;
+
+  corpus = HELP_CENTER;
+  corpusVectors: Float32Array[] = [];
+
+  query = '';
+  sampleQueries = [
+    'my parcel never showed up',
+    'the app charged me two times',
+    'I want my money back',
+    'close my account forever',
+    'phishing message in my inbox'
+  ];
+
+  isIndexing = false;
+  indexReady = false;
+  indexTimeMs: number | null = null;
+
+  isSearching = false;
+  embedLatencyMs: number | null = null;
+  keywordResults: SearchResult[] = [];
+  semanticResults: SearchResult[] = [];
+  hasSearched = false;
+
+  private query$ = new Subject<string>();
+  private searchToken = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+
+    this.subscriptions.push(
+      this.query$.pipe(debounceTime(250)).subscribe(q => this.search(q))
+    );
+
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+
+    // Build the index automatically only if no download is needed.
+    if (this.embedderStatus === 'available') {
+      await this.buildIndex();
+    }
+  }
+
+  onQueryChanged(value: string) {
+    this.query$.next(value);
+  }
+
+  useSample(sample: string) {
+    this.query = sample;
+    this.search(sample);
+  }
+
+  async buildIndex() {
+    if (this.isIndexing || this.indexReady) return;
+    this.isIndexing = true;
+    this.errorMessage = '';
+    const start = performance.now();
+    try {
+      this.corpusVectors = await this.semanticEmbedder.embed(this.corpus, 'retrieval', this.onDownloadProgress);
+      this.indexTimeMs = Math.round(performance.now() - start);
+      this.indexReady = true;
+      if (this.query.trim()) this.search(this.query);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to build the search index.';
+    } finally {
+      this.isIndexing = false;
+    }
+  }
+
+  private tokenize(text: string): string[] {
+    return text.toLowerCase().split(/[^a-z0-9']+/).filter(t => t.length > 1 && !STOP_WORDS.has(t));
+  }
+
+  private keywordSearch(query: string): SearchResult[] {
+    const queryTokens = [...new Set(this.tokenize(query))];
+    if (queryTokens.length === 0) return [];
+
+    return this.corpus
+      .map(text => {
+        const entryTokens = new Set(this.tokenize(text));
+        const matchedWords = queryTokens.filter(t => entryTokens.has(t));
+        return { text, score: matchedWords.length, matchedWords };
+      })
+      .filter(r => r.score > 0)
+      .sort((a, b) => b.score - a.score)
+      .slice(0, 5);
+  }
+
+  private keywordOverlap(query: string, text: string): number {
+    const queryTokens = new Set(this.tokenize(query));
+    return this.tokenize(text).filter(t => queryTokens.has(t)).length;
+  }
+
+  async search(rawQuery: string) {
+    const query = rawQuery.trim();
+    const token = ++this.searchToken;
+
+    if (!query) {
+      this.keywordResults = [];
+      this.semanticResults = [];
+      this.hasSearched = false;
+      return;
+    }
+
+    this.keywordResults = this.keywordSearch(query);
+
+    if (!this.indexReady) {
+      this.hasSearched = true;
+      return;
+    }
+
+    this.isSearching = true;
+    try {
+      const start = performance.now();
+      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval');
+      const latency = Math.round(performance.now() - start);
+      if (token !== this.searchToken) return; // a newer query superseded this one
+
+      this.embedLatencyMs = latency;
+      this.semanticResults = this.semanticEmbedder
+        .topK(queryVector, this.corpusVectors, 5)
+        .map(r => ({
+          text: this.corpus[r.index],
+          score: r.score,
+          keywordOverlap: this.keywordOverlap(query, this.corpus[r.index])
+        }));
+      this.hasSearched = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Search failed.';
+    } finally {
+      if (token === this.searchToken) this.isSearching = false;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const q = this.query.trim() || 'my parcel never showed up';
+    return `const embedder = await SemanticEmbedder.create({ taskType: "retrieval" });
+
+// Index the ${this.corpus.length} help center entries once, in a single batched call
+const { embeddings } = await embedder.embed(helpCenterEntries);
+
+// On every keystroke: embed the query on-device and rank by cosine similarity
+const result = await embedder.embed(${JSON.stringify(q)});
+const queryVector = result.embeddings[0].values;
+
+const topResults = embeddings
+  .map((e, i) => ({
+    entry: helpCenterEntries[i],
+    score: cosineSimilarity(queryVector, e.values)
+  }))
+  .sort((a, b) => b.score - a.score)
+  .slice(0, 5);
+
+// Keyword search finds nothing for this query —
+// semantic search matches "${this.semanticResults[0]?.text ?? 'Where is my package right now?'}"`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.html
+++ b/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.html
@@ -1,0 +1,163 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (!gameReady && embedderStatus !== 'unavailable' && !isPreparing) {
+      <div class="mb-4 bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/10 dark:border-indigo-900/30 rounded-2xl p-4 flex items-center justify-between gap-4">
+        <span class="text-sm text-indigo-900 dark:text-indigo-200">
+          <i class="bi bi-controller"></i> A secret word is picked and embedded locally. Guess it by getting semantically closer.
+        </span>
+        <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none whitespace-nowrap"
+                (click)="newGame()">
+          Start Game
+        </button>
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Game board -->
+      <div class="lg:flex-[3] w-full flex flex-col gap-4">
+
+        <!-- Win / reveal banner -->
+        @if (won) {
+          <div class="bg-emerald-50 border-2 border-emerald-300 dark:bg-emerald-900/15 dark:border-emerald-700 rounded-3xl p-6 text-center">
+            <div class="text-4xl mb-2">🎉</div>
+            <div class="text-xl font-bold text-emerald-700 dark:text-emerald-300">
+              You found "{{ secretWord }}" in {{ guessCount }} {{ guessCount === 1 ? 'guess' : 'guesses' }}!
+            </div>
+            <button class="mt-4 px-6 py-2.5 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                    (click)="newGame()">
+              <i class="bi bi-arrow-repeat"></i> Play Again
+            </button>
+          </div>
+        } @else if (gaveUp) {
+          <div class="bg-slate-100 border border-slate-200 dark:bg-zinc-800/70 dark:border-zinc-700 rounded-3xl p-6 text-center">
+            <div class="text-lg font-bold text-slate-700 dark:text-slate-300">
+              The word was "<span class="text-indigo-600 dark:text-indigo-400">{{ secretWord }}</span>"
+            </div>
+            <button class="mt-4 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                    (click)="newGame()">
+              <i class="bi bi-arrow-repeat"></i> New Word
+            </button>
+          </div>
+        }
+
+        <!-- Guess input -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5">
+          <div class="flex gap-3">
+            <input
+              type="text"
+              class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-lg text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40"
+              [(ngModel)]="guessInput"
+              (keydown.enter)="submitGuess()"
+              [disabled]="!gameReady || isOver"
+              placeholder="Guess a word..." />
+            <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                    (click)="submitGuess()"
+                    [disabled]="!gameReady || isOver || !guessInput.trim() || isGuessing">
+              @if (isGuessing) {
+                <i class="bi bi-arrow-repeat animate-spin"></i>
+              } @else {
+                <i class="bi bi-thermometer-half"></i>
+              }
+              Guess
+            </button>
+          </div>
+          <div class="flex items-center justify-between mt-3 flex-wrap gap-2">
+            <div class="flex items-center gap-3">
+              @if (inputError) {
+                <span class="text-xs text-red-500">{{ inputError }}</span>
+              } @else if (guessLatencyMs !== null) {
+                <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                  <i class="bi bi-cpu"></i> scored on-device in {{ guessLatencyMs }}ms
+                </span>
+              } @else if (gameReady) {
+                <span class="text-xs text-slate-400 dark:text-slate-500">The secret word is embedded — guesses are scored by cosine similarity.</span>
+              }
+            </div>
+            <div class="flex items-center gap-3">
+              <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">{{ guessCount }} {{ guessCount === 1 ? 'guess' : 'guesses' }}</span>
+              @if (gameReady && !isOver && guessCount > 0) {
+                <button class="text-xs font-medium text-slate-400 hover:text-red-500 dark:text-slate-500 dark:hover:text-red-400 bg-transparent border-none transition-colors"
+                        (click)="giveUp()">
+                  Give up
+                </button>
+              }
+            </div>
+          </div>
+        </div>
+
+        <!-- Guess history -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[220px]">
+          <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+            <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-list-ol text-indigo-500"></i> Guesses, Closest First
+            </span>
+          </div>
+          <div class="p-4 flex flex-col gap-2 flex-grow">
+            @if (guesses.length === 0) {
+              <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light">
+                {{ gameReady ? 'Make your first guess — any English word works.' : 'Start a game to begin guessing.' }}
+              </p>
+            }
+            @for (guess of sortedGuesses; track guess.word) {
+              @let temp = temperature(guess.score);
+              <div class="flex items-center gap-3 px-4 py-2.5 rounded-xl border transition-all"
+                   [ngClass]="guess.isLatest ? 'border-indigo-300 dark:border-indigo-700 bg-indigo-50/50 dark:bg-indigo-900/10' : 'border-slate-200 dark:border-zinc-700 bg-slate-50/50 dark:bg-[#161616]/50'">
+                <span class="text-sm font-bold text-slate-800 dark:text-slate-200 w-28 truncate">{{ guess.word }}</span>
+                <div class="flex-grow h-2.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+                  <div class="h-full rounded-full transition-all duration-500 {{ temp.barClass }}" [style.width.%]="barWidth(guess.score)"></div>
+                </div>
+                <span class="text-xs font-mono font-semibold text-slate-500 dark:text-slate-400 w-12 text-right">{{ guess.score.toFixed(3) }}</span>
+                <span class="text-xs font-bold w-20 text-right {{ temp.textClass }}">
+                  <i class="bi {{ temp.icon }}"></i> {{ temp.label }}
+                </span>
+              </div>
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- How it works -->
+      <div class="lg:flex-[2] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-6">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2 mb-4">
+          <i class="bi bi-lightbulb text-amber-500"></i> How It Works
+        </span>
+        <ol class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed pl-5 flex flex-col gap-3 m-0">
+          <li>A secret word is picked and embedded <span class="font-semibold">once</span>, on-device.</li>
+          <li>Every guess is embedded locally and compared with cosine similarity — no server ever sees your guesses.</li>
+          <li>The temperature tells you how semantically close you are: "ocean" is scorching for "submarine", "banana" is freezing.</li>
+          <li>Think in <span class="font-semibold">meaning</span>, not spelling — related concepts, categories, and contexts score high.</li>
+        </ol>
+        @if (bestGuess) {
+          <div class="mt-5 pt-4 border-t border-slate-100 dark:border-zinc-700/50">
+            <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Best so far</span>
+            <div class="text-lg font-bold text-slate-800 dark:text-slate-200 mt-0.5">
+              {{ bestGuess.word }}
+              <span class="text-sm font-mono font-semibold {{ temperature(bestGuess.score).textClass }}">{{ bestGuess.score.toFixed(3) }}</span>
+            </div>
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.ts
@@ -1,0 +1,180 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+interface Guess {
+  word: string;
+  score: number;
+  isLatest: boolean;
+}
+
+interface Temperature {
+  label: string;
+  icon: string;
+  textClass: string;
+  barClass: string;
+}
+
+const SECRET_WORDS: string[] = [
+  'volcano', 'penguin', 'library', 'thunderstorm', 'spaceship', 'chocolate',
+  'orchestra', 'glacier', 'butterfly', 'submarine', 'harvest', 'midnight',
+  'carnival', 'telescope', 'avalanche', 'honey', 'marathon', 'lighthouse',
+  'jungle', 'blizzard', 'campfire', 'pyramid', 'waterfall', 'magnet',
+  'compass', 'lantern', 'meadow', 'tornado', 'castle', 'desert',
+  'island', 'forest', 'bridge', 'mirror', 'anchor', 'comet'
+];
+
+@Component({
+  selector: 'app-semantic-word-game-demo',
+  templateUrl: './semantic-word-game-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SemanticWordGameDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'semantic-word-game')!;
+
+  secretWord = '';
+  private secretVector: Float32Array | null = null;
+
+  guessInput = '';
+  guesses: Guess[] = [];
+  guessCount = 0;
+  won = false;
+  gaveUp = false;
+  isGuessing = false;
+  isPreparing = false;
+  gameReady = false;
+  inputError = '';
+  guessLatencyMs: number | null = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    if (this.embedderStatus === 'available') {
+      await this.newGame();
+    }
+  }
+
+  get isOver(): boolean {
+    return this.won || this.gaveUp;
+  }
+
+  get bestGuess(): Guess | null {
+    return this.guesses[0] ?? null;
+  }
+
+  get sortedGuesses(): Guess[] {
+    return this.guesses;
+  }
+
+  async newGame() {
+    this.isPreparing = true;
+    this.errorMessage = '';
+    try {
+      let word = this.secretWord;
+      while (word === this.secretWord) {
+        word = SECRET_WORDS[Math.floor(Math.random() * SECRET_WORDS.length)];
+      }
+      this.secretWord = word;
+      this.secretVector = await this.semanticEmbedder.embedOne(word, 'similarity');
+      this.guesses = [];
+      this.guessCount = 0;
+      this.won = false;
+      this.gaveUp = false;
+      this.guessInput = '';
+      this.inputError = '';
+      this.guessLatencyMs = null;
+      this.gameReady = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to start a new round.';
+    } finally {
+      this.isPreparing = false;
+    }
+  }
+
+  giveUp() {
+    if (!this.gameReady || this.isOver) return;
+    this.gaveUp = true;
+  }
+
+  private normalizeWord(word: string): string {
+    const lower = word.trim().toLowerCase();
+    return lower.endsWith('s') && lower.length > 3 ? lower.slice(0, -1) : lower;
+  }
+
+  async submitGuess() {
+    const raw = this.guessInput.trim().toLowerCase();
+    this.inputError = '';
+
+    if (!raw || !this.gameReady || this.isOver || this.isGuessing) return;
+    if (!/^[a-z][a-z'-]*$/.test(raw)) {
+      this.inputError = 'Single words only — letters, hyphens, and apostrophes.';
+      return;
+    }
+    if (this.guesses.some(g => g.word === raw)) {
+      this.inputError = `You already guessed "${raw}".`;
+      return;
+    }
+
+    this.isGuessing = true;
+    try {
+      const start = performance.now();
+      const guessVector = await this.semanticEmbedder.embedOne(raw, 'similarity');
+      this.guessLatencyMs = Math.round(performance.now() - start);
+
+      const score = this.semanticEmbedder.cosineSimilarity(this.secretVector!, guessVector);
+      this.guessCount++;
+      this.guesses.forEach(g => (g.isLatest = false));
+      this.guesses.push({ word: raw, score, isLatest: true });
+      this.guesses.sort((a, b) => b.score - a.score);
+      this.guessInput = '';
+
+      if (this.normalizeWord(raw) === this.normalizeWord(this.secretWord)) {
+        this.won = true;
+      }
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to score the guess.';
+    } finally {
+      this.isGuessing = false;
+    }
+  }
+
+  temperature(score: number): Temperature {
+    if (score >= 0.9) return { label: 'Scorching', icon: 'bi-fire', textClass: 'text-red-600 dark:text-red-400', barClass: 'bg-red-500' };
+    if (score >= 0.8) return { label: 'Hot', icon: 'bi-thermometer-high', textClass: 'text-orange-600 dark:text-orange-400', barClass: 'bg-orange-500' };
+    if (score >= 0.7) return { label: 'Warm', icon: 'bi-thermometer-half', textClass: 'text-amber-600 dark:text-amber-400', barClass: 'bg-amber-500' };
+    if (score >= 0.55) return { label: 'Cool', icon: 'bi-thermometer-low', textClass: 'text-sky-600 dark:text-sky-400', barClass: 'bg-sky-500' };
+    return { label: 'Freezing', icon: 'bi-snow', textClass: 'text-blue-600 dark:text-blue-400', barClass: 'bg-blue-500' };
+  }
+
+  /** Maps a cosine score to a bar width that spreads the useful range visually. */
+  barWidth(score: number): number {
+    return Math.max(4, Math.min(100, ((score - 0.3) / 0.7) * 100));
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+
+// Pick and embed the secret word once
+const secretWord = pickRandom(WORDS);
+const { embeddings: [secret] } = await embedder.embed(secretWord);
+
+async function guess(word) {
+  // Every guess is embedded locally — instant, free, works offline
+  const { embeddings: [g] } = await embedder.embed(word);
+  const score = cosineSimilarity(secret.values, g.values);
+
+  if (word.toLowerCase() === secretWord) return "🎉 You got it!";
+  if (score >= 0.90) return "🔥 Scorching";
+  if (score >= 0.80) return "Hot";
+  if (score >= 0.70) return "Warm";
+  if (score >= 0.55) return "Cool";
+  return "🧊 Freezing";
+}
+
+// The whole game runs with zero network requests${this.guessCount > 0 ? `\n// You have made ${this.guessCount} ${this.guessCount === 1 ? 'guess' : 'guesses'} this round` : ''}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/semantic-word-game-demo.component.ts
@@ -79,7 +79,7 @@ export class SemanticWordGameDemoComponent extends BaseEmbedderDemoComponent imp
         word = SECRET_WORDS[Math.floor(Math.random() * SECRET_WORDS.length)];
       }
       this.secretWord = word;
-      this.secretVector = await this.semanticEmbedder.embedOne(word, 'similarity');
+      this.secretVector = await this.semanticEmbedder.embedOne(word, 'semantic-similarity');
       this.guesses = [];
       this.guessCount = 0;
       this.won = false;
@@ -122,7 +122,7 @@ export class SemanticWordGameDemoComponent extends BaseEmbedderDemoComponent imp
     this.isGuessing = true;
     try {
       const start = performance.now();
-      const guessVector = await this.semanticEmbedder.embedOne(raw, 'similarity');
+      const guessVector = await this.semanticEmbedder.embedOne(raw, 'semantic-similarity');
       this.guessLatencyMs = Math.round(performance.now() - start);
 
       const score = this.semanticEmbedder.cosineSimilarity(this.secretVector!, guessVector);
@@ -156,7 +156,7 @@ export class SemanticWordGameDemoComponent extends BaseEmbedderDemoComponent imp
   }
 
   get dynamicCodeSnippet(): string {
-    return `const embedder = await SemanticEmbedder.create({ taskType: "similarity" });
+    return `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
 
 // Pick and embed the secret word once
 const secretWord = pickRandom(WORDS);

--- a/webapp/src/app/pages/demos/features/smart-triage-demo.component.html
+++ b/webapp/src/app/pages/demos/features/smart-triage-demo.component.html
@@ -1,0 +1,153 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-embedder-status
+      [embedderStatus]="embedderStatus"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress">
+    </app-embedder-status>
+
+    @if (embedderStatus === 'downloadable' && !centroidsReady && !isEmbeddingExamples) {
+      <div class="mb-4 bg-indigo-50 border border-indigo-200 dark:bg-indigo-900/10 dark:border-indigo-900/30 rounded-2xl p-4 flex items-center justify-between gap-4">
+        <span class="text-sm text-indigo-900 dark:text-indigo-200"><i class="bi bi-download"></i> The embedding model needs to be downloaded before classifying.</span>
+        <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none whitespace-nowrap"
+                (click)="rebuildCentroids()">
+          Download & Prepare
+        </button>
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col xl:flex-row gap-6">
+
+      <!-- Incoming message + results -->
+      <div class="xl:flex-[3] flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-envelope-open text-indigo-500"></i> Incoming Message
+            </span>
+            @if (classifyLatencyMs !== null && results.length > 0) {
+              <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                <i class="bi bi-cpu"></i> classified in {{ classifyLatencyMs }}ms
+              </span>
+            }
+          </div>
+          <textarea
+            class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-800 dark:text-slate-200 placeholder-slate-400 resize-none p-5 leading-relaxed text-base min-h-[110px]"
+            [(ngModel)]="message"
+            (ngModelChange)="onMessageChanged()"
+            placeholder="Type a support message — it is classified live as you type..."></textarea>
+          <div class="px-5 pb-4 flex flex-wrap gap-2">
+            @for (sample of sampleMessages; track sample) {
+              <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                      (click)="useSample(sample)">
+                {{ sample }}
+              </button>
+            }
+          </div>
+        </div>
+
+        <!-- Classification results -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 min-h-[240px] flex flex-col">
+          <div class="flex items-center justify-between mb-4">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-signpost-split text-indigo-500"></i> Routing Decision
+            </span>
+            @if (isClassifying || isEmbeddingExamples) {
+              <i class="bi bi-arrow-repeat animate-spin text-indigo-400"></i>
+            }
+          </div>
+
+          @if (results.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light">
+              {{ centroidsReady ? 'Start typing a message to see it routed in real time.' : 'Preparing category centroids...' }}
+            </p>
+          } @else {
+            <div class="flex flex-col gap-3">
+              @for (result of results; track result.category.name) {
+                <div class="rounded-2xl border p-4 transition-all"
+                     [ngClass]="$first ? 'border-indigo-300 dark:border-indigo-700 bg-indigo-50/50 dark:bg-indigo-900/10 shadow-sm' : 'border-slate-200 dark:border-zinc-700 bg-slate-50/40 dark:bg-[#161616]/40'">
+                  <div class="flex items-center gap-3">
+                    <i class="bi {{ result.category.icon }} text-xl {{ result.category.colorClass }}"></i>
+                    <span class="font-semibold text-slate-800 dark:text-slate-200 text-sm">{{ result.category.name }}</span>
+                    @if ($first) {
+                      <span class="text-[10px] font-bold px-2 py-0.5 rounded-md bg-indigo-600 text-white uppercase tracking-wider">
+                        {{ isUncertain ? 'Best guess' : 'Route here' }}
+                      </span>
+                    }
+                    <div class="flex-grow"></div>
+                    <span class="text-xs font-mono font-semibold text-slate-500 dark:text-slate-400">{{ result.score.toFixed(3) }}</span>
+                  </div>
+                  <div class="h-2 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden mt-2.5">
+                    <div class="h-full rounded-full transition-all duration-300 {{ result.category.barClass }}" [style.width.%]="result.score * 100"></div>
+                  </div>
+                  @if ($first) {
+                    <p class="text-[11px] text-slate-500 dark:text-slate-400 m-0 mt-2">
+                      Closest example: "{{ result.bestExample }}"
+                    </p>
+                  }
+                </div>
+              }
+              @if (isUncertain) {
+                <p class="text-xs text-amber-600 dark:text-amber-400 m-0 flex items-center gap-1.5">
+                  <i class="bi bi-question-circle"></i> The top two categories are very close — a production system might ask a human here.
+                </p>
+              }
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Editable categories -->
+      <div class="xl:flex-[2] flex flex-col gap-4">
+        <div class="flex items-center gap-2 text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">
+          <i class="bi bi-sliders text-indigo-500"></i> Categories — edit the examples to "retrain" instantly
+        </div>
+        @for (category of categories; track category.name) {
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl shadow-sm border border-slate-200 dark:border-zinc-700 p-4">
+            <div class="flex items-center gap-2 mb-3">
+              <i class="bi {{ category.icon }} {{ category.colorClass }}"></i>
+              <span class="font-semibold text-sm text-slate-800 dark:text-slate-200">{{ category.name }}</span>
+              <div class="flex-grow"></div>
+              <button class="w-7 h-7 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+                      title="Add an example phrase"
+                      (click)="addExample(category)">
+                <i class="bi bi-plus text-sm"></i>
+              </button>
+            </div>
+            <div class="flex flex-col gap-2">
+              @for (example of category.examples; track trackByIndex($index); let i = $index) {
+                <div class="flex items-center gap-2 group">
+                  <input
+                    type="text"
+                    class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-xs text-slate-700 dark:text-slate-300 outline-none focus:ring-2 focus:ring-indigo-500/40"
+                    [(ngModel)]="category.examples[i]"
+                    (ngModelChange)="onExampleChanged()"
+                    placeholder="Example phrase..." />
+                  <button class="w-6 h-6 rounded-full text-slate-400 hover:text-red-500 bg-transparent border-none transition-colors opacity-0 group-hover:opacity-100 flex items-center justify-center"
+                          title="Remove"
+                          (click)="removeExample(category, i)">
+                    <i class="bi bi-x-lg text-xs"></i>
+                  </button>
+                </div>
+              }
+            </div>
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/smart-triage-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/smart-triage-demo.component.ts
@@ -1,0 +1,260 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Subject, debounceTime } from 'rxjs';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+interface TriageCategory {
+  name: string;
+  icon: string;
+  colorClass: string;
+  barClass: string;
+  examples: string[];
+  centroid: Float32Array | null;
+  exampleVectors: Float32Array[];
+}
+
+interface TriageResult {
+  category: TriageCategory;
+  score: number;
+  bestExample: string;
+}
+
+@Component({
+  selector: 'app-smart-triage-demo',
+  templateUrl: './smart-triage-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SmartTriageDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'smart-triage')!;
+
+  categories: TriageCategory[] = [
+    {
+      name: 'Billing & Payments',
+      icon: 'bi-credit-card',
+      colorClass: 'text-amber-600 dark:text-amber-400',
+      barClass: 'bg-amber-500',
+      examples: [
+        'I was charged twice for my subscription',
+        'How do I update my credit card?',
+        'I need a refund for last month\'s invoice'
+      ],
+      centroid: null,
+      exampleVectors: []
+    },
+    {
+      name: 'Bug Report',
+      icon: 'bi-bug',
+      colorClass: 'text-red-600 dark:text-red-400',
+      barClass: 'bg-red-500',
+      examples: [
+        'The app crashes when I open settings',
+        'Uploads fail with an error message',
+        'The page freezes after I log in'
+      ],
+      centroid: null,
+      exampleVectors: []
+    },
+    {
+      name: 'Feature Request',
+      icon: 'bi-lightbulb',
+      colorClass: 'text-emerald-600 dark:text-emerald-400',
+      barClass: 'bg-emerald-500',
+      examples: [
+        'It would be great to have a dark mode',
+        'Please add an export to CSV option',
+        'Can you support keyboard shortcuts?'
+      ],
+      centroid: null,
+      exampleVectors: []
+    },
+    {
+      name: 'Account & Login',
+      icon: 'bi-person-lock',
+      colorClass: 'text-indigo-600 dark:text-indigo-400',
+      barClass: 'bg-indigo-500',
+      examples: [
+        'I forgot my password and can\'t sign in',
+        'How do I delete my account?',
+        'My two-factor codes are not working'
+      ],
+      centroid: null,
+      exampleVectors: []
+    }
+  ];
+
+  message = '';
+  sampleMessages = [
+    'Why did my card get billed two times this month?',
+    'The dashboard throws an error whenever I click export',
+    'Would love an offline mode for long flights',
+    'Can\'t get into my account after resetting my password'
+  ];
+
+  results: TriageResult[] = [];
+  isClassifying = false;
+  isEmbeddingExamples = false;
+  centroidsReady = false;
+  classifyLatencyMs: number | null = null;
+
+  private message$ = new Subject<string>();
+  private examplesChanged$ = new Subject<void>();
+  private classifyToken = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+
+    this.subscriptions.push(
+      this.message$.pipe(debounceTime(300)).subscribe(() => this.classify()),
+      this.examplesChanged$.pipe(debounceTime(600)).subscribe(() => this.rebuildCentroids())
+    );
+
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    if (this.embedderStatus === 'available') {
+      await this.rebuildCentroids();
+    }
+  }
+
+  get topResult(): TriageResult | null {
+    return this.results[0] ?? null;
+  }
+
+  get isUncertain(): boolean {
+    return this.results.length >= 2 && this.results[0].score - this.results[1].score < 0.03;
+  }
+
+  onMessageChanged() {
+    this.message$.next(this.message);
+  }
+
+  onExampleChanged() {
+    this.centroidsReady = false;
+    this.examplesChanged$.next();
+  }
+
+  useSample(sample: string) {
+    this.message = sample;
+    this.classify();
+  }
+
+  addExample(category: TriageCategory) {
+    category.examples.push('');
+  }
+
+  removeExample(category: TriageCategory, index: number) {
+    if (category.examples.length > 1) {
+      category.examples.splice(index, 1);
+      this.onExampleChanged();
+    }
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  /**
+   * Re-embeds every example phrase and recomputes the category centroids.
+   * The service caches vectors per text, so only edited phrases hit the model.
+   */
+  async rebuildCentroids() {
+    const allExamples = this.categories.flatMap(c => c.examples.map(e => e.trim()).filter(e => e.length > 0));
+    if (allExamples.length === 0) return;
+
+    this.isEmbeddingExamples = true;
+    this.errorMessage = '';
+    try {
+      const vectors = await this.semanticEmbedder.embed(allExamples, 'classification', this.onDownloadProgress);
+      let cursor = 0;
+      for (const category of this.categories) {
+        const cleaned = category.examples.map(e => e.trim()).filter(e => e.length > 0);
+        category.exampleVectors = vectors.slice(cursor, cursor + cleaned.length);
+        cursor += cleaned.length;
+        category.centroid = category.exampleVectors.length > 0
+          ? this.semanticEmbedder.meanVector(category.exampleVectors)
+          : null;
+      }
+      this.centroidsReady = true;
+      if (this.message.trim()) await this.classify();
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Failed to embed the example phrases.';
+    } finally {
+      this.isEmbeddingExamples = false;
+    }
+  }
+
+  async classify() {
+    const text = this.message.trim();
+    const token = ++this.classifyToken;
+
+    if (!text || !this.centroidsReady) {
+      this.results = [];
+      return;
+    }
+
+    this.isClassifying = true;
+    try {
+      const start = performance.now();
+      const messageVector = await this.semanticEmbedder.embedOne(text, 'classification');
+      const latency = Math.round(performance.now() - start);
+      if (token !== this.classifyToken) return;
+
+      this.classifyLatencyMs = latency;
+      this.results = this.categories
+        .filter(c => c.centroid !== null)
+        .map(category => {
+          let bestExample = '';
+          let bestExampleScore = -Infinity;
+          const cleaned = category.examples.map(e => e.trim()).filter(e => e.length > 0);
+          category.exampleVectors.forEach((vector, i) => {
+            const score = this.semanticEmbedder.cosineSimilarity(messageVector, vector);
+            if (score > bestExampleScore) {
+              bestExampleScore = score;
+              bestExample = cleaned[i];
+            }
+          });
+          return {
+            category,
+            score: this.semanticEmbedder.cosineSimilarity(messageVector, category.centroid!),
+            bestExample
+          };
+        })
+        .sort((a, b) => b.score - a.score);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Classification failed.';
+    } finally {
+      if (token === this.classifyToken) this.isClassifying = false;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const categoryLines = this.categories
+      .map(c => `  ${JSON.stringify(c.name)}: ${JSON.stringify(c.examples.filter(e => e.trim()))}`)
+      .join(',\n');
+    return `const embedder = await SemanticEmbedder.create({ taskType: "classification" });
+
+// Each category is defined only by example phrases — no training step
+const categories = {
+${categoryLines}
+};
+
+// A category's centroid is the mean of its example vectors
+const centroids = {};
+for (const [name, examples] of Object.entries(categories)) {
+  const { embeddings } = await embedder.embed(examples);
+  centroids[name] = meanVector(embeddings.map(e => e.values));
+}
+
+// Classify any incoming message by nearest centroid
+const message = ${JSON.stringify(this.message.trim() || this.sampleMessages[0])};
+const { embeddings: [m] } = await embedder.embed(message);
+
+const ranked = Object.entries(centroids)
+  .map(([name, centroid]) => ({ name, score: cosineSimilarity(m.values, centroid) }))
+  .sort((a, b) => b.score - a.score);
+
+console.log("Route to:", ranked[0].name);`;
+  }
+}

--- a/webapp/src/app/pages/docs/apis/semantic-embedder-api.page.ts
+++ b/webapp/src/app/pages/docs/apis/semantic-embedder-api.page.ts
@@ -135,7 +135,7 @@ console.log(&quot;Semantic embedder created&quot;);"></app-code-snippet>
             <div class="mt-6 p-4 bg-slate-50 dark:bg-zinc-900/50 border border-slate-200 dark:border-zinc-800 rounded-xl text-slate-600 dark:text-slate-400 text-sm leading-relaxed flex gap-3">
               <i class="bi bi-info-circle-fill text-lg mt-0.5 text-slate-400 dark:text-slate-500"></i>
               <div>
-                Advanced model parameters are explicitly out of scope for the initial proposal. One option under discussion is an optional <code class="text-xs font-mono text-pink-600 dark:text-pink-400">taskType</code> hint (e.g. retrieval or classification) that browsers may safely ignore if the underlying model does not support it.
+                Advanced model parameters are explicitly out of scope for the initial proposal. One option under discussion is an optional <code class="text-xs font-mono text-pink-600 dark:text-pink-400">taskType</code> hint that browsers may safely ignore if the underlying model does not support it. The proposed values are <code class="text-xs font-mono">"semantic-similarity"</code>, <code class="text-xs font-mono">"retrieval-query"</code>, <code class="text-xs font-mono">"retrieval-document"</code>, <code class="text-xs font-mono">"classification"</code>, and <code class="text-xs font-mono">"clustering"</code>. For retrieval, embed your corpus with <code class="text-xs font-mono">"retrieval-document"</code> and the user's query with <code class="text-xs font-mono">"retrieval-query"</code>.
               </div>
             </div>
           </section>
@@ -254,7 +254,10 @@ interface SemanticEmbedder &#123;
 dictionary SemanticEmbedderCreateOptions &#123;
   AbortSignal signal;
   CreateMonitorCallback monitor;
-  DOMString taskType;   // under discussion: optional hint browsers may ignore
+  // under discussion: optional hint browsers may ignore
+  // &quot;semantic-similarity&quot; | &quot;retrieval-query&quot; | &quot;retrieval-document&quot;
+  //   | &quot;classification&quot; | &quot;clustering&quot;
+  DOMString taskType;
 &#125;;
 
 dictionary EmbedderResult &#123;
@@ -321,7 +324,7 @@ dictionary EmbedderMetadata &#123;
                   <tr>
                     <td class="px-4 py-3 text-sm font-mono text-amber-600 dark:text-amber-400">options.taskType</td>
                     <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-400 font-mono">DOMString</td>
-                    <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-400">Under discussion — optional quality hint (e.g. retrieval, classification) that browsers may ignore.</td>
+                    <td class="px-4 py-3 text-sm text-slate-600 dark:text-slate-400">Under discussion — optional quality hint that browsers may ignore. Values: <code class="font-mono text-xs">"semantic-similarity"</code>, <code class="font-mono text-xs">"retrieval-query"</code>, <code class="font-mono text-xs">"retrieval-document"</code>, <code class="font-mono text-xs">"classification"</code>, <code class="font-mono text-xs">"clustering"</code>.</td>
                   </tr>
                 </tbody>
               </table>

--- a/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.ts
+++ b/webapp/src/app/pages/playgrounds/semantic-embedder/semantic-embedder.page.ts
@@ -51,10 +51,11 @@ export class SemanticEmbedderPlaygroundPage implements OnInit, OnDestroy {
 
   taskTypes = [
     { value: '', label: 'None (let the browser decide)' },
-    { value: 'retrieval', label: 'retrieval' },
+    { value: 'semantic-similarity', label: 'semantic-similarity' },
+    { value: 'retrieval-query', label: 'retrieval-query' },
+    { value: 'retrieval-document', label: 'retrieval-document' },
     { value: 'classification', label: 'classification' },
-    { value: 'clustering', label: 'clustering' },
-    { value: 'similarity', label: 'similarity' }
+    { value: 'clustering', label: 'clustering' }
   ];
 
   private activeAbortController: AbortController | null = null;


### PR DESCRIPTION
## Summary

Adds a new **Embeddings** category to the demos page (shown first) with eight interactive demos built on the Semantic Embedder API, covering the dominant real-world embedding patterns — retrieval, search, classification, deduplication, clustering, caching, intent routing — plus a game:

| Demo | Route | Pattern |
|---|---|---|
| Chat With Your Document | `/demos/document-chat` | Local RAG: chunk → embed (`retrieval`) → top-k → Prompt API answer with citations |
| Semantic vs. Keyword Search | `/demos/semantic-search` | As-you-type search over a 48-entry help center, side-by-side with keyword matching |
| Smart Triage | `/demos/smart-triage` | Zero-shot nearest-centroid classifier with live-editable example phrases |
| Duplicate Detector | `/demos/duplicate-detector` | Near-duplicate warnings while typing a bug report, threshold slider |
| Cluster & Label | `/demos/cluster-and-label` | k-means++ over embeddings, PCA scatter map, clusters named by the Prompt API |
| Semantic Cache | `/demos/semantic-cache` | Similarity-keyed LLM answer cache with hit/miss scoreboard and tokens-saved estimate |
| Semantic Command Palette | `/demos/command-palette` | Intent-ranked ⌘K actions; "Toggle dark mode" really toggles the site theme |
| Hot or Cold | `/demos/semantic-word-game` | Semantle-style word guessing scored by cosine similarity |

## Shared infrastructure

- `SemanticEmbedderService`: one live embedder per `taskType`, batched `embed()` with a per-`(taskType, text)` vector cache, cosine / top-k / centroid helpers
- `BaseEmbedderDemoComponent` + `app-embedder-status` header (availability pills, download progress, `chrome://flags/#semantic-embedder-api` hint)
- Demos auto-index only when the model is `available`; `downloadable` states require an explicit button click
- Every demo generates a live code snippet reflecting its current inputs

## Testing

- `ng build` passes; all 8 routes prerender cleanly through SSR (browser-only paths are platform-guarded)
- Live embedding paths require Chrome Canary with `#semantic-embedder-api` enabled
- Similarity thresholds (0.60 duplicates, 0.85 cache) and the game's temperature buckets are first guesses to tune against the real model's score distribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)