### PR TITLE
Add search, filters, and live availability badges to the demos page

### DIFF
--- a/webapp/src/app/core/models/demo.interface.ts
+++ b/webapp/src/app/core/models/demo.interface.ts
@@ -3,11 +3,14 @@ import {AttachmentTypeEnum} from '../enums/attachment-type.enum';
 
 export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match' | 'Embeddings';
 
+export type DemoApi = 'Prompt API' | 'Semantic Embedder';
+
 export interface DemoExample {
   id: string;
   title: string;
   description: string;
   category: DemoCategory;
+  apis: DemoApi[];
   icon: string;
   onDeviceReason: string;
   codeSnippet: string;

--- a/webapp/src/app/core/services/demo-availability.service.ts
+++ b/webapp/src/app/core/services/demo-availability.service.ts
@@ -1,0 +1,47 @@
+import {Inject, Injectable, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
+import {BehaviorSubject} from 'rxjs';
+import {DemoApi} from '../models/demo.interface';
+
+export type DemoApiAvailability = 'checking' | 'available' | 'downloadable' | 'downloading' | 'unavailable';
+
+@Injectable({providedIn: 'root'})
+export class DemoAvailabilityService {
+  private readonly availabilitySubject = new BehaviorSubject<Record<DemoApi, DemoApiAvailability>>({
+    'Prompt API': 'checking',
+    'Semantic Embedder': 'checking',
+  });
+
+  readonly availability$ = this.availabilitySubject.asObservable();
+
+  constructor(@Inject(PLATFORM_ID) private readonly platformId: Object) {
+    if (isPlatformBrowser(this.platformId)) {
+      this.checkAll();
+    }
+  }
+
+  private checkAll(): void {
+    this.check('Prompt API', (globalThis as any).LanguageModel);
+    this.check('Semantic Embedder', (globalThis as any).SemanticEmbedder);
+  }
+
+  private async check(api: DemoApi, globalApi: { availability(): Promise<string> } | undefined): Promise<void> {
+    let result: DemoApiAvailability = 'unavailable';
+
+    if (globalApi?.availability) {
+      try {
+        const availability = await globalApi.availability();
+        if (availability === 'available' || availability === 'downloadable' || availability === 'downloading') {
+          result = availability;
+        }
+      } catch {
+        result = 'unavailable';
+      }
+    }
+
+    this.availabilitySubject.next({
+      ...this.availabilitySubject.value,
+      [api]: result,
+    });
+  }
+}

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -8,6 +8,7 @@ export const DEMOS_DATA: DemoExample[] = [
     title: 'Chat With Your Document',
     description: 'Fully local RAG: retrieve the relevant passages with embeddings, then answer with the Prompt API — citations included.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder', 'Prompt API'],
     icon: 'bi-chat-left-quote',
     onDeviceReason: 'The entire RAG pipeline — chunking, embedding, retrieval, and generation — runs on-device. Your document is never uploaded and no vector database is required.',
     codeSnippet: `// 1. Index: chunk the document and embed every chunk in one batch
@@ -37,6 +38,7 @@ const stream = session.promptStreaming(\`Context:\\n\${context}\\n\\nQuestion: \
     title: 'Semantic vs. Keyword Search',
     description: 'Search a help center by meaning, side by side with keyword search — and watch keywords miss what embeddings find.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-search-heart',
     onDeviceReason: 'On-device embeddings cost nothing per query, so you can afford to search on every keystroke — no network round trip, no per-call billing, and queries stay private.',
     codeSnippet: `// Index the help center once (a single batched call)
@@ -60,6 +62,7 @@ const ranked = embeddings
     title: 'Smart Triage',
     description: 'A zero-shot classifier: route incoming messages to categories defined only by a few example phrases.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-signpost-split',
     onDeviceReason: 'Classify support messages, feedback, or emails locally with no training step and no data leaving the device — and "retrain" instantly by editing the example phrases.',
     codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "classification" });
@@ -90,6 +93,7 @@ const best = Object.entries(centroids)
     title: 'Duplicate Detector',
     description: 'Catch near-duplicate bug reports before they are filed, even when they share no words with the original.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-files',
     onDeviceReason: 'Deduplication runs while the user is still typing, because every similarity check is a local vector comparison — no server calls per keystroke.',
     codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
@@ -115,6 +119,7 @@ if (duplicates.length > 0) showWarning(duplicates);`,
     title: 'Cluster & Label',
     description: 'Group raw user feedback into themes with k-means over embeddings, then let the Prompt API name each cluster.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder', 'Prompt API'],
     icon: 'bi-bounding-box-circles',
     onDeviceReason: 'Topic discovery over private feedback, notes, or tickets happens entirely locally — the embeddings power the math, the Prompt API writes the labels.',
     codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "clustering" });
@@ -143,6 +148,7 @@ for (let c = 0; c < 4; c++) {
     title: 'Semantic Cache',
     description: 'Serve instant answers for paraphrased questions by caching LLM responses under their embeddings.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-lightning-charge',
     onDeviceReason: 'A production pattern made visible: skip re-running the language model when a semantically equivalent question was already answered — saving seconds and tokens.',
     codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
@@ -171,6 +177,7 @@ async function ask(question) {
     title: 'Semantic Command Palette',
     description: 'A ⌘K palette that understands intent: describe what you want in your own words and the right action lights up.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-command',
     onDeviceReason: 'Intent matching on every keystroke is only viable when embedding is free, instant, and private — exactly what an on-device embedder provides.',
     codeSnippet: `const actions = [
@@ -200,6 +207,7 @@ const ranked = actions
     title: 'Hot or Cold',
     description: 'Guess the secret word: every guess is embedded on-device and scored by how semantically close it lands.',
     category: 'Embeddings',
+    apis: ['Semantic Embedder'],
     icon: 'bi-thermometer-half',
     onDeviceReason: 'A whole word game with zero backend: scoring is a local cosine similarity, so it is instant, free to run, and works offline.',
     codeSnippet: `const embedder = await SemanticEmbedder.create({ taskType: "semantic-similarity" });
@@ -231,9 +239,10 @@ await guess("banana");   // Freezing`,
     title: 'Translation',
     description: 'Translate text from one language to another with native-like fluency.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-translate',
     onDeviceReason: 'Translations happen instantly without sending user content to external servers, preserving privacy and enabling offline use.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are an expert translator. Translate the following text into French."
 });
 const response = await session.prompt("Hello world! How are you doing today?");
@@ -250,9 +259,10 @@ console.log(response);`,
     title: 'Summarization',
     description: 'Condense long articles or text into concise, digestible bullet points.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-card-text',
     onDeviceReason: 'Summarize sensitive documents or personal emails locally, ensuring your private data never leaves your device.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Summarize the text into 3 concise bullet points."
 });
 const result = await session.prompt(longArticleText);`,
@@ -267,9 +277,10 @@ const result = await session.prompt(longArticleText);`,
     title: 'Proofreading & Grammar',
     description: 'Fix grammatical errors and improve sentence structure.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-spellcheck',
     onDeviceReason: 'Real-time text correction while typing without network latency, offering immediate feedback.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Proofread the text. Fix grammar, spelling, and punctuation errors. Only output the corrected text."
 });
 const result = await session.prompt("I has went to the store yesterday to buy some apples, but they was all out.");`,
@@ -284,9 +295,10 @@ const result = await session.prompt("I has went to the store yesterday to buy so
     title: 'Tone Changer',
     description: 'Rewrite casual text into a formal, professional tone.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-person-lines-fill',
     onDeviceReason: 'Fast local processing allows you to preview different tones seamlessly within your email or messaging client.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Rewrite the following text to sound highly professional and polite."
 });
 const result = await session.prompt("Hey boss, I can\\'t come in today, I feel super sick. Talk tomorrow.");`,
@@ -301,9 +313,10 @@ const result = await session.prompt("Hey boss, I can\\'t come in today, I feel s
     title: 'Brainstorming Ideas',
     description: 'Generate creative ideas for a given topic.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-lightbulb',
     onDeviceReason: 'Unbounded creativity anytime, anywhere, completely independent of your internet connection.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are a creative assistant. Generate 5 unique and innovative ideas for the user\\'s prompt."
 });
 const result = await session.prompt("I want to build a new mobile app that helps people learn gardening.");`,
@@ -318,9 +331,10 @@ const result = await session.prompt("I want to build a new mobile app that helps
     title: 'Write JavaScript',
     description: 'Generate functional JavaScript code from a description.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-filetype-js',
     onDeviceReason: 'Keep your proprietary codebase or ideas private by generating utility functions entirely locally.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are a senior software engineer. Write clean, modern, and efficient JavaScript code to solve the user\\'s request. Provide only the code block."
 });
 const code = await session.prompt("Write a function to debounce an input function, with a default delay of 300ms.");`,
@@ -335,9 +349,10 @@ const code = await session.prompt("Write a function to debounce an input functio
     title: 'Write HTML/CSS',
     description: 'Generate responsive UI components with HTML and Tailwind CSS.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-filetype-html',
     onDeviceReason: 'Rapid UI prototyping without hitting rate limits or paying cloud API costs.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Generate HTML structure styled with Tailwind CSS utility classes based on the user\\'s prompt."
 });
 const result = await session.prompt("Create a responsive pricing card component with a title, price, feature list, and a buy button.");`,
@@ -352,9 +367,10 @@ const result = await session.prompt("Create a responsive pricing card component 
     title: 'Explain Like I\'m 5',
     description: 'Simplify complex technical or scientific concepts.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-book-half',
     onDeviceReason: 'A quick, private tutor on your device that provides instant analogies and simplifications.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Explain the following complex concept as if the reader is a 5-year-old child. Use simple words and analogies."
 });
 const result = await session.prompt("Quantum entanglement");`,
@@ -369,9 +385,10 @@ const result = await session.prompt("Quantum entanglement");`,
     title: 'SQL Query Generator',
     description: 'Convert natural language questions into executable SQL queries.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-database-check',
     onDeviceReason: 'Generate queries for your database without sharing your internal database schema with the cloud.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are an expert database administrator. Generate a valid SQL query based on the user\\'s request. Table: users(id, name, age, city)."
 });
 const result = await session.prompt("Find the average age of users living in New York.");`,
@@ -386,9 +403,10 @@ const result = await session.prompt("Find the average age of users living in New
     title: 'Draft an Email',
     description: 'Quickly draft a polite email from a short description.',
     category: 'Text Input',
+    apis: ['Prompt API'],
     icon: 'bi-envelope-paper',
     onDeviceReason: 'Draft emails contextually within your mail app offline.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Draft a polite and professional email based on the user\\'s prompt."
 });
 const result = await session.prompt("Ask my client John if he is available for a meeting next Tuesday at 2pm.");`,
@@ -405,9 +423,10 @@ const result = await session.prompt("Ask my client John if he is available for a
     title: 'Image OCR',
     description: 'Extract raw text from images, receipts, or documents.',
     category: 'Image Input',
+    apis: ['Prompt API'],
     icon: 'bi-fonts',
     onDeviceReason: 'Processing images locally means your private photos (like receipts, IDs, or sensitive documents) never leave your device.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   expectedInputs: [{ type: "image", languages: ["en"] }]
 });
 const result = await session.prompt([{
@@ -428,9 +447,10 @@ const result = await session.prompt([{
     title: 'Image Description',
     description: 'Generate detailed alt-text or descriptions for images.',
     category: 'Image Input',
+    apis: ['Prompt API'],
     icon: 'bi-image',
     onDeviceReason: 'Quickly generate accessibility alt-tags for entire photo libraries locally without consuming immense bandwidth.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   expectedInputs: [{ type: "image" }]
 });
 const result = await session.prompt([{
@@ -451,9 +471,10 @@ const result = await session.prompt([{
     title: 'Explain a Meme',
     description: 'Understand the context, joke, or cultural reference in a meme.',
     category: 'Image Input',
+    apis: ['Prompt API'],
     icon: 'bi-emoji-laughing',
     onDeviceReason: 'On-device vision models can quickly analyze complex visual humor without sharing your browsing habits.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   expectedInputs: [{ type: "image" }]
 });
 const result = await session.prompt([{
@@ -474,9 +495,10 @@ const result = await session.prompt([{
     title: 'Recipe from Fridge',
     description: 'Take a photo of your fridge contents and get recipe ideas.',
     category: 'Image Input',
+    apis: ['Prompt API'],
     icon: 'bi-egg-fried',
     onDeviceReason: 'Zero-latency visual processing makes everyday utility apps feel like magic extensions of the camera.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are a master chef. Look at the ingredients in the image and suggest a creative recipe.",
   expectedInputs: [{ type: "image" }]
 });
@@ -499,9 +521,10 @@ const result = await session.prompt([{
     title: 'Image Categorization',
     description: 'Categorize photos for auto-organization.',
     category: 'Image Input',
+    apis: ['Prompt API'],
     icon: 'bi-tags',
     onDeviceReason: 'Sort your photo library purely locally without uploading your entire life to the cloud.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Categorize the provided image into one of: Nature, People, Urban, Pets, Document.",
   expectedInputs: [{ type: "image" }]
 });
@@ -526,9 +549,10 @@ const result = await session.prompt([{
     title: 'Audio Transcription',
     description: 'Transcribe spoken audio into accurate text.',
     category: 'Audio Input',
+    apis: ['Prompt API'],
     icon: 'bi-mic',
     onDeviceReason: 'Audio files are large. Processing them locally saves massive amounts of data transfer and protects voice privacy.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   expectedInputs: [{ type: "audio", languages: ["en"] }]
 });
 const result = await session.prompt([{
@@ -549,9 +573,10 @@ const result = await session.prompt([{
     title: 'Meeting Notes Extractor',
     description: 'Listen to meeting audio and generate action items.',
     category: 'Audio Input',
+    apis: ['Prompt API'],
     icon: 'bi-journal-check',
     onDeviceReason: 'Confidential corporate meetings can be securely transcribed and summarized directly on an employee\'s laptop.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "You are an executive assistant. Listen to the meeting and extract the top 3 action items.",
   expectedInputs: [{ type: "audio" }]
 });
@@ -574,9 +599,10 @@ const result = await session.prompt([{
     title: 'Audio Summarization',
     description: 'Get a quick summary of a long voice note.',
     category: 'Audio Input',
+    apis: ['Prompt API'],
     icon: 'bi-file-earmark-music',
     onDeviceReason: 'Save time by summarizing long personal voice notes locally without sending private thoughts to an API.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   systemPrompt: "Listen to the audio and provide a 2-sentence summary of the main points.",
   expectedInputs: [{ type: "audio" }]
 });
@@ -601,6 +627,7 @@ const result = await session.prompt([{
     title: 'Structured JSON Output',
     description: 'Force the model to output a strictly formatted JSON object.',
     category: 'Tools Calling',
+    apis: ['Prompt API'],
     icon: 'bi-braces',
     onDeviceReason: 'Perfect for local data parsing pipelines where data shouldn\'t leave the system, ensuring reliable programmatic ingestion.',
     codeSnippet: `const schema = {
@@ -612,7 +639,7 @@ const result = await session.prompt([{
   required: ["name", "age"]
 };
 
-const session = await ai.languageModel.create();
+const session = await LanguageModel.create();
 const result = await session.prompt(
   "My name is John Doe and I just turned 30 years old.",
   { responseConstraint: schema }
@@ -636,6 +663,7 @@ const result = await session.prompt(
     title: 'Extract Entities (NER)',
     description: 'Extract people, locations, and organizations into JSON.',
     category: 'Tools Calling',
+    apis: ['Prompt API'],
     icon: 'bi-box-seam',
     onDeviceReason: 'Safe, private local extraction of names and addresses from personal text.',
     codeSnippet: `const schema = {
@@ -645,7 +673,7 @@ const result = await session.prompt(
     locations: { type: "array", items: { type: "string" } }
   }
 };
-const session = await ai.languageModel.create();
+const session = await LanguageModel.create();
 const result = await session.prompt(
   "Yesterday, Alice and Bob traveled from Seattle to Tokyo.",
   { responseConstraint: schema }
@@ -671,9 +699,10 @@ const result = await session.prompt(
     title: 'Image + Audio Query',
     description: 'Ask a question about an image using your voice.',
     category: 'Mix-and-Match',
+    apis: ['Prompt API'],
     icon: 'bi-collection-play',
     onDeviceReason: 'Combining multiple heavy modalities (images and audio) locally avoids massive upload times and creates a seamless interactive experience.',
-    codeSnippet: `const session = await ai.languageModel.create({
+    codeSnippet: `const session = await LanguageModel.create({
   expectedInputs: [{ type: "image" }, { type: "audio" }]
 });
 const result = await session.prompt([{
@@ -694,6 +723,7 @@ const result = await session.prompt([{
     title: 'Receipt to JSON',
     description: 'Extract line items from a receipt image into structured JSON data.',
     category: 'Mix-and-Match',
+    apis: ['Prompt API'],
     icon: 'bi-receipt',
     onDeviceReason: 'Combines Vision processing and Structured JSON Output entirely locally, creating a private and powerful expense tracker.',
     codeSnippet: `const schema = {
@@ -704,7 +734,7 @@ const result = await session.prompt([{
     items: { type: "array", items: { type: "string" } }
   }
 };
-const session = await ai.languageModel.create({
+const session = await LanguageModel.create({
   expectedInputs: [{ type: "image" }]
 });
 const result = await session.prompt([

--- a/webapp/src/app/pages/demos/demos.page.html
+++ b/webapp/src/app/pages/demos/demos.page.html
@@ -1,8 +1,8 @@
 <div class="flex flex-col h-full bg-slate-50 dark:bg-[#121212] transition-colors duration-200 overflow-y-auto">
   <!-- Hero Section -->
-  <div class="relative py-16 md:py-24 px-6 overflow-hidden shrink-0">
+  <div class="relative py-16 md:py-20 px-6 overflow-hidden shrink-0">
     <div class="absolute inset-x-0 bottom-0 h-32 bg-gradient-to-t from-slate-50 dark:from-[#121212] to-transparent"></div>
-    
+
     <div class="relative max-w-4xl mx-auto text-center z-10">
       <div class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-slate-200/50 dark:bg-zinc-800/50 text-slate-700 dark:text-zinc-300 text-xs font-bold uppercase tracking-wider mb-6 border border-slate-300/50 dark:border-zinc-700/50">
         <i class="bi bi-stars text-amber-500"></i> Chrome Built-in AI
@@ -11,14 +11,80 @@
         WebAI <span class="text-slate-400 dark:text-zinc-500">Demos</span>
       </h1>
       <p class="text-lg md:text-xl text-slate-600 dark:text-slate-400 max-w-2xl mx-auto leading-relaxed">
-        Explore what's possible with On-Device AI directly in the browser. 
+        Explore what's possible with On-Device AI directly in the browser.
         No API keys, no server costs, full privacy.
       </p>
     </div>
   </div>
 
+  <!-- Search & Filters -->
+  <div class="px-6 md:px-10 max-w-7xl mx-auto w-full relative z-20">
+    <div class="bg-[#ffffff] dark:bg-[#18181b] rounded-3xl border border-slate-200 dark:border-zinc-800 shadow-sm p-5 md:p-6 flex flex-col gap-4">
+      <!-- Search input -->
+      <div class="relative">
+        <i class="bi bi-search absolute left-4 top-1/2 -translate-y-1/2 text-slate-400 dark:text-zinc-500"></i>
+        <input
+          type="search"
+          [ngModel]="searchQuery"
+          (ngModelChange)="onSearchChanged($event)"
+          placeholder="Search demos… (e.g. OCR, receipt, translate)"
+          class="w-full pl-11 pr-4 py-3 rounded-2xl bg-slate-50 dark:bg-zinc-900 border border-slate-200 dark:border-zinc-700 text-slate-800 dark:text-slate-200 placeholder:text-slate-400 dark:placeholder:text-zinc-500 focus:outline-none focus:ring-2 focus:ring-indigo-500/40 focus:border-indigo-400 dark:focus:border-indigo-500 transition-colors" />
+      </div>
+
+      <!-- Filter chips -->
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500 mr-1">Category</span>
+        @for (category of categories; track category) {
+          <button
+            type="button"
+            (click)="toggleCategory(category)"
+            class="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors"
+            [ngClass]="selectedCategory === category
+              ? 'bg-slate-900 text-white border-slate-900 dark:bg-white dark:text-slate-900 dark:border-white'
+              : 'bg-slate-50 dark:bg-zinc-900 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-zinc-700 hover:border-slate-400 dark:hover:border-zinc-500'">
+            {{ category }}
+          </button>
+        }
+      </div>
+
+      <div class="flex flex-wrap items-center gap-2">
+        <span class="text-xs font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500 mr-1">API</span>
+        @for (api of apis; track api) {
+          <button
+            type="button"
+            (click)="toggleApi(api)"
+            class="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors"
+            [ngClass]="selectedApi === api
+              ? 'bg-indigo-600 text-white border-indigo-600'
+              : 'bg-slate-50 dark:bg-zinc-900 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-zinc-700 hover:border-indigo-400 dark:hover:border-indigo-500'">
+            {{ api }}
+          </button>
+        }
+
+        @if (hasActiveFilters) {
+          <button
+            type="button"
+            (click)="clearFilters()"
+            class="ml-auto px-3 py-1.5 rounded-full text-xs font-semibold text-slate-500 dark:text-slate-400 hover:text-slate-900 dark:hover:text-white transition-colors inline-flex items-center gap-1.5">
+            <i class="bi bi-x-circle"></i> Clear filters
+          </button>
+        }
+      </div>
+    </div>
+  </div>
+
   <div class="p-6 md:px-10 pb-20 max-w-7xl mx-auto w-full relative z-20 mt-8">
-    @for (category of categories; track category) {
+    @if (filteredDemos.length === 0) {
+      <div class="text-center py-24">
+        <i class="bi bi-binoculars text-5xl text-slate-300 dark:text-zinc-700"></i>
+        <p class="mt-4 text-lg font-semibold text-slate-600 dark:text-slate-400">No demos match your filters.</p>
+        <button type="button" (click)="clearFilters()" class="mt-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:underline">
+          Clear filters
+        </button>
+      </div>
+    }
+
+    @for (category of visibleCategories; track category) {
       <div class="mb-16">
         <div class="flex items-center gap-3 mb-8">
           <div class="h-px bg-slate-200 dark:bg-zinc-800 flex-grow"></div>
@@ -27,12 +93,14 @@
           </h2>
           <div class="h-px bg-slate-200 dark:bg-zinc-800 flex-grow"></div>
         </div>
-        
+
         <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 xl:gap-8">
           @for (demo of getDemosByCategory(category); track demo.id) {
+            @let style = getCategoryStyle(demo.category);
+            @let demoAvailability = getDemoAvailability(demo);
             <a [routerLink]="['/demos', demo.id]" class="!no-underline group/card h-full block focus:outline-none focus-visible:ring-4 focus-visible:ring-slate-500/50 rounded-3xl">
               <div class="relative h-full bg-[#ffffff] dark:bg-[#18181b] rounded-3xl p-7 border border-slate-200 dark:border-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 shadow-sm hover:shadow-2xl transition-all duration-500 hover:-translate-y-1 overflow-hidden flex flex-col">
-                
+
                 <!-- Sleek Top Gradient Bar -->
                 <div class="absolute top-0 left-0 right-0 h-1 bg-gradient-to-r from-transparent via-slate-300 dark:via-zinc-600 to-transparent opacity-0 group-hover/card:opacity-100 transition-opacity duration-500"></div>
 
@@ -40,14 +108,54 @@
                 <div class="absolute -right-20 -top-20 w-48 h-48 bg-slate-100 dark:bg-zinc-800/50 rounded-full blur-3xl group-hover/card:bg-slate-200 dark:group-hover/card:bg-zinc-800 transition-colors duration-500"></div>
 
                 <div class="relative z-10 flex flex-col h-full">
-                  <!-- Icon Container -->
-                  <div class="w-14 h-14 rounded-2xl bg-slate-100 dark:bg-zinc-800 text-slate-800 dark:text-slate-200 flex items-center justify-center mb-6 text-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.1)] group-hover/card:scale-110 transition-transform duration-500 ease-out">
-                    <i class="bi {{ demo.icon }}"></i>
+                  <div class="flex items-start justify-between mb-6">
+                    <!-- Icon Container -->
+                    <div class="w-14 h-14 rounded-2xl {{ style.iconContainer }} {{ style.icon }} flex items-center justify-center text-2xl shadow-[inset_0_1px_0_rgba(255,255,255,0.5)] dark:shadow-[inset_0_1px_0_rgba(255,255,255,0.1)] group-hover/card:scale-110 transition-transform duration-500 ease-out">
+                      <i class="bi {{ demo.icon }}"></i>
+                    </div>
+
+                    <!-- Availability badge -->
+                    @switch (demoAvailability) {
+                      @case ('available') {
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-500/10 text-emerald-700 dark:text-emerald-400 text-[10px] font-bold uppercase tracking-wider">
+                          <span class="w-1.5 h-1.5 rounded-full bg-emerald-500"></span> Ready
+                        </span>
+                      }
+                      @case ('downloadable') {
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-amber-50 dark:bg-amber-500/10 text-amber-700 dark:text-amber-400 text-[10px] font-bold uppercase tracking-wider">
+                          <span class="w-1.5 h-1.5 rounded-full bg-amber-500"></span> Download needed
+                        </span>
+                      }
+                      @case ('downloading') {
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-sky-50 dark:bg-sky-500/10 text-sky-700 dark:text-sky-400 text-[10px] font-bold uppercase tracking-wider">
+                          <span class="w-1.5 h-1.5 rounded-full bg-sky-500 animate-pulse"></span> Downloading
+                        </span>
+                      }
+                      @case ('unavailable') {
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-rose-50 dark:bg-rose-500/10 text-rose-700 dark:text-rose-400 text-[10px] font-bold uppercase tracking-wider">
+                          <span class="w-1.5 h-1.5 rounded-full bg-rose-500"></span> Unsupported
+                        </span>
+                      }
+                      @case ('checking') {
+                        <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-zinc-400 text-[10px] font-bold uppercase tracking-wider">
+                          <span class="w-1.5 h-1.5 rounded-full bg-slate-400 animate-pulse"></span> Checking
+                        </span>
+                      }
+                    }
                   </div>
-                  
+
                   <h3 class="text-xl font-bold text-slate-900 dark:text-white mb-3 tracking-tight group-hover/card:text-slate-700 dark:group-hover/card:text-slate-300 transition-colors break-words">{{ demo.title }}</h3>
-                  
-                  <p class="text-sm text-slate-500 dark:text-slate-400 line-clamp-3 leading-relaxed mb-8 flex-grow font-medium">{{ demo.description }}</p>
+
+                  <p class="text-sm text-slate-500 dark:text-slate-400 line-clamp-3 leading-relaxed mb-6 flex-grow font-medium">{{ demo.description }}</p>
+
+                  <!-- API chips -->
+                  <div class="flex flex-wrap gap-1.5 mb-6">
+                    @for (api of demo.apis; track api) {
+                      <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-zinc-400 border border-slate-200/60 dark:border-zinc-700/60">
+                        {{ api }}
+                      </span>
+                    }
+                  </div>
 
                   <div class="flex items-center justify-between mt-auto">
                     <div class="flex items-center justify-center w-8 h-8 rounded-full bg-slate-50 dark:bg-zinc-800/80 group-hover/card:bg-slate-900 group-hover/card:text-white dark:group-hover/card:bg-[#ffffff] dark:group-hover/card:text-slate-900 transition-colors duration-300 shadow-sm border border-slate-200 dark:border-zinc-700/50 group-hover/card:border-transparent">

--- a/webapp/src/app/pages/demos/demos.page.ts
+++ b/webapp/src/app/pages/demos/demos.page.ts
@@ -2,8 +2,15 @@ import { Component, Inject, OnInit } from '@angular/core';
 import { BasePage } from '../base-page';
 import { Title } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
+import { ActivatedRoute, Router } from '@angular/router';
 import { DEMOS_DATA } from '../../core/services/demos.data';
-import { DemoExample, DemoCategory } from '../../core/models/demo.interface';
+import { DemoApi, DemoCategory, DemoExample } from '../../core/models/demo.interface';
+import { DemoApiAvailability, DemoAvailabilityService } from '../../core/services/demo-availability.service';
+
+interface CategoryStyle {
+  icon: string;
+  iconContainer: string;
+}
 
 @Component({
   selector: 'app-demos-page',
@@ -14,16 +21,152 @@ import { DemoExample, DemoCategory } from '../../core/models/demo.interface';
 export class DemosPage extends BasePage implements OnInit {
   demos: DemoExample[] = DEMOS_DATA;
   categories: DemoCategory[] = ['Embeddings', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
+  apis: DemoApi[] = ['Prompt API', 'Semantic Embedder'];
+
+  searchQuery = '';
+  selectedCategory: DemoCategory | null = null;
+  selectedApi: DemoApi | null = null;
+
+  availability: Record<DemoApi, DemoApiAvailability> = {
+    'Prompt API': 'checking',
+    'Semantic Embedder': 'checking',
+  };
+
+  private readonly categoryStyles: Record<DemoCategory, CategoryStyle> = {
+    'Embeddings': {
+      icon: 'text-indigo-600 dark:text-indigo-400',
+      iconContainer: 'bg-indigo-50 dark:bg-indigo-500/10',
+    },
+    'Text Input': {
+      icon: 'text-sky-600 dark:text-sky-400',
+      iconContainer: 'bg-sky-50 dark:bg-sky-500/10',
+    },
+    'Image Input': {
+      icon: 'text-violet-600 dark:text-violet-400',
+      iconContainer: 'bg-violet-50 dark:bg-violet-500/10',
+    },
+    'Audio Input': {
+      icon: 'text-amber-600 dark:text-amber-400',
+      iconContainer: 'bg-amber-50 dark:bg-amber-500/10',
+    },
+    'Tools Calling': {
+      icon: 'text-emerald-600 dark:text-emerald-400',
+      iconContainer: 'bg-emerald-50 dark:bg-emerald-500/10',
+    },
+    'Mix-and-Match': {
+      icon: 'text-rose-600 dark:text-rose-400',
+      iconContainer: 'bg-rose-50 dark:bg-rose-500/10',
+    },
+  };
 
   constructor(
     @Inject(DOCUMENT) document: Document,
-    title: Title
+    title: Title,
+    private readonly route: ActivatedRoute,
+    private readonly router: Router,
+    private readonly demoAvailabilityService: DemoAvailabilityService,
   ) {
     super(document, title);
     this.setTitle("Demos");
   }
 
+  override ngOnInit(): void {
+    super.ngOnInit();
+
+    this.subscriptions.push(this.route.queryParamMap.subscribe(params => {
+      this.searchQuery = params.get('q') ?? '';
+
+      const category = params.get('category');
+      this.selectedCategory = this.categories.find(c => c === category) ?? null;
+
+      const api = params.get('api');
+      this.selectedApi = this.apis.find(a => a === api) ?? null;
+    }));
+
+    this.subscriptions.push(this.demoAvailabilityService.availability$.subscribe(availability => {
+      this.availability = availability;
+    }));
+  }
+
+  get filteredDemos(): DemoExample[] {
+    const query = this.searchQuery.trim().toLowerCase();
+
+    return this.demos.filter(demo => {
+      if (this.selectedCategory && demo.category !== this.selectedCategory) {
+        return false;
+      }
+
+      if (this.selectedApi && !demo.apis.includes(this.selectedApi)) {
+        return false;
+      }
+
+      if (query) {
+        const haystack = `${demo.title} ${demo.description} ${demo.category} ${demo.apis.join(' ')}`.toLowerCase();
+        if (!haystack.includes(query)) {
+          return false;
+        }
+      }
+
+      return true;
+    });
+  }
+
+  get visibleCategories(): DemoCategory[] {
+    const filtered = this.filteredDemos;
+    return this.categories.filter(category => filtered.some(demo => demo.category === category));
+  }
+
   getDemosByCategory(category: DemoCategory): DemoExample[] {
-    return this.demos.filter(demo => demo.category === category);
+    return this.filteredDemos.filter(demo => demo.category === category);
+  }
+
+  onSearchChanged(query: string): void {
+    this.searchQuery = query;
+    this.syncQueryParams();
+  }
+
+  toggleCategory(category: DemoCategory): void {
+    this.selectedCategory = this.selectedCategory === category ? null : category;
+    this.syncQueryParams();
+  }
+
+  toggleApi(api: DemoApi): void {
+    this.selectedApi = this.selectedApi === api ? null : api;
+    this.syncQueryParams();
+  }
+
+  clearFilters(): void {
+    this.searchQuery = '';
+    this.selectedCategory = null;
+    this.selectedApi = null;
+    this.syncQueryParams();
+  }
+
+  get hasActiveFilters(): boolean {
+    return this.searchQuery.trim() !== '' || this.selectedCategory !== null || this.selectedApi !== null;
+  }
+
+  getCategoryStyle(category: DemoCategory): CategoryStyle {
+    return this.categoryStyles[category];
+  }
+
+  getDemoAvailability(demo: DemoExample): DemoApiAvailability {
+    const severity: DemoApiAvailability[] = ['unavailable', 'checking', 'downloading', 'downloadable', 'available'];
+    return demo.apis
+      .map(api => this.availability[api])
+      .reduce((worst, current) => severity.indexOf(current) < severity.indexOf(worst) ? current : worst, 'available');
+  }
+
+  private syncQueryParams(): void {
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: {
+        q: this.searchQuery.trim() || null,
+        category: this.selectedCategory,
+        api: this.selectedApi,
+      },
+      queryParamsHandling: 'merge',
+      replaceUrl: true,
+    });
   }
 }


### PR DESCRIPTION
## Summary

First iteration of making the demos page easier to browse and more compelling:

- **Search + filters**: search box plus category and API filter chips above the grid, synced to URL query params (`?q=`, `?category=`, `?api=`) so filtered views are shareable. Empty categories are hidden while filtering, with an empty state and "Clear filters".
- **API tagging**: every demo in `demos.data.ts` now declares the APIs it uses via a new `apis: DemoApi[]` field (`Prompt API`, `Semantic Embedder`; `document-chat` and `cluster-and-label` use both).
- **Live availability badges**: a new SSR-guarded `DemoAvailabilityService` checks `LanguageModel.availability()` and `SemanticEmbedder.availability()` in the visitor's browser; each card shows Ready / Download needed / Downloading / Unsupported (worst status wins for multi-API demos).
- **Color-coded cards**: card icons are tinted per category (indigo/sky/violet/amber/emerald/rose) and cards carry API chips.
- **Snippet fix**: replaced the deprecated `ai.languageModel` surface with `LanguageModel` in 10 demo code snippets.

## Test plan

- `npm run build` passes (only pre-existing ACE CommonJS warnings).
- Manually verify on `/demos`: search narrows cards, chips toggle and reflect in the URL, availability badges resolve in Chrome with Built-in AI enabled.

🤖 Generated with [Claude Code](https://claude.com/claude-code)