### PR TITLE
Add Speech demos and multi-API pipeline demos

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -129,6 +129,14 @@ import { ClusterLabelDemoComponent } from './pages/demos/features/cluster-label-
 import { SemanticCacheDemoComponent } from './pages/demos/features/semantic-cache-demo.component';
 import { CommandPaletteDemoComponent } from './pages/demos/features/command-palette-demo.component';
 import { SemanticWordGameDemoComponent } from './pages/demos/features/semantic-word-game-demo.component';
+import { ApiStatusComponent } from './pages/demos/components/api-status/api-status.component';
+import { LiveTranslatedCaptionsDemoComponent } from './pages/demos/features/live-translated-captions-demo.component';
+import { SpeakToFillDemoComponent } from './pages/demos/features/speak-to-fill-demo.component';
+import { AsrQualityTiersDemoComponent } from './pages/demos/features/asr-quality-tiers-demo.component';
+import { ContextualBiasingDemoComponent } from './pages/demos/features/contextual-biasing-demo.component';
+import { PolyglotChatDemoComponent } from './pages/demos/features/polyglot-chat-demo.component';
+import { ProofreaderInlineDemoComponent } from './pages/demos/features/proofreader-inline-demo.component';
+import { UniversalInboxDemoComponent } from './pages/demos/features/universal-inbox-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { TrackingDownloadPage } from './pages/docs/tracking-download/tracking-download.page';
@@ -234,6 +242,14 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     SemanticCacheDemoComponent,
     CommandPaletteDemoComponent,
     SemanticWordGameDemoComponent,
+    ApiStatusComponent,
+    LiveTranslatedCaptionsDemoComponent,
+    SpeakToFillDemoComponent,
+    AsrQualityTiersDemoComponent,
+    ContextualBiasingDemoComponent,
+    PolyglotChatDemoComponent,
+    ProofreaderInlineDemoComponent,
+    UniversalInboxDemoComponent,
     AutoScrollDirective,
     CortexPage,
     CortexInsightsPage,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -45,6 +45,13 @@ import { ClusterLabelDemoComponent } from './pages/demos/features/cluster-label-
 import { SemanticCacheDemoComponent } from './pages/demos/features/semantic-cache-demo.component';
 import { CommandPaletteDemoComponent } from './pages/demos/features/command-palette-demo.component';
 import { SemanticWordGameDemoComponent } from './pages/demos/features/semantic-word-game-demo.component';
+import { LiveTranslatedCaptionsDemoComponent } from './pages/demos/features/live-translated-captions-demo.component';
+import { SpeakToFillDemoComponent } from './pages/demos/features/speak-to-fill-demo.component';
+import { AsrQualityTiersDemoComponent } from './pages/demos/features/asr-quality-tiers-demo.component';
+import { ContextualBiasingDemoComponent } from './pages/demos/features/contextual-biasing-demo.component';
+import { PolyglotChatDemoComponent } from './pages/demos/features/polyglot-chat-demo.component';
+import { ProofreaderInlineDemoComponent } from './pages/demos/features/proofreader-inline-demo.component';
+import { UniversalInboxDemoComponent } from './pages/demos/features/universal-inbox-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { DocsErrorsPage } from './pages/docs/errors/errors.page';
@@ -512,6 +519,55 @@ const routes: Routes = [
       {
         path: "demos/semantic-word-game",
         component: SemanticWordGameDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/live-translated-captions",
+        component: LiveTranslatedCaptionsDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/speak-to-fill",
+        component: SpeakToFillDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/asr-quality-tiers",
+        component: AsrQualityTiersDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/contextual-biasing",
+        component: ContextualBiasingDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/polyglot-chat",
+        component: PolyglotChatDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/proofreader-inline",
+        component: ProofreaderInlineDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/universal-inbox",
+        component: UniversalInboxDemoComponent,
         data: {
           route: RouteEnum.Demos
         }

--- a/webapp/src/app/core/models/demo.interface.ts
+++ b/webapp/src/app/core/models/demo.interface.ts
@@ -1,9 +1,18 @@
 import {PromptRunOptions} from './prompt-run.options';
 import {AttachmentTypeEnum} from '../enums/attachment-type.enum';
 
-export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match' | 'Embeddings';
+export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match' | 'Embeddings' | 'Speech';
 
-export type DemoApi = 'Prompt API' | 'Semantic Embedder';
+export type DemoApi =
+  | 'Prompt API'
+  | 'Semantic Embedder'
+  | 'Web Speech'
+  | 'Translator'
+  | 'Language Detector'
+  | 'Summarizer'
+  | 'Writer'
+  | 'Rewriter'
+  | 'Proofreader';
 
 export interface DemoExample {
   id: string;

--- a/webapp/src/app/core/services/demo-availability.service.ts
+++ b/webapp/src/app/core/services/demo-availability.service.ts
@@ -10,6 +10,13 @@ export class DemoAvailabilityService {
   private readonly availabilitySubject = new BehaviorSubject<Record<DemoApi, DemoApiAvailability>>({
     'Prompt API': 'checking',
     'Semantic Embedder': 'checking',
+    'Web Speech': 'checking',
+    'Translator': 'checking',
+    'Language Detector': 'checking',
+    'Summarizer': 'checking',
+    'Writer': 'checking',
+    'Rewriter': 'checking',
+    'Proofreader': 'checking',
   });
 
   readonly availability$ = this.availabilitySubject.asObservable();
@@ -21,22 +28,37 @@ export class DemoAvailabilityService {
   }
 
   private checkAll(): void {
-    this.check('Prompt API', (globalThis as any).LanguageModel);
-    this.check('Semantic Embedder', (globalThis as any).SemanticEmbedder);
+    this.check('Prompt API', () => (globalThis as any).LanguageModel?.availability());
+    this.check('Semantic Embedder', () => (globalThis as any).SemanticEmbedder?.availability());
+    this.check('Language Detector', () => (globalThis as any).LanguageDetector?.availability());
+    this.check('Summarizer', () => (globalThis as any).Summarizer?.availability());
+    this.check('Writer', () => (globalThis as any).Writer?.availability());
+    this.check('Rewriter', () => (globalThis as any).Rewriter?.availability());
+    this.check('Proofreader', () => (globalThis as any).Proofreader?.availability());
+
+    // Translator availability is per language pair — use a representative one.
+    this.check('Translator', () => (globalThis as any).Translator?.availability({
+      sourceLanguage: 'en',
+      targetLanguage: 'es',
+    }));
+
+    // Web Speech: only on-device recognition counts (available() is the gate).
+    this.check('Web Speech', () => {
+      const SR = (globalThis as any).SpeechRecognition || (globalThis as any).webkitSpeechRecognition;
+      return SR?.available?.({langs: ['en-US'], processLocally: true});
+    });
   }
 
-  private async check(api: DemoApi, globalApi: { availability(): Promise<string> } | undefined): Promise<void> {
+  private async check(api: DemoApi, probe: () => Promise<string> | undefined): Promise<void> {
     let result: DemoApiAvailability = 'unavailable';
 
-    if (globalApi?.availability) {
-      try {
-        const availability = await globalApi.availability();
-        if (availability === 'available' || availability === 'downloadable' || availability === 'downloading') {
-          result = availability;
-        }
-      } catch {
-        result = 'unavailable';
+    try {
+      const availability = await probe();
+      if (availability === 'available' || availability === 'downloadable' || availability === 'downloading') {
+        result = availability;
       }
+    } catch {
+      result = 'unavailable';
     }
 
     this.availabilitySubject.next({

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -2,6 +2,259 @@ import { DemoExample } from '../models/demo.interface';
 import { AttachmentTypeEnum } from '../enums/attachment-type.enum';
 
 export const DEMOS_DATA: DemoExample[] = [
+  // SPEECH
+  {
+    id: 'live-translated-captions',
+    title: 'Live Translated Captions',
+    description: 'Speak into the mic: on-device captions appear instantly, and a second track renders them live in another language.',
+    category: 'Speech',
+    apis: ['Web Speech', 'Language Detector', 'Translator'],
+    icon: 'bi-badge-cc',
+    onDeviceReason: 'Recognition, detection, and translation all run locally — captions work offline and the audio never leaves the microphone\'s device. A babel fish in a browser tab.',
+    codeSnippet: `// On-device recognition (explainer: on-device-speech-recognition)
+const options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+if (await SpeechRecognition.available(options) === "downloadable") {
+  await SpeechRecognition.install(options);
+}
+
+const recognition = new SpeechRecognition();
+recognition.options = options;
+recognition.continuous = true;
+recognition.interimResults = true;
+
+const detector = await LanguageDetector.create();
+const translators = new Map(); // cached per language pair
+
+recognition.onresult = async (event) => {
+  for (let i = event.resultIndex; i < event.results.length; i++) {
+    const result = event.results[i];
+    showCaption(result[0].transcript, result.isFinal);
+    if (!result.isFinal) continue;
+
+    // New final segment: detect its language, then translate it
+    const [{ detectedLanguage }] = await detector.detect(result[0].transcript);
+    const key = detectedLanguage + "->fr";
+    if (!translators.has(key)) {
+      translators.set(key, await Translator.create({
+        sourceLanguage: detectedLanguage, targetLanguage: "fr"
+      }));
+    }
+    showTranslatedCaption(await translators.get(key).translate(result[0].transcript));
+  }
+};
+
+recognition.start();`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'speak-to-fill',
+    title: 'Speak to Fill',
+    description: 'Say "table for four next Friday at seven, outside" and watch the booking form fill itself — speech in, structured data out.',
+    category: 'Speech',
+    apis: ['Web Speech', 'Prompt API'],
+    icon: 'bi-ui-checks',
+    onDeviceReason: 'Voice hits the on-device recognizer, the transcript hits the on-device LLM with a JSON schema, and the form fills — no audio or personal details ever reach a server.',
+    codeSnippet: `// 1. Capture one utterance on-device
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.onresult = (e) => extract(e.results[0][0].transcript);
+recognition.start();
+
+// 2. Turn the transcript into structured form data
+const schema = {
+  type: "object",
+  properties: {
+    name: { type: ["string", "null"] },
+    date: { type: ["string", "null"] },
+    time: { type: ["string", "null"] },
+    partySize: { type: ["number", "null"] },
+    seating: { type: ["string", "null"], enum: ["inside", "outside", null] },
+    specialRequests: { type: ["string", "null"] }
+  },
+  additionalProperties: false
+};
+
+async function extract(utterance) {
+  const session = await LanguageModel.create({
+    systemPrompt: "Extract restaurant booking details. " +
+      "Return null for fields the user did not mention. Today is " + new Date().toDateString()
+  });
+  const result = await session.prompt(utterance, { responseConstraint: schema });
+  fillForm(JSON.parse(result)); // only non-null fields overwrite the form
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'asr-quality-tiers',
+    title: 'ASR Quality Tier Lab',
+    description: 'Read the same passage against the command, dictation, and conversation models — then compare accuracy and latency.',
+    category: 'Speech',
+    apis: ['Web Speech'],
+    icon: 'bi-speedometer2',
+    onDeviceReason: 'The quality-levels explainer lets sites pick the right on-device model for the job — this lab makes the size/accuracy/latency trade-off measurable on your own hardware.',
+    codeSnippet: `// Quality tiers (explainer: quality-levels): each maps to a different on-device model
+for (const quality of ["command", "dictation", "conversation"]) {
+  const options = { langs: ["en-US"], processLocally: true, quality };
+
+  const availability = await SpeechRecognition.available(options);
+  if (availability === "downloadable") await SpeechRecognition.install(options);
+
+  const recognition = new SpeechRecognition();
+  recognition.options = options;
+  recognition.interimResults = true;
+
+  recognition.onresult = (event) => {
+    const transcript = [...event.results].map(r => r[0].transcript).join("");
+    // Score against the reference passage with word error rate
+    console.log(quality, wordErrorRate(referenceText, transcript));
+  };
+
+  recognition.start(); // record one attempt per tier, then compare
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'contextual-biasing',
+    title: 'Jargon Dictation',
+    description: 'Dictate product names the recognizer has never heard — then boost them with contextual biasing and watch the diff.',
+    category: 'Speech',
+    apis: ['Web Speech'],
+    icon: 'bi-sliders',
+    onDeviceReason: 'Contextual biasing tunes the on-device recognizer to your app\'s vocabulary at runtime — no custom model training, and your domain terms stay on the device.',
+    codeSnippet: `const options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+const recognition = new SpeechRecognition();
+recognition.options = options;
+
+// Contextual biasing (explainer: contextual-biasing):
+// boost domain terms the base model would otherwise mangle
+recognition.phrases.push(new SpeechRecognitionPhrase("TinyGemma", 3.0));
+recognition.phrases.push(new SpeechRecognitionPhrase("WebNN", 3.0));
+recognition.phrases.push(new SpeechRecognitionPhrase("Axon", 2.0));
+
+recognition.onresult = (event) => {
+  // "Add TinyGemma and WebNN benchmarks to the Axon suite"
+  // Without biasing: "add tiny gemma and web and then benchmarks to the axon sweet"
+  console.log(event.results[0][0].transcript);
+};
+
+recognition.start();`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+
+  // MULTI-API
+  {
+    id: 'polyglot-chat',
+    title: 'Polyglot Chat',
+    description: 'Two people, two languages, one conversation — every message is detected and translated both ways as it is sent.',
+    category: 'Mix-and-Match',
+    apis: ['Translator', 'Language Detector'],
+    icon: 'bi-chat-dots',
+    onDeviceReason: 'Private conversations get translated without a translation server in the middle — detection and translation are instant, local, and free per message.',
+    codeSnippet: `const detector = await LanguageDetector.create();
+const translators = new Map();
+
+async function send(message, recipientLanguage) {
+  // 1. Detect what language the sender actually typed
+  const [{ detectedLanguage, confidence }] = await detector.detect(message);
+
+  if (detectedLanguage === recipientLanguage) {
+    return { original: message }; // same language, nothing to do
+  }
+
+  // 2. Translate into the recipient's language (translators cached per pair)
+  const key = \`\${detectedLanguage}->\${recipientLanguage}\`;
+  if (!translators.has(key)) {
+    translators.set(key, await Translator.create({
+      sourceLanguage: detectedLanguage,
+      targetLanguage: recipientLanguage
+    }));
+  }
+
+  return {
+    original: message,
+    translated: await translators.get(key).translate(message),
+    from: detectedLanguage
+  };
+}
+
+await send("On se voit demain à midi ?", "en");
+// → { translated: "See you tomorrow at noon?", from: "fr" }`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'proofreader-inline',
+    title: 'Proofreader, Inline',
+    description: 'The dedicated Proofreader API: every error underlined in place, with a label, an explanation, and one-click accept.',
+    category: 'Text Input',
+    apis: ['Proofreader'],
+    icon: 'bi-patch-check',
+    onDeviceReason: 'Structured corrections — indices, labels, explanations — enable real editor UX, not just corrected text. And drafts are proofread without leaving the device.',
+    codeSnippet: `const proofreader = await Proofreader.create({
+  expectedInputLanguages: ["en"],
+  includeCorrectionTypes: true,        // not yet returned by Chrome's current build
+  includeCorrectionExplanations: true  // not yet returned by Chrome's current build
+});
+
+const result = await proofreader.proofread(
+  "I has went to the libary yesterday, but they was allready closed."
+);
+
+console.log(result.correctedInput);
+// "I went to the library yesterday, but they were already closed."
+
+for (const c of result.corrections) {
+  // startIndex/endIndex point into the ORIGINAL string — perfect for underlines
+  console.log(c.startIndex, c.endIndex, "→", c.correction, c.types, c.explanation);
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'universal-inbox',
+    title: 'Universal Inbox',
+    description: 'A five-API pipeline: detect each message\'s language, translate it, triage it into folders, digest the inbox, and draft replies in the sender\'s language.',
+    category: 'Mix-and-Match',
+    apis: ['Language Detector', 'Translator', 'Semantic Embedder', 'Summarizer', 'Writer'],
+    icon: 'bi-inbox',
+    onDeviceReason: 'Five Built-In AI APIs chained into one workflow, entirely on-device: a support inbox that reads every language, sorts itself, summarizes itself, and answers customers in their own words.',
+    codeSnippet: `const detector = await LanguageDetector.create();
+const embedder = await SemanticEmbedder.create({ taskType: "classification" });
+
+for (const message of inbox) {
+  // 1. Detect the sender's language
+  const [{ detectedLanguage }] = await detector.detect(message.body);
+
+  // 2. Translate to English for the pipeline
+  const translator = await Translator.create({
+    sourceLanguage: detectedLanguage, targetLanguage: "en"
+  });
+  message.english = await translator.translate(message.body);
+
+  // 3. Triage into a folder by embedding similarity to category centroids
+  const { embeddings: [e] } = await embedder.embed(message.english);
+  message.folder = nearestCentroid(e.values, folderCentroids);
+}
+
+// 4. Digest the whole inbox
+const summarizer = await Summarizer.create({ type: "key-points", length: "short" });
+const digest = await summarizer.summarize(
+  inbox.map(m => \`From \${m.sender}: \${m.english}\`).join("\\n")
+);
+
+// 5. Draft a reply — then translate it BACK to the sender's language
+const writer = await Writer.create({ tone: "formal", length: "short" });
+const reply = await writer.write(\`Reply to: "\${message.english}"\`);
+const back = await Translator.create({ sourceLanguage: "en", targetLanguage: message.lang });
+message.draft = await back.translate(reply);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+
   // EMBEDDINGS
   {
     id: 'document-chat',
@@ -177,7 +430,7 @@ async function ask(question) {
     title: 'Semantic Command Palette',
     description: 'A ⌘K palette that understands intent: describe what you want in your own words and the right action lights up.',
     category: 'Embeddings',
-    apis: ['Semantic Embedder'],
+    apis: ['Semantic Embedder', 'Web Speech'],
     icon: 'bi-command',
     onDeviceReason: 'Intent matching on every keystroke is only viable when embedding is free, instant, and private — exactly what an on-device embedder provides.',
     codeSnippet: `const actions = [
@@ -239,7 +492,7 @@ await guess("banana");   // Freezing`,
     title: 'Translation',
     description: 'Translate text from one language to another with native-like fluency.',
     category: 'Text Input',
-    apis: ['Prompt API'],
+    apis: ['Translator', 'Language Detector', 'Prompt API'],
     icon: 'bi-translate',
     onDeviceReason: 'Translations happen instantly without sending user content to external servers, preserving privacy and enabling offline use.',
     codeSnippet: `const session = await LanguageModel.create({
@@ -259,7 +512,7 @@ console.log(response);`,
     title: 'Summarization',
     description: 'Condense long articles or text into concise, digestible bullet points.',
     category: 'Text Input',
-    apis: ['Prompt API'],
+    apis: ['Summarizer', 'Prompt API'],
     icon: 'bi-card-text',
     onDeviceReason: 'Summarize sensitive documents or personal emails locally, ensuring your private data never leaves your device.',
     codeSnippet: `const session = await LanguageModel.create({

--- a/webapp/src/app/core/services/web-speech.service.ts
+++ b/webapp/src/app/core/services/web-speech.service.ts
@@ -1,0 +1,136 @@
+import { Injectable, Inject, NgZone, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+
+export type SpeechQuality = 'command' | 'dictation' | 'conversation';
+
+export interface SpeechRecognitionConfig {
+  lang?: string;
+  quality?: SpeechQuality;
+  continuous?: boolean;
+  interimResults?: boolean;
+  maxAlternatives?: number;
+  phrases?: { phrase: string; boost: number }[];
+}
+
+/**
+ * Thin wrapper around the Web Speech API focused on on-device recognition
+ * (processLocally: true) with the quality-tier and contextual-biasing explainers.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class WebSpeechService {
+  private isBrowser: boolean;
+
+  constructor(
+    @Inject(PLATFORM_ID) platformId: Object,
+    private readonly ngZone: NgZone
+  ) {
+    this.isBrowser = isPlatformBrowser(platformId);
+  }
+
+  private getRecognitionCtor(): any {
+    if (!this.isBrowser) return undefined;
+    return (window as any).SpeechRecognition || (window as any).webkitSpeechRecognition;
+  }
+
+  isSupported(): boolean {
+    return !!this.getRecognitionCtor();
+  }
+
+  private toOptions(config: SpeechRecognitionConfig) {
+    return {
+      langs: [config.lang ?? 'en-US'],
+      processLocally: true,
+      quality: config.quality ?? 'dictation'
+    };
+  }
+
+  /** Availability of ON-DEVICE recognition for the given language and quality tier. */
+  async available(config: SpeechRecognitionConfig = {}): Promise<string> {
+    const SR = this.getRecognitionCtor();
+    if (!SR) return 'unavailable';
+    // Without available(), on-device support cannot be guaranteed.
+    if (typeof SR.available !== 'function') return 'unavailable';
+    try {
+      return String(await SR.available(this.toOptions(config)));
+    } catch {
+      return 'unavailable';
+    }
+  }
+
+  /** Downloads the on-device model for the given language and quality tier. */
+  async install(config: SpeechRecognitionConfig = {}): Promise<boolean> {
+    const SR = this.getRecognitionCtor();
+    if (!SR || typeof SR.install !== 'function') return false;
+    return await SR.install(this.toOptions(config));
+  }
+
+  /**
+   * Builds a configured recognizer. The caller owns it: bind events (wrapped in
+   * NgZone.run for change detection), then call start()/stop()/abort().
+   */
+  createRecognizer(config: SpeechRecognitionConfig = {}): any {
+    const SR = this.getRecognitionCtor();
+    if (!SR) throw new Error('SpeechRecognition is not supported in this browser.');
+
+    const recognition = new SR();
+    const options = this.toOptions(config);
+
+    // Options dict per the on-device-speech-recognition + quality-levels explainers.
+    try { recognition.options = options; } catch {}
+    // Backwards compat with the older explainer pattern.
+    try { recognition.processLocally = true; } catch {}
+
+    recognition.lang = config.lang ?? 'en-US';
+    recognition.continuous = config.continuous ?? false;
+    recognition.interimResults = config.interimResults ?? true;
+    recognition.maxAlternatives = config.maxAlternatives ?? 1;
+
+    const Phrase = (window as any).SpeechRecognitionPhrase;
+    if (config.phrases?.length && Phrase && recognition.phrases) {
+      try {
+        for (const p of config.phrases) {
+          if (p.phrase.trim()) recognition.phrases.push(new Phrase(p.phrase.trim(), p.boost));
+        }
+      } catch {}
+    }
+
+    return recognition;
+  }
+
+  supportsContextualBiasing(): boolean {
+    return this.isBrowser && !!(window as any).SpeechRecognitionPhrase;
+  }
+
+  /**
+   * Captures a single utterance and resolves with the final transcript.
+   * onInterim receives live partial transcripts. Callbacks run inside the Angular zone.
+   */
+  listenOnce(config: SpeechRecognitionConfig = {}, onInterim?: (text: string) => void): { result: Promise<string>; abort: () => void } {
+    const recognition = this.createRecognizer({ ...config, continuous: false, interimResults: true });
+
+    const result = new Promise<string>((resolve, reject) => {
+      let finalTranscript = '';
+
+      recognition.onresult = (event: any) => this.ngZone.run(() => {
+        let interim = '';
+        for (let i = 0; i < event.results.length; i++) {
+          const transcript = event.results[i][0].transcript;
+          if (event.results[i].isFinal) finalTranscript += transcript;
+          else interim += transcript;
+        }
+        if (interim && onInterim) onInterim(interim);
+      });
+
+      recognition.onerror = (event: any) => this.ngZone.run(() => {
+        reject(new Error(event.error === 'no-speech' ? 'No speech detected.' : event.error));
+      });
+
+      recognition.onend = () => this.ngZone.run(() => resolve(finalTranscript.trim()));
+    });
+
+    recognition.start();
+    return { result, abort: () => { try { recognition.abort(); } catch {} } };
+  }
+}

--- a/webapp/src/app/pages/demos/components/api-status/api-status.component.html
+++ b/webapp/src/app/pages/demos/components/api-status/api-status.component.html
@@ -1,0 +1,39 @@
+<div class="mb-4 flex flex-col gap-3">
+  <div class="flex flex-wrap items-center gap-x-6 gap-y-2">
+    @for (api of apis; track api.name) {
+      <div class="text-sm font-medium text-slate-600 dark:text-slate-400 flex items-center gap-2">
+        {{ api.name }}:
+        @if (api.status === 'available') {
+          <span class="text-emerald-600 dark:text-emerald-400 flex items-center gap-1"><i class="bi bi-check-circle-fill"></i> Available</span>
+        } @else if (api.status === 'unavailable') {
+          <span class="text-red-600 dark:text-red-400 flex items-center gap-1"><i class="bi bi-x-circle-fill"></i> Unavailable</span>
+        } @else if (api.status === 'loading...') {
+          <span class="text-slate-600 dark:text-slate-400 flex items-center gap-1"><i class="bi bi-hourglass-split"></i> Loading...</span>
+        } @else if (api.status === 'downloading') {
+          <span class="text-amber-600 dark:text-amber-400 flex items-center gap-1"><i class="bi bi-arrow-down-circle-fill"></i> Downloading...</span>
+        } @else {
+          <span class="text-amber-600 dark:text-amber-400 flex items-center gap-1"><i class="bi bi-arrow-down-circle-fill"></i> Download Required</span>
+        }
+      </div>
+    }
+
+    @if (showInstall && hasDownloadable) {
+      <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 disabled:opacity-50 border-none"
+              [disabled]="isInstalling"
+              (click)="install.emit()">
+        @if (isInstalling) {
+          <i class="bi bi-arrow-repeat animate-spin"></i> Installing...
+        } @else {
+          <i class="bi bi-download"></i> Install Model
+        }
+      </button>
+    }
+  </div>
+
+  @if (hasUnavailable && unavailableHint) {
+    <div class="bg-amber-50 border border-amber-200 dark:bg-amber-900/10 dark:border-amber-900/30 rounded-2xl p-4 text-sm text-amber-900 dark:text-amber-100/90 flex items-start gap-3">
+      <i class="bi bi-exclamation-triangle-fill text-amber-500 text-lg"></i>
+      <div [innerHTML]="unavailableHint"></div>
+    </div>
+  }
+</div>

--- a/webapp/src/app/pages/demos/components/api-status/api-status.component.ts
+++ b/webapp/src/app/pages/demos/components/api-status/api-status.component.ts
@@ -1,0 +1,32 @@
+import { Component, EventEmitter, Input, Output } from '@angular/core';
+
+export interface ApiStatusPill {
+  name: string;
+  status: string;
+}
+
+/**
+ * Generic availability header for demos composing multiple Built-In AI APIs:
+ * one status pill per API, an optional install button for on-device speech
+ * models, and a hint banner when something is unavailable.
+ */
+@Component({
+  selector: 'app-api-status',
+  templateUrl: './api-status.component.html',
+  standalone: false
+})
+export class ApiStatusComponent {
+  @Input() apis: ApiStatusPill[] = [];
+  @Input() showInstall = false;
+  @Input() isInstalling = false;
+  @Input() unavailableHint = '';
+  @Output() install = new EventEmitter<void>();
+
+  get hasUnavailable(): boolean {
+    return this.apis.some(api => api.status === 'unavailable');
+  }
+
+  get hasDownloadable(): boolean {
+    return this.apis.some(api => api.status === 'downloadable');
+  }
+}

--- a/webapp/src/app/pages/demos/components/base-demo/base-speech-demo.component.ts
+++ b/webapp/src/app/pages/demos/components/base-demo/base-speech-demo.component.ts
@@ -1,0 +1,58 @@
+import { Directive, NgZone, inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from './base-demo.component';
+import { WebSpeechService, SpeechRecognitionConfig } from '../../../../core/services/web-speech.service';
+
+@Directive()
+export abstract class BaseSpeechDemoComponent extends BaseDemoComponent {
+  protected readonly webSpeech = inject(WebSpeechService);
+  protected readonly ngZone = inject(NgZone);
+
+  speechStatus: string = 'loading...';
+  isInstalling = false;
+  errorMessage = '';
+
+  protected recognition: any = null;
+  isListening = false;
+
+  async checkSpeechAvailability(config: SpeechRecognitionConfig = {}) {
+    if (isPlatformServer(this.platformId)) return;
+    this.speechStatus = await this.webSpeech.available(config);
+  }
+
+  async installSpeechModel(config: SpeechRecognitionConfig = {}) {
+    this.isInstalling = true;
+    this.errorMessage = '';
+    try {
+      const installed = await this.webSpeech.install(config);
+      if (installed) {
+        this.speechStatus = 'available';
+      } else {
+        this.errorMessage = 'The on-device speech model could not be installed.';
+      }
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Installation failed.';
+    } finally {
+      this.isInstalling = false;
+    }
+  }
+
+  protected stopRecognition() {
+    if (this.recognition) {
+      try { this.recognition.stop(); } catch {}
+    }
+  }
+
+  protected abortRecognition() {
+    if (this.recognition) {
+      try { this.recognition.abort(); } catch {}
+      this.recognition = null;
+    }
+    this.isListening = false;
+  }
+
+  override ngOnDestroy() {
+    this.abortRecognition();
+    super.ngOnDestroy();
+  }
+}

--- a/webapp/src/app/pages/demos/demos.page.ts
+++ b/webapp/src/app/pages/demos/demos.page.ts
@@ -20,8 +20,8 @@ interface CategoryStyle {
 })
 export class DemosPage extends BasePage implements OnInit {
   demos: DemoExample[] = DEMOS_DATA;
-  categories: DemoCategory[] = ['Embeddings', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
-  apis: DemoApi[] = ['Prompt API', 'Semantic Embedder'];
+  categories: DemoCategory[] = ['Speech', 'Embeddings', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
+  apis: DemoApi[] = ['Prompt API', 'Semantic Embedder', 'Web Speech', 'Translator', 'Language Detector', 'Summarizer', 'Writer', 'Proofreader'];
 
   searchQuery = '';
   selectedCategory: DemoCategory | null = null;
@@ -30,9 +30,20 @@ export class DemosPage extends BasePage implements OnInit {
   availability: Record<DemoApi, DemoApiAvailability> = {
     'Prompt API': 'checking',
     'Semantic Embedder': 'checking',
+    'Web Speech': 'checking',
+    'Translator': 'checking',
+    'Language Detector': 'checking',
+    'Summarizer': 'checking',
+    'Writer': 'checking',
+    'Rewriter': 'checking',
+    'Proofreader': 'checking',
   };
 
   private readonly categoryStyles: Record<DemoCategory, CategoryStyle> = {
+    'Speech': {
+      icon: 'text-cyan-600 dark:text-cyan-400',
+      iconContainer: 'bg-cyan-50 dark:bg-cyan-500/10',
+    },
     'Embeddings': {
       icon: 'text-indigo-600 dark:text-indigo-400',
       iconContainer: 'bg-indigo-50 dark:bg-indigo-500/10',

--- a/webapp/src/app/pages/demos/features/asr-quality-tiers-demo.component.html
+++ b/webapp/src/app/pages/demos/features/asr-quality-tiers-demo.component.html
@@ -1,0 +1,129 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Web Speech (on-device)', status: speechStatus }]"
+      unavailableHint="<span class='font-semibold'>On-device speech recognition is not available in this browser.</span> Use a recent Chrome build with on-device Web Speech support — recognition with <code class='font-mono text-xs'>processLocally: true</code> is required for this lab.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Reference passage -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden mb-6">
+      <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-journal-text text-cyan-500"></i> Reference Passage — read this aloud for each tier
+        </span>
+      </div>
+      <textarea
+        class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 resize-none p-5 leading-relaxed text-base font-serif min-h-[100px]"
+        [(ngModel)]="referenceText"
+        (ngModelChange)="onReferenceChanged()"></textarea>
+    </div>
+
+    <!-- Tier columns -->
+    <div class="grid grid-cols-1 lg:grid-cols-3 gap-5">
+      @for (tier of tiers; track tier.value) {
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border overflow-hidden flex flex-col"
+             [ngClass]="bestTier?.value === tier.value ? 'border-emerald-300 dark:border-emerald-700' : 'border-slate-200 dark:border-zinc-700'">
+          <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+            <div class="flex items-center justify-between">
+              <span class="text-sm font-bold text-slate-800 dark:text-slate-200 flex items-center gap-2">
+                <span class="font-mono text-xs px-2 py-0.5 rounded-md bg-cyan-100 dark:bg-cyan-900/40 text-cyan-700 dark:text-cyan-300">{{ tier.value }}</span>
+                {{ tier.label }}
+              </span>
+              @if (bestTier?.value === tier.value) {
+                <span class="text-[10px] font-bold px-2 py-0.5 rounded bg-emerald-600 text-white uppercase tracking-wider">Most accurate</span>
+              }
+            </div>
+            <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-1">{{ tier.hint }}</p>
+          </div>
+
+          <div class="p-4 flex flex-col gap-3 flex-grow">
+            <!-- Availability / record controls -->
+            @if (tier.availability === 'loading...') {
+              <span class="text-xs text-slate-400"><i class="bi bi-hourglass-split"></i> Checking availability...</span>
+            } @else if (tier.availability === 'unavailable') {
+              <span class="text-xs text-red-500"><i class="bi bi-x-circle-fill"></i> This tier is unavailable on this device.</span>
+            } @else if (tier.availability !== 'available') {
+              <button class="flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                      [disabled]="tier.isInstalling"
+                      (click)="installTier(tier)">
+                @if (tier.isInstalling) {
+                  <i class="bi bi-arrow-repeat animate-spin"></i> Installing {{ tier.label }} model...
+                } @else {
+                  <i class="bi bi-download"></i> Install {{ tier.label }} model
+                }
+              </button>
+            } @else if (activeTier === tier.value) {
+              <button class="flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none"
+                      (click)="stop()">
+                <span class="w-2 h-2 rounded-full bg-white animate-pulse"></span> Stop Recording
+              </button>
+            } @else {
+              <button class="flex items-center justify-center gap-2 px-4 py-2.5 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                      [disabled]="activeTier !== null"
+                      (click)="record(tier)">
+                <i class="bi bi-mic-fill"></i> {{ tier.recorded ? 'Record Again' : 'Record' }}
+              </button>
+            }
+
+            <!-- Live transcript / diff -->
+            <div class="rounded-xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-3.5 min-h-[120px] text-sm leading-relaxed">
+              @if (activeTier === tier.value) {
+                <span class="text-slate-800 dark:text-slate-200">{{ tier.transcript }}</span>
+                <span class="text-slate-400 dark:text-slate-500 italic">{{ tier.interim }}</span>
+                @if (!tier.transcript && !tier.interim) {
+                  <span class="text-slate-400 dark:text-slate-500 font-light">Listening — read the passage above...</span>
+                }
+              } @else if (tier.recorded) {
+                @for (token of tier.diff; track $index) {
+                  <span [ngClass]="diffTokenClass(token.kind)">{{ token.text }}</span>{{ ' ' }}
+                }
+              } @else {
+                <span class="text-slate-400 dark:text-slate-500 font-light">The transcript and its diff against the reference will appear here.</span>
+              }
+            </div>
+
+            <!-- Metrics -->
+            @if (tier.recorded && tier.accuracy !== null) {
+              <div class="grid grid-cols-3 gap-2">
+                <div class="rounded-xl bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 p-2.5 text-center">
+                  <div class="text-lg font-bold" [ngClass]="tier.accuracy >= 90 ? 'text-emerald-600 dark:text-emerald-400' : tier.accuracy >= 70 ? 'text-amber-600 dark:text-amber-400' : 'text-red-600 dark:text-red-400'">{{ tier.accuracy }}%</div>
+                  <div class="text-[9px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Accuracy</div>
+                </div>
+                <div class="rounded-xl bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 p-2.5 text-center">
+                  <div class="text-lg font-bold text-slate-700 dark:text-slate-300">{{ tier.setupMs ?? 'N/A' }}<span class="text-[9px] text-slate-400 ml-0.5">ms</span></div>
+                  <div class="text-[9px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Setup</div>
+                </div>
+                <div class="rounded-xl bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 p-2.5 text-center">
+                  <div class="text-lg font-bold text-slate-700 dark:text-slate-300">{{ tier.soundToFirstWordMs ?? 'N/A' }}<span class="text-[9px] text-slate-400 ml-0.5">ms</span></div>
+                  <div class="text-[9px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">First word</div>
+                </div>
+              </div>
+              <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0">
+                {{ tier.substitutions }} substituted · {{ tier.insertions }} inserted · {{ tier.deletions }} missed
+              </p>
+            }
+          </div>
+        </div>
+      }
+    </div>
+
+    <div class="mt-4 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-slate-400 dark:text-slate-500">
+      <span><span class="inline-block w-3 h-3 rounded bg-red-100 dark:bg-red-900/30 align-middle mr-1"></span> substituted word</span>
+      <span><span class="inline-block w-3 h-3 rounded bg-amber-100 dark:bg-amber-900/30 align-middle mr-1"></span> extra word</span>
+      <span><span class="line-through mr-1">word</span> missed word</span>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/asr-quality-tiers-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/asr-quality-tiers-demo.component.ts
@@ -1,0 +1,244 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { SpeechQuality } from '../../../core/services/web-speech.service';
+
+interface DiffToken {
+  text: string;
+  kind: 'match' | 'sub' | 'ins' | 'del';
+}
+
+interface TierState {
+  value: SpeechQuality;
+  label: string;
+  hint: string;
+  availability: string;
+  isInstalling: boolean;
+  transcript: string;
+  interim: string;
+  setupMs: number | null;
+  soundToFirstWordMs: number | null;
+  accuracy: number | null;
+  substitutions: number;
+  insertions: number;
+  deletions: number;
+  diff: DiffToken[];
+  recorded: boolean;
+}
+
+const REFERENCE_PASSAGE =
+  'The quick brown fox jumps over the lazy dog while seventeen curious penguins watch from the frozen harbor. ' +
+  'Please schedule a briefing for Thursday at quarter past nine, and remember that the observatory telescope requires careful calibration before every single use.';
+
+@Component({
+  selector: 'app-asr-quality-tiers-demo',
+  templateUrl: './asr-quality-tiers-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class AsrQualityTiersDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'asr-quality-tiers')!;
+
+  referenceText = REFERENCE_PASSAGE;
+
+  tiers: TierState[] = [
+    { value: 'command', label: 'Command', hint: 'Smallest model — short phrases, limited vocabulary.', availability: 'loading...', isInstalling: false, transcript: '', interim: '', setupMs: null, soundToFirstWordMs: null, accuracy: null, substitutions: 0, insertions: 0, deletions: 0, diff: [], recorded: false },
+    { value: 'dictation', label: 'Dictation', hint: 'Mid-size model — continuous single-speaker speech.', availability: 'loading...', isInstalling: false, transcript: '', interim: '', setupMs: null, soundToFirstWordMs: null, accuracy: null, substitutions: 0, insertions: 0, deletions: 0, diff: [], recorded: false },
+    { value: 'conversation', label: 'Conversation', hint: 'Largest model — complex vocabulary, high noise.', availability: 'loading...', isInstalling: false, transcript: '', interim: '', setupMs: null, soundToFirstWordMs: null, accuracy: null, substitutions: 0, insertions: 0, deletions: 0, diff: [], recorded: false }
+  ];
+
+  activeTier: SpeechQuality | null = null;
+
+  private startCallTime = 0;
+  private soundStartTime = 0;
+  private firstSoundCaptured = false;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    // Availability is per quality tier — each maps to a different on-device model.
+    await Promise.all(this.tiers.map(async tier => {
+      tier.availability = await this.webSpeech.available({ quality: tier.value });
+    }));
+    this.speechStatus = this.tiers.some(t => t.availability !== 'unavailable') ? 'available' : 'unavailable';
+  }
+
+  get anyTierUsable(): boolean {
+    return this.tiers.some(t => t.availability === 'available');
+  }
+
+  async installTier(tier: TierState) {
+    tier.isInstalling = true;
+    this.errorMessage = '';
+    try {
+      const installed = await this.webSpeech.install({ quality: tier.value });
+      if (installed) tier.availability = 'available';
+      else this.errorMessage = `Could not install the ${tier.label} model.`;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Installation failed.';
+    } finally {
+      tier.isInstalling = false;
+    }
+  }
+
+  record(tier: TierState) {
+    if (this.activeTier || tier.availability !== 'available') return;
+
+    this.errorMessage = '';
+    tier.transcript = '';
+    tier.interim = '';
+    tier.setupMs = null;
+    tier.soundToFirstWordMs = null;
+    tier.accuracy = null;
+    tier.diff = [];
+    tier.recorded = false;
+    this.firstSoundCaptured = false;
+
+    try {
+      this.recognition = this.webSpeech.createRecognizer({
+        quality: tier.value,
+        continuous: true,
+        interimResults: true
+      });
+    } catch (e: any) {
+      this.errorMessage = e.message;
+      return;
+    }
+
+    const r = this.recognition;
+    this.activeTier = tier.value;
+    this.isListening = true;
+
+    r.onstart = () => this.ngZone.run(() => {
+      tier.setupMs = Math.round(performance.now() - this.startCallTime);
+    });
+
+    const captureSoundStart = () => this.ngZone.run(() => {
+      if (!this.firstSoundCaptured) {
+        this.soundStartTime = performance.now();
+        this.firstSoundCaptured = true;
+      }
+    });
+    r.onsoundstart = captureSoundStart;
+    r.onspeechstart = captureSoundStart;
+
+    r.onresult = (event: any) => this.ngZone.run(() => {
+      let finalText = '';
+      let interim = '';
+      for (let i = 0; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) finalText += transcript + ' ';
+        else interim += transcript;
+      }
+      tier.transcript = finalText.trim();
+      tier.interim = interim;
+
+      if (tier.soundToFirstWordMs === null && this.firstSoundCaptured && (finalText || interim)) {
+        tier.soundToFirstWordMs = Math.round(performance.now() - this.soundStartTime);
+      }
+    });
+
+    r.onerror = (event: any) => this.ngZone.run(() => {
+      this.errorMessage = event.error === 'not-allowed'
+        ? 'Microphone access was denied. Allow the mic to run the lab.'
+        : `Recognition error: ${event.error}`;
+    });
+
+    r.onend = () => this.ngZone.run(() => {
+      this.activeTier = null;
+      this.isListening = false;
+      this.recognition = null;
+      if (tier.transcript) {
+        this.scoreTier(tier);
+        tier.recorded = true;
+      }
+    });
+
+    this.startCallTime = performance.now();
+    r.start();
+  }
+
+  stop() {
+    this.stopRecognition();
+  }
+
+  onReferenceChanged() {
+    // Re-score every recorded attempt against the new reference.
+    this.tiers.filter(t => t.recorded).forEach(t => this.scoreTier(t));
+  }
+
+  private scoreTier(tier: TierState) {
+    const ref = this.tokenizeWords(this.referenceText);
+    const hyp = this.tokenizeWords(tier.transcript);
+    const { tokens, substitutions, insertions, deletions } = this.diffWords(ref, hyp);
+    tier.diff = tokens;
+    tier.substitutions = substitutions;
+    tier.insertions = insertions;
+    tier.deletions = deletions;
+    const wer = ref.length > 0 ? (substitutions + insertions + deletions) / ref.length : 0;
+    tier.accuracy = Math.max(0, Math.round((1 - wer) * 100));
+  }
+
+  private tokenizeWords(text: string): string[] {
+    return text
+      .toLowerCase()
+      .replace(/[^\p{L}\p{N}\s'-]/gu, '')
+      .split(/\s+/)
+      .filter(Boolean);
+  }
+
+  /** Word-level alignment via edit distance, backtraced into per-token diff ops. */
+  private diffWords(ref: string[], hyp: string[]): { tokens: DiffToken[]; substitutions: number; insertions: number; deletions: number } {
+    const n = ref.length, m = hyp.length;
+    const d: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+    for (let i = 0; i <= n; i++) d[i][0] = i;
+    for (let j = 0; j <= m; j++) d[0][j] = j;
+    for (let i = 1; i <= n; i++) {
+      for (let j = 1; j <= m; j++) {
+        const substitution = d[i - 1][j - 1] + (ref[i - 1] === hyp[j - 1] ? 0 : 1);
+        d[i][j] = Math.min(substitution, d[i - 1][j] + 1, d[i][j - 1] + 1);
+      }
+    }
+
+    const tokens: DiffToken[] = [];
+    let i = n, j = m, substitutions = 0, insertions = 0, deletions = 0;
+    while (i > 0 || j > 0) {
+      if (i > 0 && j > 0 && d[i][j] === d[i - 1][j - 1] && ref[i - 1] === hyp[j - 1]) {
+        tokens.unshift({ text: hyp[j - 1], kind: 'match' });
+        i--; j--;
+      } else if (i > 0 && j > 0 && d[i][j] === d[i - 1][j - 1] + 1) {
+        tokens.unshift({ text: hyp[j - 1], kind: 'sub' });
+        substitutions++; i--; j--;
+      } else if (j > 0 && d[i][j] === d[i][j - 1] + 1) {
+        tokens.unshift({ text: hyp[j - 1], kind: 'ins' });
+        insertions++; j--;
+      } else {
+        tokens.unshift({ text: ref[i - 1], kind: 'del' });
+        deletions++; i--;
+      }
+    }
+    return { tokens, substitutions, insertions, deletions };
+  }
+
+  diffTokenClass(kind: DiffToken['kind']): string {
+    switch (kind) {
+      case 'sub': return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded px-0.5';
+      case 'ins': return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded px-0.5';
+      case 'del': return 'text-slate-400 dark:text-slate-500 line-through';
+      default: return '';
+    }
+  }
+
+  get bestTier(): TierState | null {
+    const recorded = this.tiers.filter(t => t.recorded && t.accuracy !== null);
+    if (recorded.length < 2) return null;
+    return recorded.reduce((best, t) => (t.accuracy! > best.accuracy! ? t : best));
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/command-palette-demo.component.html
+++ b/webapp/src/app/pages/demos/features/command-palette-demo.component.html
@@ -60,6 +60,23 @@
                 {{ rankLatencyMs }}ms
               </span>
             }
+            @if (micAvailable) {
+              @if (isListening) {
+                <button class="w-9 h-9 rounded-full bg-red-600 hover:bg-red-700 text-white shadow-md transition-all active:scale-95 border-none flex items-center justify-center relative shrink-0"
+                        title="Stop listening"
+                        (click)="stopListening()">
+                  <span class="absolute inset-0 rounded-full bg-red-500/40 animate-ping"></span>
+                  <i class="bi bi-stop-fill relative"></i>
+                </button>
+              } @else {
+                <button class="w-9 h-9 rounded-full bg-slate-100 hover:bg-indigo-600 hover:text-white dark:bg-zinc-800 dark:hover:bg-indigo-600 text-slate-500 dark:text-slate-400 shadow-sm transition-all active:scale-95 border-none flex items-center justify-center shrink-0 disabled:opacity-40"
+                        title="Say your intent (on-device recognition, command quality tier)"
+                        [disabled]="!indexReady"
+                        (click)="listen()">
+                  <i class="bi bi-mic-fill"></i>
+                </button>
+              }
+            }
           </div>
 
           <!-- Results -->

--- a/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/command-palette-demo.component.ts
@@ -4,6 +4,7 @@ import { Subject, debounceTime } from 'rxjs';
 import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
 import { DEMOS_DATA } from '../../../core/services/demos.data';
 import { ThemeService } from '../../../core/services/theme.service';
+import { WebSpeechService } from '../../../core/services/web-speech.service';
 
 interface PaletteAction {
   id: string;
@@ -65,6 +66,11 @@ export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent imple
   isRanking = false;
   rankLatencyMs: number | null = null;
 
+  private readonly webSpeech = inject(WebSpeechService);
+  micStatus: string = 'loading...';
+  isListening = false;
+  private abortListen: (() => void) | null = null;
+
   executedLog: { label: string; icon: string; real: boolean }[] = [];
 
   private query$ = new Subject<string>();
@@ -80,9 +86,52 @@ export class CommandPaletteDemoComponent extends BaseEmbedderDemoComponent imple
 
     if (isPlatformServer(this.platformId)) return;
     await this.checkEmbedderAvailability();
+    this.micStatus = await this.webSpeech.available({ quality: 'command' });
     if (this.embedderStatus === 'available') {
       await this.buildIndex();
     }
+  }
+
+  get micAvailable(): boolean {
+    return this.micStatus === 'available';
+  }
+
+  /** Speak an intent instead of typing it — interim results rank live as you talk. */
+  async listen() {
+    if (this.isListening || !this.micAvailable || !this.indexReady) return;
+
+    this.isListening = true;
+    this.errorMessage = '';
+    try {
+      const { result, abort } = this.webSpeech.listenOnce(
+        { quality: 'command' },
+        interim => {
+          this.query = interim;
+          this.query$.next(interim);
+        }
+      );
+      this.abortListen = abort;
+
+      const transcript = await result;
+      if (transcript) {
+        this.query = transcript;
+        await this.rank(transcript);
+      }
+    } catch (e: any) {
+      if (e.message !== 'aborted') this.errorMessage = e.message || 'Voice input failed.';
+    } finally {
+      this.isListening = false;
+      this.abortListen = null;
+    }
+  }
+
+  stopListening() {
+    this.abortListen?.();
+  }
+
+  override ngOnDestroy() {
+    this.abortListen?.();
+    super.ngOnDestroy();
   }
 
   async buildIndex() {

--- a/webapp/src/app/pages/demos/features/contextual-biasing-demo.component.html
+++ b/webapp/src/app/pages/demos/features/contextual-biasing-demo.component.html
@@ -1,0 +1,157 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Web Speech (on-device)', status: speechStatus }]"
+      [showInstall]="true"
+      [isInstalling]="isInstalling"
+      (install)="installSpeechModel({ quality: 'dictation' })"
+      unavailableHint="<span class='font-semibold'>On-device speech recognition is not available in this browser.</span> Use a recent Chrome build with on-device Web Speech support (<code class='font-mono text-xs'>processLocally: true</code>).">
+    </app-api-status>
+
+    @if (speechStatus === 'available' && !biasingSupported) {
+      <div class="mb-4 bg-amber-50 border border-amber-200 dark:bg-amber-900/10 dark:border-amber-900/30 rounded-2xl p-4 text-sm text-amber-900 dark:text-amber-100/90 flex items-start gap-3">
+        <i class="bi bi-exclamation-triangle-fill text-amber-500 text-lg"></i>
+        <div><span class="font-semibold">SpeechRecognitionPhrase is not exposed in this browser</span> — the "with biasing" recording will behave like the unbiased one. The contextual-biasing explainer is still rolling out.</div>
+      </div>
+    }
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col xl:flex-row gap-6">
+
+      <!-- Phrase list -->
+      <div class="xl:flex-[2] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden self-start w-full">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-sliders text-cyan-500"></i> Boosted Phrases
+          </span>
+          <button class="w-7 h-7 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors flex items-center justify-center"
+                  title="Add phrase" (click)="addPhrase()">
+            <i class="bi bi-plus text-sm"></i>
+          </button>
+        </div>
+        <div class="p-4 flex flex-col gap-3">
+          @for (phrase of phrases; track trackByIndex($index); let i = $index) {
+            <div class="flex items-center gap-3 group">
+              <input type="text"
+                     class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-sm font-mono text-slate-700 dark:text-slate-300 outline-none focus:ring-2 focus:ring-cyan-500/40"
+                     [(ngModel)]="phrase.phrase"
+                     placeholder="Domain term..." />
+              <input type="range" min="0" max="10" step="0.5"
+                     class="w-24 accent-cyan-600"
+                     [(ngModel)]="phrase.boost"
+                     title="Boost" />
+              <span class="text-xs font-mono font-bold text-cyan-600 dark:text-cyan-400 w-8">{{ phrase.boost.toFixed(1) }}</span>
+              <button class="w-6 h-6 rounded-full text-slate-400 hover:text-red-500 bg-transparent border-none transition-colors opacity-0 group-hover:opacity-100 flex items-center justify-center"
+                      title="Remove" (click)="removePhrase(i)">
+                <i class="bi bi-x-lg text-xs"></i>
+              </button>
+            </div>
+          }
+          <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0">Boost 0–10. Higher values make the recognizer favor these spellings. Phrases apply only to the "with biasing" recording.</p>
+        </div>
+
+        <!-- Scoreboard -->
+        @if (bothRecorded) {
+          <div class="border-t border-slate-100 dark:border-zinc-700/50 p-4">
+            <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Terms recognized</span>
+            <table class="w-full mt-2">
+              <thead>
+                <tr class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase">
+                  <th class="text-left pb-1">Term</th>
+                  <th class="text-center pb-1">Without</th>
+                  <th class="text-center pb-1">With</th>
+                </tr>
+              </thead>
+              <tbody>
+                @for (phrase of validPhrases; track phrase.phrase) {
+                  <tr class="text-sm border-t border-slate-100 dark:border-zinc-800">
+                    <td class="py-1.5 font-mono text-xs text-slate-700 dark:text-slate-300">{{ phrase.phrase }}</td>
+                    <td class="text-center">
+                      <i class="bi" [ngClass]="termFound('without', phrase.phrase) ? 'bi-check-circle-fill text-emerald-500' : 'bi-x-circle-fill text-red-400'"></i>
+                    </td>
+                    <td class="text-center">
+                      <i class="bi" [ngClass]="termFound('with', phrase.phrase) ? 'bi-check-circle-fill text-emerald-500' : 'bi-x-circle-fill text-red-400'"></i>
+                    </td>
+                  </tr>
+                }
+                <tr class="text-xs font-bold border-t border-slate-200 dark:border-zinc-700">
+                  <td class="py-1.5 text-slate-500 dark:text-slate-400">Total</td>
+                  <td class="text-center text-slate-700 dark:text-slate-300">{{ hitCount('without') }}/{{ validPhrases.length }}</td>
+                  <td class="text-center" [ngClass]="hitCount('with') > hitCount('without') ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-700 dark:text-slate-300'">{{ hitCount('with') }}/{{ validPhrases.length }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+        }
+      </div>
+
+      <!-- Recordings -->
+      <div class="xl:flex-[3] flex flex-col gap-4 w-full">
+        <div class="bg-cyan-50 border border-cyan-200 dark:bg-cyan-900/10 dark:border-cyan-900/30 rounded-2xl p-4 text-sm text-cyan-900 dark:text-cyan-100/90">
+          <i class="bi bi-megaphone"></i> Say this sentence in both recordings:
+          <span class="font-semibold block mt-1">"{{ suggestedSentence }}"</span>
+        </div>
+
+        @for (mode of modes; track mode) {
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border overflow-hidden"
+               [ngClass]="mode === 'with' ? 'border-cyan-200 dark:border-cyan-900/50' : 'border-slate-200 dark:border-zinc-700'">
+            <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 flex justify-between items-center"
+                 [ngClass]="mode === 'with' ? 'bg-cyan-50/50 dark:bg-cyan-900/10' : 'bg-slate-50/50 dark:bg-[#161616]/50'">
+              <span class="text-xs font-bold uppercase tracking-wider flex items-center gap-2"
+                    [ngClass]="mode === 'with' ? 'text-cyan-700 dark:text-cyan-300' : 'text-slate-500 dark:text-slate-400'">
+                @if (mode === 'with') {
+                  <i class="bi bi-stars"></i> With Biasing
+                } @else {
+                  <i class="bi bi-mic"></i> Without Biasing
+                }
+              </span>
+              @if (activeMode === mode) {
+                <button class="flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-600 hover:bg-red-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                        (click)="stop()">
+                  <span class="w-1.5 h-1.5 rounded-full bg-white animate-pulse"></span> Stop
+                </button>
+              } @else {
+                <button class="flex items-center gap-2 px-4 py-1.5 rounded-full text-xs font-semibold shadow-sm transition-all active:scale-95 disabled:opacity-50 border-none text-white"
+                        [ngClass]="mode === 'with' ? 'bg-cyan-600 hover:bg-cyan-700' : 'bg-slate-600 hover:bg-slate-700'"
+                        [disabled]="activeMode !== null || speechStatus !== 'available'"
+                        (click)="record(mode)">
+                  <i class="bi bi-mic-fill"></i> Record
+                </button>
+              }
+            </div>
+            <div class="p-4 min-h-[70px] text-base leading-relaxed">
+              @if (activeMode === mode && interim) {
+                <span class="text-slate-400 dark:text-slate-500 italic">{{ interim }}</span>
+              } @else if (transcripts[mode]) {
+                @for (segment of highlight(mode); track $index) {
+                  @if (segment.hit) {
+                    <span class="bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-300 rounded px-1 font-semibold">{{ segment.text }}</span>
+                  } @else {
+                    <span class="text-slate-800 dark:text-slate-200">{{ segment.text }}</span>
+                  }
+                }
+              } @else if (activeMode === mode) {
+                <span class="text-slate-400 dark:text-slate-500 font-light">Listening...</span>
+              } @else {
+                <span class="text-slate-400 dark:text-slate-500 font-light">Transcript will appear here.</span>
+              }
+            </div>
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/contextual-biasing-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/contextual-biasing-demo.component.ts
@@ -1,0 +1,168 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+interface BiasPhrase {
+  phrase: string;
+  boost: number;
+}
+
+interface TranscriptSegment {
+  text: string;
+  hit: boolean;
+}
+
+type BiasMode = 'without' | 'with';
+
+@Component({
+  selector: 'app-contextual-biasing-demo',
+  templateUrl: './contextual-biasing-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ContextualBiasingDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'contextual-biasing')!;
+
+  phrases: BiasPhrase[] = [
+    { phrase: 'TinyGemma', boost: 3.0 },
+    { phrase: 'WebNN', boost: 3.0 },
+    { phrase: 'Gemma Nano', boost: 2.0 },
+    { phrase: 'Axon', boost: 2.0 },
+    { phrase: 'Chrome Canary', boost: 2.0 }
+  ];
+
+  suggestedSentence = 'Add TinyGemma and WebNN benchmarks to the Axon suite in Chrome Canary.';
+
+  readonly modes: BiasMode[] = ['without', 'with'];
+  transcripts: Record<BiasMode, string> = { without: '', with: '' };
+  interim = '';
+  activeMode: BiasMode | null = null;
+  biasingSupported = false;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkSpeechAvailability({ quality: 'dictation' });
+    this.biasingSupported = this.webSpeech.supportsContextualBiasing();
+  }
+
+  addPhrase() {
+    this.phrases.push({ phrase: '', boost: 2.0 });
+  }
+
+  removePhrase(index: number) {
+    if (this.phrases.length > 1) this.phrases.splice(index, 1);
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  get validPhrases(): BiasPhrase[] {
+    return this.phrases.filter(p => p.phrase.trim().length > 0);
+  }
+
+  record(mode: BiasMode) {
+    if (this.activeMode || this.speechStatus !== 'available') return;
+
+    this.errorMessage = '';
+    this.transcripts[mode] = '';
+    this.interim = '';
+
+    try {
+      this.recognition = this.webSpeech.createRecognizer({
+        quality: 'dictation',
+        continuous: false,
+        interimResults: true,
+        phrases: mode === 'with' ? this.validPhrases : undefined
+      });
+    } catch (e: any) {
+      this.errorMessage = e.message;
+      return;
+    }
+
+    const r = this.recognition;
+    this.activeMode = mode;
+    this.isListening = true;
+
+    r.onresult = (event: any) => this.ngZone.run(() => {
+      let finalText = '';
+      let interim = '';
+      for (let i = 0; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) finalText += transcript + ' ';
+        else interim += transcript;
+      }
+      this.transcripts[mode] = finalText.trim();
+      this.interim = interim;
+    });
+
+    r.onerror = (event: any) => this.ngZone.run(() => {
+      this.errorMessage = event.error === 'not-allowed'
+        ? 'Microphone access was denied. Allow the mic to record.'
+        : `Recognition error: ${event.error}`;
+    });
+
+    r.onend = () => this.ngZone.run(() => {
+      this.activeMode = null;
+      this.isListening = false;
+      this.interim = '';
+      this.recognition = null;
+    });
+
+    r.start();
+  }
+
+  stop() {
+    this.stopRecognition();
+  }
+
+  termFound(mode: BiasMode, phrase: string): boolean {
+    return this.transcripts[mode].toLowerCase().includes(phrase.trim().toLowerCase());
+  }
+
+  /** Splits a transcript into segments so boosted terms can be highlighted inline. */
+  highlight(mode: BiasMode): TranscriptSegment[] {
+    const transcript = this.transcripts[mode];
+    if (!transcript) return [];
+    const terms = this.validPhrases.map(p => p.phrase.trim()).filter(Boolean);
+    if (terms.length === 0) return [{ text: transcript, hit: false }];
+
+    const escaped = terms.map(t => t.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+    const parts = transcript.split(new RegExp(`(${escaped.join('|')})`, 'gi'));
+    const lowered = new Set(terms.map(t => t.toLowerCase()));
+    return parts.filter(p => p.length > 0).map(part => ({ text: part, hit: lowered.has(part.toLowerCase()) }));
+  }
+
+  hitCount(mode: BiasMode): number {
+    return this.validPhrases.filter(p => this.termFound(mode, p.phrase)).length;
+  }
+
+  get bothRecorded(): boolean {
+    return !!this.transcripts.without && !!this.transcripts.with;
+  }
+
+  get dynamicCodeSnippet(): string {
+    const phraseLines = this.validPhrases
+      .map(p => `recognition.phrases.push(new SpeechRecognitionPhrase(${JSON.stringify(p.phrase)}, ${p.boost.toFixed(1)}));`)
+      .join('\n');
+    return `const options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+
+const recognition = new SpeechRecognition();
+recognition.options = options;
+recognition.interimResults = true;
+
+// Contextual biasing (explainer: contextual-biasing):
+// boost domain terms the base model would otherwise mangle
+${phraseLines}
+
+recognition.onresult = (event) => {
+  // Try saying: "${this.suggestedSentence}"
+  console.log(event.results[0][0].transcript);
+};
+
+recognition.start();`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/live-translated-captions-demo.component.html
+++ b/webapp/src/app/pages/demos/features/live-translated-captions-demo.component.html
@@ -1,0 +1,132 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [showInstall]="true"
+      [isInstalling]="isInstalling"
+      (install)="installSpeechModel({ lang: spokenLang, quality: 'dictation' })"
+      unavailableHint="<span class='font-semibold'>An API needed for live captions is unavailable.</span> On-device speech needs a recent Chrome build; the Translator and Language Detector need their models available on this device.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Controls -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-4">
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">I speak</span>
+        <select [(ngModel)]="spokenLang" (ngModelChange)="onSpokenLangChanged()"
+                [disabled]="isListening"
+                class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 outline-none cursor-pointer">
+          @for (lang of spokenLanguages; track lang.code) {
+            <option [value]="lang.code">{{ lang.label }}</option>
+          }
+        </select>
+      </div>
+      <i class="bi bi-arrow-right text-slate-300 dark:text-zinc-600"></i>
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">Caption in</span>
+        <select [(ngModel)]="targetLang"
+                [disabled]="isListening"
+                class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 outline-none cursor-pointer">
+          @for (lang of targetLanguages; track lang.code) {
+            <option [value]="lang.code">{{ lang.label }}</option>
+          }
+        </select>
+      </div>
+
+      <div class="flex-grow"></div>
+
+      @if (isListening) {
+        <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                (click)="stop()">
+          <span class="w-2 h-2 rounded-full bg-white animate-pulse"></span> Stop Captions
+        </button>
+      } @else {
+        <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                [disabled]="speechStatus !== 'available'"
+                (click)="start()">
+          <i class="bi bi-mic-fill"></i> Start Captions
+        </button>
+      }
+    </div>
+
+    <!-- Caption cinema -->
+    <div class="bg-[#101014] rounded-3xl shadow-xl border border-zinc-800 overflow-hidden">
+      <div class="px-5 py-3 border-b border-zinc-800 flex items-center justify-between">
+        <span class="text-xs font-bold text-zinc-500 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-badge-cc"></i> Live Captions
+        </span>
+        <div class="flex items-center gap-3">
+          @if (lastDetected) {
+            <span class="text-[10px] font-semibold px-2 py-0.5 rounded bg-zinc-800 text-zinc-400">
+              detected: {{ languageLabel(lastDetected.language) }} ({{ (lastDetected.confidence * 100).toFixed(0) }}%)
+            </span>
+          }
+          @if (isListening) {
+            <span class="flex items-center gap-1.5 text-[10px] font-bold text-red-400 uppercase tracking-wider">
+              <span class="w-1.5 h-1.5 rounded-full bg-red-500 animate-pulse"></span> Live
+            </span>
+          }
+        </div>
+      </div>
+
+      <div class="p-6 md:p-8 min-h-[260px] flex flex-col justify-end gap-4">
+        @if (segments.length === 0 && !interim) {
+          <p class="text-zinc-600 text-center font-light m-auto">
+            {{ isListening ? 'Listening — start speaking...' : 'Captions will appear here, in both languages, as you speak.' }}
+          </p>
+        }
+
+        @for (segment of segments.slice(-3); track $index) {
+          <div class="flex flex-col gap-1">
+            <p class="m-0 text-zinc-400 text-base leading-snug">{{ segment.original }}</p>
+            <div class="flex items-baseline gap-2">
+              <p class="m-0 text-white text-xl font-medium leading-snug">
+                @if (segment.translated !== null) {
+                  {{ segment.translated }}
+                } @else {
+                  <span class="text-zinc-600 italic text-base">translating…</span>
+                }
+              </p>
+              @if (segment.translateMs !== null && segment.translateMs > 0) {
+                <span class="text-[9px] font-mono text-zinc-600 shrink-0">{{ segment.translateMs }}ms</span>
+              }
+            </div>
+          </div>
+        }
+
+        @if (interim) {
+          <p class="m-0 text-zinc-500 italic text-base leading-snug">{{ interim }}</p>
+        }
+      </div>
+    </div>
+
+    <!-- Full transcript -->
+    @if (segments.length > 3) {
+      <div class="mt-6 bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Full Session Transcript</span>
+        </div>
+        <div class="p-5 flex flex-col gap-3 max-h-[300px] overflow-y-auto">
+          @for (segment of segments; track $index) {
+            <div class="grid grid-cols-1 md:grid-cols-2 gap-2 text-sm border-b border-slate-100 dark:border-zinc-800 pb-2.5">
+              <span class="text-slate-500 dark:text-slate-400">{{ segment.original }}</span>
+              <span class="text-slate-800 dark:text-slate-200">{{ segment.translated ?? '…' }}</span>
+            </div>
+          }
+        </div>
+      </div>
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/live-translated-captions-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/live-translated-captions-demo.component.ts
@@ -1,0 +1,245 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageDetector: any;
+declare const Translator: any;
+
+interface CaptionSegment {
+  original: string;
+  translated: string | null;
+  detectedLanguage: string | null;
+  translateMs: number | null;
+}
+
+const SPOKEN_LANGUAGES = [
+  { code: 'en-US', label: 'English (US)' },
+  { code: 'fr-FR', label: 'French' },
+  { code: 'es-ES', label: 'Spanish' },
+  { code: 'de-DE', label: 'German' },
+  { code: 'ja-JP', label: 'Japanese' }
+];
+
+const TARGET_LANGUAGES = [
+  { code: 'fr', label: 'French' },
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'de', label: 'German' },
+  { code: 'ja', label: 'Japanese' }
+];
+
+@Component({
+  selector: 'app-live-translated-captions-demo',
+  templateUrl: './live-translated-captions-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class LiveTranslatedCaptionsDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'live-translated-captions')!;
+
+  spokenLanguages = SPOKEN_LANGUAGES;
+  targetLanguages = TARGET_LANGUAGES;
+  spokenLang = 'en-US';
+  targetLang = 'fr';
+
+  detectorStatus = 'loading...';
+  translatorStatus = 'loading...';
+
+  segments: CaptionSegment[] = [];
+  interim = '';
+  lastDetected: { language: string; confidence: number } | null = null;
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+  private processedFinalCount = 0;
+  private translationQueue: Promise<void> = Promise.resolve();
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    await this.checkSpeechAvailability({ lang: this.spokenLang, quality: 'dictation' });
+
+    try {
+      this.detectorStatus = 'LanguageDetector' in self ? await LanguageDetector.availability() : 'unavailable';
+    } catch { this.detectorStatus = 'unavailable'; }
+
+    try {
+      this.translatorStatus = 'Translator' in self
+        ? await Translator.availability({ sourceLanguage: this.baseLang(this.spokenLang), targetLanguage: this.targetLang })
+        : 'unavailable';
+    } catch { this.translatorStatus = 'unavailable'; }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Web Speech (on-device)', status: this.speechStatus },
+      { name: 'Language Detector', status: this.detectorStatus },
+      { name: 'Translator', status: this.translatorStatus }
+    ];
+  }
+
+  private baseLang(locale: string): string {
+    return locale.split('-')[0];
+  }
+
+  async onSpokenLangChanged() {
+    await this.checkSpeechAvailability({ lang: this.spokenLang, quality: 'dictation' });
+  }
+
+  async start() {
+    if (this.isListening || this.speechStatus !== 'available') return;
+
+    this.errorMessage = '';
+    this.segments = [];
+    this.interim = '';
+    this.lastDetected = null;
+    this.processedFinalCount = 0;
+
+    try {
+      if (!this.detector && this.detectorStatus !== 'unavailable') {
+        this.detector = await LanguageDetector.create();
+      }
+      this.recognition = this.webSpeech.createRecognizer({
+        lang: this.spokenLang,
+        quality: 'dictation',
+        continuous: true,
+        interimResults: true
+      });
+    } catch (e: any) {
+      this.errorMessage = e.message;
+      return;
+    }
+
+    const r = this.recognition;
+    this.isListening = true;
+
+    r.onresult = (event: any) => this.ngZone.run(() => {
+      let interim = '';
+      for (let i = 0; i < event.results.length; i++) {
+        const result = event.results[i];
+        if (!result.isFinal) {
+          interim += result[0].transcript;
+        } else if (i >= this.processedFinalCount) {
+          // A newly finalized segment: caption it, then translate it in order.
+          this.processedFinalCount = i + 1;
+          const segment: CaptionSegment = {
+            original: result[0].transcript.trim(),
+            translated: null,
+            detectedLanguage: null,
+            translateMs: null
+          };
+          if (segment.original) {
+            this.segments.push(segment);
+            this.translationQueue = this.translationQueue.then(() => this.translateSegment(segment));
+          }
+        }
+      }
+      this.interim = interim;
+    });
+
+    r.onerror = (event: any) => this.ngZone.run(() => {
+      this.errorMessage = event.error === 'not-allowed'
+        ? 'Microphone access was denied. Allow the mic to start captioning.'
+        : `Recognition error: ${event.error}`;
+    });
+
+    r.onend = () => this.ngZone.run(() => {
+      this.isListening = false;
+      this.interim = '';
+      this.recognition = null;
+    });
+
+    r.start();
+  }
+
+  stop() {
+    this.stopRecognition();
+  }
+
+  private async translateSegment(segment: CaptionSegment) {
+    const start = performance.now();
+    try {
+      let sourceLanguage = this.baseLang(this.spokenLang);
+
+      if (this.detector) {
+        const results = await this.detector.detect(segment.original);
+        if (results?.length && results[0].detectedLanguage !== 'und') {
+          sourceLanguage = results[0].detectedLanguage;
+          this.ngZone.run(() => {
+            segment.detectedLanguage = sourceLanguage;
+            this.lastDetected = { language: sourceLanguage, confidence: results[0].confidence };
+          });
+        }
+      }
+
+      if (sourceLanguage === this.targetLang) {
+        this.ngZone.run(() => {
+          segment.translated = segment.original;
+          segment.translateMs = 0;
+        });
+        return;
+      }
+
+      const key = `${sourceLanguage}->${this.targetLang}`;
+      if (!this.translators.has(key)) {
+        this.translators.set(key, await Translator.create({
+          sourceLanguage,
+          targetLanguage: this.targetLang
+        }));
+      }
+      const translated = await this.translators.get(key).translate(segment.original);
+      this.ngZone.run(() => {
+        segment.translated = translated;
+        segment.translateMs = Math.round(performance.now() - start);
+      });
+    } catch (e: any) {
+      this.ngZone.run(() => {
+        segment.translated = `[translation failed: ${e.message}]`;
+      });
+    }
+  }
+
+  languageLabel(code: string | null): string {
+    if (!code) return '';
+    return this.targetLanguages.find(l => l.code === code)?.label ?? code;
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `// On-device recognition (explainer: on-device-speech-recognition)
+const options = { langs: ["${this.spokenLang}"], processLocally: true, quality: "dictation" };
+if (await SpeechRecognition.available(options) === "downloadable") {
+  await SpeechRecognition.install(options);
+}
+
+const recognition = new SpeechRecognition();
+recognition.options = options;
+recognition.continuous = true;
+recognition.interimResults = true;
+
+const detector = await LanguageDetector.create();
+const translators = new Map(); // cached per language pair
+
+recognition.onresult = async (event) => {
+  for (let i = event.resultIndex; i < event.results.length; i++) {
+    const result = event.results[i];
+    showCaption(result[0].transcript, result.isFinal);
+    if (!result.isFinal) continue;
+
+    // New final segment: detect its language, then translate it
+    const [{ detectedLanguage }] = await detector.detect(result[0].transcript);
+    const key = detectedLanguage + "->${this.targetLang}";
+    if (!translators.has(key)) {
+      translators.set(key, await Translator.create({
+        sourceLanguage: detectedLanguage, targetLanguage: "${this.targetLang}"
+      }));
+    }
+    showTranslatedCaption(await translators.get(key).translate(result[0].transcript));
+  }
+};
+
+recognition.start();`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/polyglot-chat-demo.component.html
+++ b/webapp/src/app/pages/demos/features/polyglot-chat-demo.component.html
@@ -1,0 +1,107 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>Translation is unavailable.</span> The Translator and Language Detector models must be available on this device — language pairs download on first use.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      @for (pane of panes; track pane.speaker; let paneIdx = $index) {
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[480px]">
+
+          <!-- Pane header -->
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex items-center gap-3">
+            <span class="text-2xl">{{ pane.avatar }}</span>
+            <div class="flex-grow">
+              <div class="text-sm font-bold text-slate-800 dark:text-slate-200">{{ pane.speaker }}</div>
+              <div class="text-[10px] text-slate-400 dark:text-slate-500 uppercase tracking-wider font-semibold">reads & writes</div>
+            </div>
+            <select [(ngModel)]="pane.lang"
+                    class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-1.5 text-sm font-semibold text-slate-700 dark:text-slate-300 outline-none cursor-pointer">
+              @for (lang of languages; track lang.code) {
+                <option [value]="lang.code">{{ lang.label }}</option>
+              }
+            </select>
+          </div>
+
+          <!-- Messages, rendered in THIS pane's language -->
+          <div class="flex-grow p-4 flex flex-col gap-2.5 overflow-y-auto max-h-[340px]">
+            @if (messages.length === 0) {
+              <p class="text-xs text-slate-400 dark:text-slate-500 m-auto text-center font-light px-6">
+                Each person writes in their own language and reads the whole conversation in it too.
+              </p>
+            }
+            @for (message of messages; track $index) {
+              <div class="max-w-[85%] flex flex-col gap-0.5"
+                   [ngClass]="message.paneIndex === paneIdx ? 'self-end items-end' : 'self-start items-start'">
+                <div class="px-3.5 py-2 rounded-2xl text-sm leading-snug"
+                     [ngClass]="message.paneIndex === paneIdx
+                       ? 'bg-indigo-600 text-white rounded-br-md'
+                       : 'bg-slate-100 dark:bg-zinc-800 text-slate-800 dark:text-slate-200 rounded-bl-md'">
+                  @if (message.isTranslating && message.paneIndex !== paneIdx) {
+                    <i class="bi bi-three-dots animate-pulse"></i>
+                  } @else if (message.showOriginal && message.paneIndex !== paneIdx) {
+                    {{ message.original }}
+                  } @else {
+                    {{ displayText(message, pane) }}
+                  }
+                </div>
+                @if (message.paneIndex !== paneIdx && isTranslatedFor(message, pane) && !message.isTranslating) {
+                  <button class="text-[9px] text-slate-400 dark:text-slate-500 hover:text-indigo-500 bg-transparent border-none px-1 transition-colors"
+                          (click)="message.showOriginal = !message.showOriginal">
+                    @if (message.showOriginal) {
+                      show translation
+                    } @else {
+                      translated from {{ languageLabel(message.detectedLanguage) || 'auto' }}
+                      @if (message.detectedConfidence !== null) {
+                        ({{ (message.detectedConfidence * 100).toFixed(0) }}%)
+                      }
+                      — show original
+                    }
+                  </button>
+                }
+              </div>
+            }
+          </div>
+
+          <!-- Composer -->
+          <div class="p-4 border-t border-slate-100 dark:border-zinc-700/50">
+            <div class="flex gap-2">
+              <input type="text"
+                     class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-4 py-2.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40"
+                     [(ngModel)]="pane.draft"
+                     (keydown.enter)="send(pane)"
+                     placeholder="Write in {{ languageLabel(pane.lang) }}..." />
+              <button class="w-10 h-10 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white shadow-md transition-all active:scale-95 disabled:opacity-50 border-none flex items-center justify-center"
+                      [disabled]="!pane.draft.trim()"
+                      (click)="send(pane)">
+                <i class="bi bi-send"></i>
+              </button>
+            </div>
+            <div class="flex flex-wrap gap-1.5 mt-2.5">
+              @for (starter of pane.starters; track starter) {
+                <button class="px-2.5 py-1 rounded-full text-[11px] font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-500 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                        (click)="useStarter(pane, starter)">
+                  {{ starter }}
+                </button>
+              }
+            </div>
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/polyglot-chat-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/polyglot-chat-demo.component.ts
@@ -1,0 +1,185 @@
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageDetector: any;
+declare const Translator: any;
+
+interface ChatMessage {
+  paneIndex: number;
+  original: string;
+  detectedLanguage: string | null;
+  detectedConfidence: number | null;
+  translations: Record<string, string>;
+  showOriginal: boolean;
+  isTranslating: boolean;
+  translateMs: number | null;
+}
+
+interface ChatPane {
+  speaker: string;
+  avatar: string;
+  lang: string;
+  draft: string;
+  starters: string[];
+}
+
+const LANGUAGES = [
+  { code: 'en', label: 'English' },
+  { code: 'fr', label: 'French' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'de', label: 'German' },
+  { code: 'ja', label: 'Japanese' }
+];
+
+@Component({
+  selector: 'app-polyglot-chat-demo',
+  templateUrl: './polyglot-chat-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class PolyglotChatDemoComponent extends BasePage implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'polyglot-chat')!;
+
+  languages = LANGUAGES;
+
+  panes: ChatPane[] = [
+    {
+      speaker: 'Amélie',
+      avatar: '👩🏻‍🎨',
+      lang: 'fr',
+      draft: '',
+      starters: ['Bonjour ! Comment ça va aujourd\'hui ?', 'On se voit toujours demain à midi ?', 'J\'ai adoré les photos de ton voyage !']
+    },
+    {
+      speaker: 'Sam',
+      avatar: '🧑🏽‍💻',
+      lang: 'en',
+      draft: '',
+      starters: ['Hey! All good here, how about you?', 'Yes, noon works perfectly for me.', 'Thanks! The mountains were incredible.']
+    }
+  ];
+
+  messages: ChatMessage[] = [];
+
+  detectorStatus = 'loading...';
+  translatorStatus = 'loading...';
+  errorMessage = '';
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.detectorStatus = 'LanguageDetector' in self ? await LanguageDetector.availability() : 'unavailable';
+    } catch { this.detectorStatus = 'unavailable'; }
+
+    try {
+      this.translatorStatus = 'Translator' in self
+        ? await Translator.availability({ sourceLanguage: this.panes[0].lang, targetLanguage: this.panes[1].lang })
+        : 'unavailable';
+    } catch { this.translatorStatus = 'unavailable'; }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Language Detector', status: this.detectorStatus },
+      { name: 'Translator', status: this.translatorStatus }
+    ];
+  }
+
+  languageLabel(code: string | null): string {
+    if (!code) return '';
+    return this.languages.find(l => l.code === code)?.label ?? code;
+  }
+
+  useStarter(pane: ChatPane, starter: string) {
+    pane.draft = starter;
+    this.send(pane);
+  }
+
+  async send(pane: ChatPane) {
+    const text = pane.draft.trim();
+    if (!text) return;
+
+    const paneIndex = this.panes.indexOf(pane);
+    const message: ChatMessage = {
+      paneIndex,
+      original: text,
+      detectedLanguage: null,
+      detectedConfidence: null,
+      translations: {},
+      showOriginal: false,
+      isTranslating: true,
+      translateMs: null
+    };
+    this.messages.push(message);
+    pane.draft = '';
+    this.errorMessage = '';
+
+    const start = performance.now();
+    try {
+      // 1. Detect what was actually typed (senders don't always use "their" language)
+      let sourceLanguage = pane.lang;
+      if (this.detectorStatus !== 'unavailable') {
+        if (!this.detector) this.detector = await LanguageDetector.create();
+        const results = await this.detector.detect(text);
+        if (results?.length && results[0].detectedLanguage !== 'und') {
+          sourceLanguage = results[0].detectedLanguage;
+          message.detectedLanguage = sourceLanguage;
+          message.detectedConfidence = results[0].confidence;
+        }
+      }
+
+      // 2. Translate for every pane that reads a different language
+      for (const target of this.panes) {
+        if (target.lang === sourceLanguage) {
+          message.translations[target.lang] = text;
+          continue;
+        }
+        const key = `${sourceLanguage}->${target.lang}`;
+        if (!this.translators.has(key)) {
+          this.translators.set(key, await Translator.create({
+            sourceLanguage,
+            targetLanguage: target.lang
+          }));
+        }
+        message.translations[target.lang] = await this.translators.get(key).translate(text);
+      }
+      message.translateMs = Math.round(performance.now() - start);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Translation failed — is this language pair available on this device?';
+      message.translations[pane.lang] = text;
+    } finally {
+      message.isTranslating = false;
+    }
+  }
+
+  /** What a given pane displays for a message: its own language when available. */
+  displayText(message: ChatMessage, pane: ChatPane): string {
+    return message.translations[pane.lang] ?? message.original;
+  }
+
+  isTranslatedFor(message: ChatMessage, pane: ChatPane): boolean {
+    const shown = message.translations[pane.lang];
+    return shown !== undefined && shown !== message.original;
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/proofreader-inline-demo.component.html
+++ b/webapp/src/app/pages/demos/features/proofreader-inline-demo.component.html
@@ -1,0 +1,183 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Proofreader', status: proofreaderStatus }]"
+      unavailableHint="<span class='font-semibold'>The Proofreader API is not exposed in this browser.</span> Enable <code class='font-mono text-xs'>chrome://flags/#proofreader-api</code> in a recent Chrome build, then restart.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Editor -->
+      <div class="lg:flex-[3] w-full flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center flex-wrap gap-2">
+            <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-patch-check text-sky-500"></i> Your Draft
+            </span>
+            <div class="flex items-center gap-3">
+              @if (proofreadTimeMs !== null && hasResult) {
+                <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                  proofread in {{ proofreadTimeMs }}ms
+                </span>
+              }
+              <button class="flex items-center gap-2 px-5 py-2 rounded-full bg-sky-600 hover:bg-sky-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                      [disabled]="isProofreading || !text.trim() || proofreaderStatus === 'unavailable'"
+                      (click)="proofread()">
+                @if (isProofreading) {
+                  <i class="bi bi-arrow-repeat animate-spin"></i> Proofreading...
+                } @else {
+                  <i class="bi bi-spellcheck"></i> Proofread
+                }
+              </button>
+            </div>
+          </div>
+
+          <!-- Annotated view OR editable textarea -->
+          @if (hasResult && corrections.length > 0) {
+            <div class="p-5 text-lg leading-relaxed text-slate-800 dark:text-slate-200 font-serif">
+              @for (segment of segments; track $index) {
+                @if (segment.correction) {
+                  <button class="bg-transparent border-none p-0 font-serif text-lg cursor-pointer transition-colors rounded-sm"
+                          [ngClass]="selectedIndex === segment.correctionIndex
+                            ? 'bg-red-100 dark:bg-red-900/40 text-red-800 dark:text-red-300'
+                            : 'text-red-700 dark:text-red-400 hover:bg-red-50 dark:hover:bg-red-900/20'"
+                          style="text-decoration: underline wavy #ef4444 1.5px; text-underline-offset: 4px;"
+                          (click)="select(segment.correctionIndex)">
+                    {{ segment.text }}
+                  </button>
+                } @else {
+                  <span>{{ segment.text }}</span>
+                }
+              }
+            </div>
+            <div class="px-5 pb-4 flex items-center justify-between flex-wrap gap-2">
+              <button class="text-xs font-medium text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 bg-transparent border-none transition-colors"
+                      (click)="onTextChanged()">
+                <i class="bi bi-pencil"></i> Edit text
+              </button>
+              <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="acceptAll()">
+                <i class="bi bi-check2-all"></i> Accept all {{ corrections.length }}
+              </button>
+            </div>
+          } @else if (hasResult && corrections.length === 0) {
+            <div class="p-5">
+              <div class="bg-emerald-50 border border-emerald-200 dark:bg-emerald-900/10 dark:border-emerald-900/30 rounded-2xl p-4 flex items-center gap-2 text-sm text-emerald-800 dark:text-emerald-300">
+                <i class="bi bi-check-circle-fill text-emerald-500"></i>
+                No errors found{{ acceptedCount > 0 ? ' — ' + acceptedCount + ' corrections accepted this session' : '' }}.
+              </div>
+              <div class="mt-4 text-lg leading-relaxed text-slate-800 dark:text-slate-200 font-serif">{{ text }}</div>
+              <button class="mt-3 text-xs font-medium text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 bg-transparent border-none transition-colors"
+                      (click)="onTextChanged()">
+                <i class="bi bi-pencil"></i> Edit text
+              </button>
+            </div>
+          } @else {
+            <textarea
+              class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-800 dark:text-slate-200 resize-none p-5 leading-relaxed text-lg font-serif min-h-[180px]"
+              [(ngModel)]="text"
+              (ngModelChange)="onTextChanged()"
+              placeholder="Type or paste text with errors..."></textarea>
+          }
+        </div>
+
+        <!-- Options -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl shadow-sm border border-slate-200 dark:border-zinc-700 px-5 py-4 flex flex-wrap items-center gap-x-6 gap-y-2">
+          <label class="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400 cursor-pointer">
+            <input type="checkbox" class="accent-sky-600" [(ngModel)]="includeTypes" (ngModelChange)="onOptionsChanged()" />
+            <code class="text-xs font-mono">includeCorrectionTypes</code>
+          </label>
+          <label class="flex items-center gap-2 text-sm text-slate-600 dark:text-slate-400 cursor-pointer">
+            <input type="checkbox" class="accent-sky-600" [(ngModel)]="includeExplanations" (ngModelChange)="onOptionsChanged()" />
+            <code class="text-xs font-mono">includeCorrectionExplanations</code>
+          </label>
+          @if (hasResult && !hasStructuredMetadata && corrections.length > 0) {
+            <span class="text-[11px] text-amber-600 dark:text-amber-400"><i class="bi bi-info-circle"></i> Chrome's current build doesn't return types/explanations yet — the indices and corrections below are live.</span>
+          }
+        </div>
+      </div>
+
+      <!-- Correction inspector -->
+      <div class="lg:flex-[2] w-full flex flex-col gap-4">
+        @if (hasResult && corrections.length > 0) {
+          <!-- Summary chips -->
+          <div class="flex flex-wrap gap-2">
+            <span class="px-3 py-1.5 rounded-full text-xs font-bold bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400">
+              {{ corrections.length }} {{ corrections.length === 1 ? 'issue' : 'issues' }}
+            </span>
+            @for (entry of typeCounts; track entry.type) {
+              @if (entry.type !== 'unlabeled') {
+                <span class="px-3 py-1.5 rounded-full text-xs font-semibold {{ typeChipClass(entry.type) }}">
+                  {{ entry.type }} × {{ entry.count }}
+                </span>
+              }
+            }
+          </div>
+
+          <!-- Correction list -->
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col max-h-[480px]">
+            <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+              <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Corrections</span>
+            </div>
+            <div class="overflow-y-auto p-3 flex flex-col gap-2">
+              @for (correction of corrections; track $index) {
+                <div class="rounded-xl border p-3.5 cursor-pointer transition-all"
+                     [ngClass]="selectedIndex === $index
+                       ? 'border-sky-300 dark:border-sky-700 bg-sky-50/60 dark:bg-sky-900/15'
+                       : 'border-slate-200 dark:border-zinc-700 bg-slate-50/40 dark:bg-[#161616]/40 hover:border-slate-300 dark:hover:border-zinc-600'"
+                     (click)="select($index)">
+                  <div class="flex items-center gap-2 flex-wrap">
+                    <span class="text-sm font-mono text-red-600 dark:text-red-400 line-through">{{ text.slice(correction.startIndex, correction.endIndex) }}</span>
+                    <i class="bi bi-arrow-right text-slate-300 dark:text-zinc-600 text-xs"></i>
+                    <span class="text-sm font-mono font-semibold text-emerald-700 dark:text-emerald-400">{{ correction.correction }}</span>
+                    <div class="flex-grow"></div>
+                    <button class="px-3 py-1 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white text-[11px] font-semibold shadow-sm transition-all active:scale-95 border-none"
+                            (click)="$event.stopPropagation(); acceptCorrection($index)">
+                      Accept
+                    </button>
+                  </div>
+                  @if (correction.types.length > 0 || correction.explanation) {
+                    <div class="mt-2 flex flex-col gap-1.5">
+                      @if (correction.types.length > 0) {
+                        <div class="flex gap-1.5">
+                          @for (type of correction.types; track type) {
+                            <span class="px-2 py-0.5 rounded text-[10px] font-bold uppercase tracking-wider {{ typeChipClass(type) }}">{{ type }}</span>
+                          }
+                        </div>
+                      }
+                      @if (correction.explanation) {
+                        <p class="text-xs text-slate-500 dark:text-slate-400 m-0 leading-relaxed">{{ correction.explanation }}</p>
+                      }
+                    </div>
+                  }
+                  <div class="text-[10px] font-mono text-slate-300 dark:text-zinc-600 mt-1.5">chars {{ correction.startIndex }}–{{ correction.endIndex }}</div>
+                </div>
+              }
+            </div>
+          </div>
+        } @else {
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-8 text-center">
+            <i class="bi bi-patch-check text-4xl text-slate-200 dark:text-zinc-700"></i>
+            <p class="text-sm text-slate-400 dark:text-slate-500 mt-3 font-light m-0">
+              Run the proofreader to see structured corrections — each with its exact character range, suggested fix, error label, and explanation.
+            </p>
+          </div>
+        }
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/proofreader-inline-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/proofreader-inline-demo.component.ts
@@ -1,0 +1,227 @@
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Proofreader: any;
+
+interface ProofCorrection {
+  startIndex: number;
+  endIndex: number;
+  correction: string;
+  types: string[];
+  explanation: string | null;
+}
+
+interface TextSegment {
+  text: string;
+  correction: ProofCorrection | null;
+  correctionIndex: number;
+}
+
+const SAMPLE_TEXT =
+  'I has went to the libary yesterday, but they was allready closed. ' +
+  'Me and him decided to goes back tommorow morning, weather or not it rains. ' +
+  'Their going to be so much books to chose from!';
+
+@Component({
+  selector: 'app-proofreader-inline-demo',
+  templateUrl: './proofreader-inline-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ProofreaderInlineDemoComponent extends BasePage implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'proofreader-inline')!;
+
+  text = SAMPLE_TEXT;
+  proofreaderStatus = 'loading...';
+  errorMessage = '';
+
+  includeTypes = true;
+  includeExplanations = true;
+
+  isProofreading = false;
+  hasResult = false;
+  corrections: ProofCorrection[] = [];
+  segments: TextSegment[] = [];
+  correctedInput = '';
+  selectedIndex: number | null = null;
+  proofreadTimeMs: number | null = null;
+  acceptedCount = 0;
+
+  private proofreader: any = null;
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.proofreaderStatus = 'Proofreader' in self ? await Proofreader.availability() : 'unavailable';
+    } catch {
+      this.proofreaderStatus = 'unavailable';
+    }
+  }
+
+  get selectedCorrection(): ProofCorrection | null {
+    return this.selectedIndex !== null ? this.corrections[this.selectedIndex] ?? null : null;
+  }
+
+  get typeCounts(): { type: string; count: number }[] {
+    const counts = new Map<string, number>();
+    for (const correction of this.corrections) {
+      for (const type of correction.types.length ? correction.types : ['unlabeled']) {
+        counts.set(type, (counts.get(type) ?? 0) + 1);
+      }
+    }
+    return [...counts.entries()].map(([type, count]) => ({ type, count })).sort((a, b) => b.count - a.count);
+  }
+
+  get hasStructuredMetadata(): boolean {
+    return this.corrections.some(c => c.types.length > 0 || c.explanation);
+  }
+
+  onTextChanged() {
+    this.hasResult = false;
+    this.corrections = [];
+    this.segments = [];
+    this.selectedIndex = null;
+  }
+
+  async onOptionsChanged() {
+    // Options are fixed at create() time — a new proofreader is needed.
+    this.proofreader?.destroy?.();
+    this.proofreader = null;
+    if (this.hasResult) await this.proofread();
+  }
+
+  async proofread() {
+    const input = this.text;
+    if (!input.trim() || this.isProofreading) return;
+
+    this.isProofreading = true;
+    this.errorMessage = '';
+    this.selectedIndex = null;
+    const start = performance.now();
+
+    try {
+      if (!this.proofreader) {
+        this.proofreader = await Proofreader.create({
+          expectedInputLanguages: ['en'],
+          includeCorrectionTypes: this.includeTypes,
+          includeCorrectionExplanations: this.includeExplanations
+        });
+      }
+
+      const result = await this.proofreader.proofread(input);
+      this.proofreadTimeMs = Math.round(performance.now() - start);
+
+      this.correctedInput = result.correctedInput ?? result.correction ?? input;
+      this.corrections = (result.corrections ?? []).map((c: any) => ({
+        startIndex: c.startIndex,
+        endIndex: c.endIndex,
+        correction: c.correction ?? '',
+        types: Array.isArray(c.types) ? c.types : (c.type ? [c.type] : []),
+        explanation: c.explanation ?? null
+      })).sort((a: ProofCorrection, b: ProofCorrection) => a.startIndex - b.startIndex);
+
+      this.segments = this.buildSegments(input, this.corrections);
+      this.hasResult = true;
+      if (this.corrections.length > 0) this.selectedIndex = 0;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Proofreading failed.';
+    } finally {
+      this.isProofreading = false;
+    }
+  }
+
+  /** Splits the original text into plain and underlined (correction) segments. */
+  private buildSegments(input: string, corrections: ProofCorrection[]): TextSegment[] {
+    const segments: TextSegment[] = [];
+    let cursor = 0;
+    corrections.forEach((correction, index) => {
+      if (correction.startIndex > cursor) {
+        segments.push({ text: input.slice(cursor, correction.startIndex), correction: null, correctionIndex: -1 });
+      }
+      segments.push({
+        text: input.slice(correction.startIndex, correction.endIndex),
+        correction,
+        correctionIndex: index
+      });
+      cursor = correction.endIndex;
+    });
+    if (cursor < input.length) {
+      segments.push({ text: input.slice(cursor), correction: null, correctionIndex: -1 });
+    }
+    return segments;
+  }
+
+  select(index: number) {
+    this.selectedIndex = index;
+  }
+
+  async acceptCorrection(index: number) {
+    const correction = this.corrections[index];
+    if (!correction) return;
+    this.text = this.text.slice(0, correction.startIndex) + correction.correction + this.text.slice(correction.endIndex);
+    this.acceptedCount++;
+    await this.proofread();
+  }
+
+  async acceptAll() {
+    if (!this.correctedInput) return;
+    this.acceptedCount += this.corrections.length;
+    this.text = this.correctedInput;
+    await this.proofread();
+  }
+
+  typeChipClass(type: string): string {
+    switch (type.toLowerCase()) {
+      case 'spelling': return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
+      case 'grammar': return 'bg-indigo-100 dark:bg-indigo-900/30 text-indigo-700 dark:text-indigo-400';
+      case 'punctuation': return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400';
+      case 'capitalization': return 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400';
+      case 'preposition': return 'bg-violet-100 dark:bg-violet-900/30 text-violet-700 dark:text-violet-400';
+      case 'missing-words': return 'bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400';
+      default: return 'bg-slate-100 dark:bg-zinc-800 text-slate-600 dark:text-slate-400';
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const proofreader = await Proofreader.create({
+  expectedInputLanguages: ["en"],
+  includeCorrectionTypes: ${this.includeTypes},${this.includeTypes ? '        // labels: spelling, grammar, punctuation...' : ''}
+  includeCorrectionExplanations: ${this.includeExplanations}${this.includeExplanations ? ' // plain-language "why" per correction' : ''}
+});
+
+const result = await proofreader.proofread(text);
+
+// The fully corrected string
+console.log(result.correctedInput);
+
+// Structured corrections: indices point into the ORIGINAL text,
+// which is exactly what an inline editor UI needs for underlines
+for (const c of result.corrections) {
+  console.log(
+    text.slice(c.startIndex, c.endIndex), // the error span
+    "→", c.correction,                    // the fix
+    c.types,                              // e.g. ["grammar"]
+    c.explanation                         // e.g. "Subject-verb agreement"
+  );
+}
+
+// Accepting one correction = splicing it into the string
+function accept(c) {
+  return text.slice(0, c.startIndex) + c.correction + text.slice(c.endIndex);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/speak-to-fill-demo.component.html
+++ b/webapp/src/app/pages/demos/features/speak-to-fill-demo.component.html
@@ -1,0 +1,139 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [showInstall]="true"
+      [isInstalling]="isInstalling"
+      (install)="installSpeechModel({ quality: 'dictation' })"
+      unavailableHint="<span class='font-semibold'>An API needed for this demo is unavailable.</span> You can still type an utterance below and use the Prompt API extraction without the microphone.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6">
+
+      <!-- Voice input -->
+      <div class="lg:flex-[2] flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-6 flex flex-col items-center gap-4">
+          @if (isListening) {
+            <button class="w-20 h-20 rounded-full bg-red-600 hover:bg-red-700 text-white text-3xl shadow-lg transition-all active:scale-95 border-none relative"
+                    (click)="cancelListening()">
+              <span class="absolute inset-0 rounded-full bg-red-500/40 animate-ping"></span>
+              <i class="bi bi-stop-fill relative"></i>
+            </button>
+            <p class="text-sm text-slate-500 dark:text-slate-400 m-0 text-center min-h-[40px]">
+              @if (interim) {
+                <span class="italic">"{{ interim }}"</span>
+              } @else {
+                Listening — describe your booking...
+              }
+            </p>
+          } @else {
+            <button class="w-20 h-20 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white text-3xl shadow-lg transition-all active:scale-95 disabled:opacity-40 border-none"
+                    [disabled]="speechStatus !== 'available' || isExtracting"
+                    (click)="listen()">
+              <i class="bi bi-mic-fill"></i>
+            </button>
+            <p class="text-sm text-slate-500 dark:text-slate-400 m-0 text-center min-h-[40px]">
+              @if (transcript) {
+                <span class="text-slate-700 dark:text-slate-300">"{{ transcript }}"</span>
+              } @else {
+                Tap and say something like<br />"Table for four next Friday at seven, outside."
+              }
+            </p>
+          }
+        </div>
+
+        <!-- Typed fallback -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5">
+          <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">No mic? Type the utterance</span>
+          <div class="flex gap-2 mt-2">
+            <input type="text"
+                   class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-4 py-2.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-cyan-500/40"
+                   [(ngModel)]="typedUtterance"
+                   (keydown.enter)="extractTyped()"
+                   placeholder="Book a table for..." />
+            <button class="px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                    [disabled]="!typedUtterance.trim() || isExtracting"
+                    (click)="extractTyped()">
+              Extract
+            </button>
+          </div>
+          <div class="flex flex-col gap-1.5 mt-3">
+            @for (sample of sampleUtterances; track sample) {
+              <button class="text-left px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                      [disabled]="isExtracting"
+                      (click)="useSample(sample)">
+                "{{ sample }}"
+              </button>
+            }
+          </div>
+          <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-2">Utterances refine the form — try the corrections after the first one.</p>
+        </div>
+      </div>
+
+      <!-- The form -->
+      <div class="lg:flex-[3] bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden self-start w-full">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-ui-checks text-cyan-500"></i> Reservation at Chez Nimbus
+          </span>
+          <div class="flex items-center gap-3">
+            @if (isExtracting) {
+              <span class="text-xs font-semibold text-indigo-600 dark:text-indigo-400 flex items-center gap-1.5">
+                <i class="bi bi-arrow-repeat animate-spin"></i> Extracting...
+              </span>
+            }
+            <button class="text-xs font-medium text-slate-400 hover:text-red-500 dark:text-slate-500 dark:hover:text-red-400 bg-transparent border-none transition-colors"
+                    (click)="resetForm()">
+              Reset
+            </button>
+          </div>
+        </div>
+
+        <div class="p-5 grid grid-cols-1 sm:grid-cols-2 gap-4">
+          @for (field of formFields; track field.key) {
+            <div class="flex flex-col gap-1.5 transition-all duration-500 rounded-xl p-3 -m-1"
+                 [ngClass]="{
+                   'bg-emerald-50 dark:bg-emerald-900/15 ring-1 ring-emerald-300 dark:ring-emerald-800': recentlyUpdated.has(field.key),
+                   'sm:col-span-2': field.key === 'specialRequests'
+                 }">
+              <label class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider flex items-center gap-1.5">
+                <i class="bi {{ field.icon }}"></i> {{ field.label }}
+                @if (recentlyUpdated.has(field.key)) {
+                  <span class="text-emerald-600 dark:text-emerald-400 normal-case font-semibold">· just filled</span>
+                }
+              </label>
+              <div class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-xl px-4 py-3 text-sm min-h-[44px]"
+                   [ngClass]="displayValue(field.key) ? 'text-slate-800 dark:text-slate-200 font-medium' : 'text-slate-300 dark:text-zinc-600'">
+                {{ displayValue(field.key) || '—' }}
+              </div>
+            </div>
+          }
+        </div>
+
+        <div class="px-5 pb-5">
+          <button class="w-full flex items-center justify-center gap-2 px-6 py-3 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-40 border-none"
+                  [disabled]="!form.name || !form.date || !form.partySize">
+            <i class="bi bi-check-circle"></i> Confirm Reservation
+          </button>
+          <p class="text-[11px] text-slate-400 dark:text-slate-500 text-center m-0 mt-2">The confirm button unlocks once name, date, and party size are filled.</p>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/speak-to-fill-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/speak-to-fill-demo.component.ts
@@ -1,0 +1,217 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+interface BookingForm {
+  name: string | null;
+  date: string | null;
+  time: string | null;
+  partySize: number | null;
+  seating: 'inside' | 'outside' | null;
+  specialRequests: string | null;
+}
+
+const BOOKING_SCHEMA = {
+  type: 'object',
+  properties: {
+    name: { type: ['string', 'null'] },
+    date: { type: ['string', 'null'] },
+    time: { type: ['string', 'null'] },
+    partySize: { type: ['number', 'null'] },
+    seating: { type: ['string', 'null'], enum: ['inside', 'outside', null] },
+    specialRequests: { type: ['string', 'null'] }
+  },
+  required: ['name', 'date', 'time', 'partySize', 'seating', 'specialRequests'],
+  additionalProperties: false
+};
+
+@Component({
+  selector: 'app-speak-to-fill-demo',
+  templateUrl: './speak-to-fill-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SpeakToFillDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'speak-to-fill')!;
+
+  form: BookingForm = { name: null, date: null, time: null, partySize: null, seating: null, specialRequests: null };
+  recentlyUpdated = new Set<keyof BookingForm>();
+
+  transcript = '';
+  interim = '';
+  typedUtterance = '';
+  isExtracting = false;
+
+  sampleUtterances = [
+    'Book a table for four next Friday at 7 pm, outside if possible, under the name Martin.',
+    'Actually make that six people at 8 o\'clock instead.',
+    'We\'ll need a high chair for a toddler, and my name is spelled M-A-R-T-Y-N.'
+  ];
+
+  private abortListen: (() => void) | null = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkSpeechAvailability({ quality: 'dictation' });
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Web Speech (on-device)', status: this.speechStatus },
+      { name: 'Prompt API', status: this.languageModelAvailability }
+    ];
+  }
+
+  get formFields(): { key: keyof BookingForm; label: string; icon: string }[] {
+    return [
+      { key: 'name', label: 'Name', icon: 'bi-person' },
+      { key: 'date', label: 'Date', icon: 'bi-calendar-event' },
+      { key: 'time', label: 'Time', icon: 'bi-clock' },
+      { key: 'partySize', label: 'Party size', icon: 'bi-people' },
+      { key: 'seating', label: 'Seating', icon: 'bi-tree' },
+      { key: 'specialRequests', label: 'Special requests', icon: 'bi-chat-left-text' }
+    ];
+  }
+
+  async listen() {
+    if (this.isListening || this.speechStatus !== 'available') return;
+
+    this.errorMessage = '';
+    this.transcript = '';
+    this.interim = '';
+    this.isListening = true;
+
+    try {
+      const { result, abort } = this.webSpeech.listenOnce(
+        { quality: 'dictation' },
+        interim => { this.interim = interim; }
+      );
+      this.abortListen = abort;
+
+      const transcript = await result;
+      this.interim = '';
+      this.isListening = false;
+      this.abortListen = null;
+
+      if (transcript) {
+        this.transcript = transcript;
+        await this.extract(transcript);
+      }
+    } catch (e: any) {
+      this.isListening = false;
+      this.interim = '';
+      this.abortListen = null;
+      this.errorMessage = e.message || 'Could not capture speech.';
+    }
+  }
+
+  cancelListening() {
+    this.abortListen?.();
+  }
+
+  async extractTyped() {
+    const utterance = this.typedUtterance.trim();
+    if (!utterance) return;
+    this.transcript = utterance;
+    await this.extract(utterance);
+  }
+
+  useSample(sample: string) {
+    this.typedUtterance = sample;
+    this.extractTyped();
+  }
+
+  resetForm() {
+    this.form = { name: null, date: null, time: null, partySize: null, seating: null, specialRequests: null };
+    this.recentlyUpdated.clear();
+    this.transcript = '';
+    this.typedUtterance = '';
+  }
+
+  private async extract(utterance: string) {
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable — cannot extract form fields.';
+      return;
+    }
+
+    this.isExtracting = true;
+    this.state = PromptInputStateEnum.Inferencing;
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    const startTime = performance.now();
+
+    try {
+      const session = await LanguageModel.create({
+        systemPrompt:
+          'You extract restaurant booking details from spoken utterances. ' +
+          `Today is ${new Date().toDateString()}. ` +
+          'The current form state is provided; the utterance may fill new fields or correct existing ones. ' +
+          'Return the COMPLETE updated form. Use null for fields that remain unknown. ' +
+          'Format dates like "Friday, August 7" and times like "7:00 PM".'
+      });
+
+      const response = await session.prompt(
+        `Current form: ${JSON.stringify(this.form)}\n\nUtterance: "${utterance}"`,
+        { responseConstraint: BOOKING_SCHEMA }
+      );
+      session.destroy?.();
+
+      const updated = JSON.parse(response) as BookingForm;
+      this.recentlyUpdated.clear();
+      (Object.keys(updated) as (keyof BookingForm)[]).forEach(key => {
+        if (updated[key] !== null && updated[key] !== this.form[key]) {
+          this.recentlyUpdated.add(key);
+          (this.form as any)[key] = updated[key];
+        }
+      });
+
+      this.totalTime = Math.round(performance.now() - startTime);
+      this.ttft = this.totalTime;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Extraction failed.';
+    } finally {
+      this.isExtracting = false;
+      this.state = PromptInputStateEnum.Ready;
+    }
+  }
+
+  displayValue(key: keyof BookingForm): string {
+    const value = this.form[key];
+    if (value === null || value === '') return '';
+    return String(value);
+  }
+
+  get dynamicCodeSnippet(): string {
+    const utterance = this.transcript || this.sampleUtterances[0];
+    return `// 1. Capture one utterance on-device
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.onresult = (e) => extract(e.results[0][0].transcript);
+recognition.start();
+
+// 2. Turn the transcript into structured form data
+const schema = ${JSON.stringify(BOOKING_SCHEMA, null, 2)};
+
+async function extract(utterance) {
+  // e.g. ${JSON.stringify(utterance)}
+  const session = await LanguageModel.create({
+    systemPrompt: "You extract restaurant booking details. " +
+      "Return the complete updated form; null for unknown fields. " +
+      "Today is " + new Date().toDateString()
+  });
+  const result = await session.prompt(
+    \`Current form: \${JSON.stringify(currentForm)}\\n\\nUtterance: "\${utterance}"\`,
+    { responseConstraint: schema }
+  );
+  applyToForm(JSON.parse(result)); // only non-null fields overwrite
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/universal-inbox-demo.component.html
+++ b/webapp/src/app/pages/demos/features/universal-inbox-demo.component.html
@@ -1,0 +1,243 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>Part of the pipeline is unavailable on this device.</span> Detection, translation, and triage are required to process the inbox; the digest and reply steps degrade gracefully if the Summarizer or Writer is missing.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Control bar -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-4">
+      <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-rose-600 hover:bg-rose-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+              [disabled]="!canProcess"
+              (click)="processInbox()">
+        @if (isProcessing) {
+          <i class="bi bi-arrow-repeat animate-spin"></i> Processing...
+        } @else {
+          <i class="bi bi-play-fill text-lg"></i> {{ processed ? 'Re-process Inbox' : 'Process Inbox' }}
+        }
+      </button>
+
+      <div class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400">
+        <span class="font-semibold px-2 py-1 rounded-md bg-slate-100 dark:bg-zinc-800">detect</span>
+        <i class="bi bi-arrow-right text-slate-300"></i>
+        <span class="font-semibold px-2 py-1 rounded-md bg-slate-100 dark:bg-zinc-800">translate</span>
+        <i class="bi bi-arrow-right text-slate-300"></i>
+        <span class="font-semibold px-2 py-1 rounded-md bg-slate-100 dark:bg-zinc-800">triage</span>
+        <i class="bi bi-arrow-right text-slate-300"></i>
+        <span class="font-semibold px-2 py-1 rounded-md bg-slate-100 dark:bg-zinc-800">digest</span>
+        <i class="bi bi-arrow-right text-slate-300"></i>
+        <span class="font-semibold px-2 py-1 rounded-md bg-slate-100 dark:bg-zinc-800">reply</span>
+      </div>
+
+      <div class="flex-grow"></div>
+
+      @if (totalPipelineMs !== null) {
+        <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+          {{ inbox.length }} messages piped in {{ totalPipelineMs }}ms
+        </span>
+      }
+    </div>
+
+    <!-- Folder chips -->
+    <div class="flex flex-wrap gap-2 mb-6">
+      @for (folder of folders; track folder.name) {
+        <div class="flex items-center gap-2 px-3.5 py-2 rounded-full border border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90 shadow-sm">
+          <i class="bi {{ folder.icon }} text-sm text-slate-500 dark:text-slate-400"></i>
+          <span class="text-xs font-semibold text-slate-700 dark:text-slate-300">{{ folder.name }}</span>
+          <span class="text-[10px] font-mono font-bold px-1.5 py-0.5 rounded-md {{ folder.chipClass }}">{{ folderCount(folder) }}</span>
+        </div>
+      }
+    </div>
+
+    <div class="flex flex-col xl:flex-row gap-6 items-start">
+
+      <!-- Inbox list -->
+      <div class="xl:flex-[3] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-inbox text-rose-500"></i> Inbox — {{ inbox.length }} messages, 4 languages
+          </span>
+        </div>
+
+        <div class="divide-y divide-slate-100 dark:divide-zinc-800">
+          @for (message of inbox; track message.id) {
+            <div class="px-5 py-3.5 flex items-start gap-3 transition-colors cursor-pointer"
+                 [ngClass]="{
+                   'hover:bg-slate-50 dark:hover:bg-zinc-800/60': message.stage === 'done',
+                   'bg-indigo-50/60 dark:bg-indigo-900/10': selectedMessage?.id === message.id,
+                   'opacity-90': message.stage !== 'done' && message.stage !== 'pending'
+                 }"
+                 (click)="selectMessage(message)">
+              <span class="text-xl mt-0.5">{{ message.flag }}</span>
+              <div class="flex-grow min-w-0">
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="text-sm font-bold text-slate-800 dark:text-slate-200">{{ message.sender }}</span>
+                  @if (message.detectedLanguage) {
+                    <span class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-slate-400">
+                      {{ languageName(message.detectedLanguage) }} {{ message.detectedConfidence !== null ? (message.detectedConfidence * 100).toFixed(0) + '%' : '' }}
+                    </span>
+                  }
+                  @if (message.folder) {
+                    @let folder = folderByName(message.folder);
+                    <span class="text-[10px] font-bold px-2 py-0.5 rounded-md {{ folder?.chipClass }}">
+                      <i class="bi {{ folder?.icon }}"></i> {{ message.folder }}
+                    </span>
+                  }
+                  <div class="flex-grow"></div>
+                  @if (message.pipelineMs !== null) {
+                    <span class="text-[9px] font-mono text-slate-300 dark:text-zinc-600">{{ message.pipelineMs }}ms</span>
+                  }
+                </div>
+                <p class="text-xs text-slate-500 dark:text-slate-400 m-0 mt-1 leading-relaxed">
+                  @if (message.english && !message.showOriginal && message.english !== message.body) {
+                    {{ message.english }}
+                  } @else {
+                    {{ message.body }}
+                  }
+                </p>
+                @if (message.english && message.english !== message.body) {
+                  <button class="text-[9px] text-slate-400 dark:text-slate-500 hover:text-indigo-500 bg-transparent border-none p-0 mt-1 transition-colors"
+                          (click)="$event.stopPropagation(); message.showOriginal = !message.showOriginal">
+                    {{ message.showOriginal ? 'show translation' : 'show original' }}
+                  </button>
+                }
+              </div>
+
+              <!-- Pipeline stage indicators -->
+              <div class="flex items-center gap-1.5 mt-1 shrink-0">
+                @for (stage of ['detect', 'translate', 'triage']; track stage) {
+                  @let state = stageIcon(message, stage === 'detect' ? 'detect' : stage === 'translate' ? 'translate' : 'triage');
+                  <span class="w-2 h-2 rounded-full transition-colors"
+                        [ngClass]="{
+                          'bg-slate-200 dark:bg-zinc-700': state === 'idle',
+                          'bg-indigo-500 animate-pulse': state === 'active',
+                          'bg-emerald-500': state === 'done',
+                          'bg-red-500': state === 'error'
+                        }"
+                        title="{{ stage }}"></span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      </div>
+
+      <!-- Right column: digest + detail -->
+      <div class="xl:flex-[2] w-full flex flex-col gap-5">
+
+        <!-- Digest -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-stars text-amber-500"></i> Inbox Digest
+              <span class="normal-case font-medium text-slate-400">(Summarizer)</span>
+            </span>
+            @if (processed && summarizerStatus !== 'unavailable') {
+              <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-amber-500 hover:bg-amber-600 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 disabled:opacity-50 border-none"
+                      [disabled]="isDigesting"
+                      (click)="generateDigest()">
+                @if (isDigesting) {
+                  <i class="bi bi-arrow-repeat animate-spin"></i> Summarizing...
+                } @else {
+                  Generate
+                }
+              </button>
+            }
+          </div>
+          <div class="p-5 text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap min-h-[60px]">
+            @if (digest) {
+              {{ digest }}
+            } @else if (summarizerStatus === 'unavailable') {
+              <span class="text-slate-400 dark:text-slate-500 font-light">The Summarizer API is unavailable — the digest step is skipped.</span>
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light">{{ processed ? 'Generate a key-points digest of the processed inbox.' : 'Process the inbox first, then summarize it here.' }}</span>
+            }
+          </div>
+        </div>
+
+        <!-- Selected message + reply -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-reply text-indigo-500"></i> Reply
+              <span class="normal-case font-medium text-slate-400">(Writer + Translator)</span>
+            </span>
+          </div>
+
+          <div class="p-5">
+            @if (!selectedMessage) {
+              <p class="text-sm text-slate-400 dark:text-slate-500 font-light m-0 text-center py-4">
+                {{ processed ? 'Select a processed message to draft a reply.' : 'Process the inbox, then pick a message.' }}
+              </p>
+            } @else {
+              <div class="flex items-center gap-2 mb-3">
+                <span class="text-lg">{{ selectedMessage.flag }}</span>
+                <span class="text-sm font-bold text-slate-800 dark:text-slate-200">{{ selectedMessage.sender }}</span>
+                <span class="text-xs text-slate-400">speaks {{ languageName(selectedMessage.detectedLanguage) }}</span>
+              </div>
+
+              @if (!canReply) {
+                <p class="text-sm text-slate-400 dark:text-slate-500 font-light m-0">The Writer API is unavailable — the reply step is skipped.</p>
+              } @else if (!reply) {
+                <div class="flex items-center gap-2 flex-wrap">
+                  <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">Draft a</span>
+                  @for (tone of ['formal', 'neutral', 'casual']; track tone) {
+                    <button class="px-4 py-2 rounded-full text-xs font-semibold bg-indigo-600 hover:bg-indigo-700 text-white shadow-sm transition-all active:scale-95 border-none"
+                            (click)="draftReply(tone === 'formal' ? 'formal' : tone === 'neutral' ? 'neutral' : 'casual')">
+                      {{ tone }}
+                    </button>
+                  }
+                  <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">reply</span>
+                </div>
+              } @else if (reply.isDrafting) {
+                <div class="flex items-center gap-2 text-sm text-indigo-600 dark:text-indigo-400 py-3">
+                  <i class="bi bi-arrow-repeat animate-spin"></i> Writing a {{ reply.tone }} reply, then translating it back to {{ languageName(reply.targetLanguage) }}...
+                </div>
+              } @else {
+                <div class="rounded-2xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-4">
+                  <div class="flex items-center justify-between mb-2">
+                    <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">
+                      {{ reply.showEnglish || !reply.translated ? 'English draft' : 'In ' + languageName(reply.targetLanguage) }}
+                    </span>
+                    @if (reply.translated) {
+                      <button class="text-[10px] text-slate-400 hover:text-indigo-500 bg-transparent border-none transition-colors"
+                              (click)="reply.showEnglish = !reply.showEnglish">
+                        {{ reply.showEnglish ? 'show ' + languageName(reply.targetLanguage) : 'show English draft' }}
+                      </button>
+                    }
+                  </div>
+                  <p class="text-sm text-slate-700 dark:text-slate-300 m-0 leading-relaxed whitespace-pre-wrap">
+                    {{ reply.showEnglish || !reply.translated ? reply.english : reply.translated }}
+                  </p>
+                </div>
+                <div class="flex items-center gap-2 mt-3">
+                  <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none">
+                    <i class="bi bi-send"></i> Send (pretend)
+                  </button>
+                  <button class="text-xs font-medium text-slate-400 hover:text-slate-600 dark:text-slate-500 dark:hover:text-slate-300 bg-transparent border-none transition-colors"
+                          (click)="reply = null">
+                    Try another tone
+                  </button>
+                </div>
+              }
+            }
+          </div>
+        </div>
+
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/universal-inbox-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/universal-inbox-demo.component.ts
@@ -1,0 +1,351 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageDetector: any;
+declare const Translator: any;
+declare const Summarizer: any;
+declare const Writer: any;
+
+type PipelineStage = 'pending' | 'detecting' | 'translating' | 'triaging' | 'done' | 'error';
+
+interface InboxMessage {
+  id: number;
+  sender: string;
+  flag: string;
+  body: string;
+  stage: PipelineStage;
+  detectedLanguage: string | null;
+  detectedConfidence: number | null;
+  english: string | null;
+  folder: string | null;
+  folderScore: number | null;
+  showOriginal: boolean;
+  pipelineMs: number | null;
+}
+
+interface Folder {
+  name: string;
+  icon: string;
+  chipClass: string;
+  examples: string[];
+  centroid: Float32Array | null;
+}
+
+interface ReplyDraft {
+  tone: 'formal' | 'neutral' | 'casual';
+  english: string;
+  translated: string | null;
+  targetLanguage: string | null;
+  isDrafting: boolean;
+  showEnglish: boolean;
+}
+
+const INBOX: { sender: string; flag: string; body: string }[] = [
+  { sender: 'Camille Moreau', flag: '🇫🇷', body: 'Bonjour, j\'ai été facturée deux fois pour mon abonnement ce mois-ci. Pouvez-vous me rembourser ?' },
+  { sender: 'Diego Fernández', flag: '🇪🇸', body: 'La aplicación se cierra cada vez que intento subir una foto desde mi teléfono.' },
+  { sender: 'Lena Hoffmann', flag: '🇩🇪', body: 'Wäre es möglich, einen Dunkelmodus hinzuzufügen? Meine Augen würden es Ihnen danken!' },
+  { sender: 'Priya Sharma', flag: '🇬🇧', body: 'Could we schedule a call next week to discuss the enterprise plan for my team?' },
+  { sender: 'Antoine Lefèvre', flag: '🇫🇷', body: 'Votre dernière mise à jour est fantastique, l\'application est beaucoup plus rapide. Merci !' },
+  { sender: 'Marcus Webb', flag: '🇺🇸', body: 'The export button does nothing when my report has more than a thousand rows.' },
+  { sender: 'Lucía Ortiz', flag: '🇪🇸', body: '¿Cómo puedo cambiar la tarjeta de crédito asociada a mi cuenta?' },
+  { sender: 'Jonas Becker', flag: '🇩🇪', body: 'Ich würde gerne wissen, ob eine Offline-Funktion geplant ist.' }
+];
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  en: 'English', fr: 'French', es: 'Spanish', de: 'German', ja: 'Japanese', it: 'Italian', pt: 'Portuguese'
+};
+
+@Component({
+  selector: 'app-universal-inbox-demo',
+  templateUrl: './universal-inbox-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class UniversalInboxDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'universal-inbox')!;
+
+  inbox: InboxMessage[] = INBOX.map((m, i) => ({
+    id: i + 1,
+    ...m,
+    stage: 'pending',
+    detectedLanguage: null,
+    detectedConfidence: null,
+    english: null,
+    folder: null,
+    folderScore: null,
+    showOriginal: false,
+    pipelineMs: null
+  }));
+
+  folders: Folder[] = [
+    {
+      name: 'Billing', icon: 'bi-credit-card', chipClass: 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400',
+      examples: ['I was charged twice for my subscription', 'How do I update my payment method?', 'I would like a refund for my last invoice'],
+      centroid: null
+    },
+    {
+      name: 'Bug Reports', icon: 'bi-bug', chipClass: 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400',
+      examples: ['The app crashes when I upload a photo', 'The export button does not work at all', 'The page freezes right after I log in'],
+      centroid: null
+    },
+    {
+      name: 'Feature Requests', icon: 'bi-lightbulb', chipClass: 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400',
+      examples: ['Please add a dark mode', 'It would be great to have an offline mode', 'Can you support keyboard shortcuts?'],
+      centroid: null
+    },
+    {
+      name: 'Meetings', icon: 'bi-calendar-event', chipClass: 'bg-sky-100 dark:bg-sky-900/30 text-sky-700 dark:text-sky-400',
+      examples: ['Can we schedule a call next week?', 'I would like to book a demo with your team', 'Are you available for a meeting on Tuesday?'],
+      centroid: null
+    },
+    {
+      name: 'Praise', icon: 'bi-heart', chipClass: 'bg-rose-100 dark:bg-rose-900/30 text-rose-700 dark:text-rose-400',
+      examples: ['I love the new update, great work!', 'The app is fantastic, thank you so much!', 'Amazing product, keep it up!'],
+      centroid: null
+    }
+  ];
+
+  detectorStatus = 'loading...';
+  translatorStatus = 'loading...';
+  summarizerStatus = 'loading...';
+  writerStatus = 'loading...';
+
+  isProcessing = false;
+  processed = false;
+  totalPipelineMs: number | null = null;
+
+  digest = '';
+  isDigesting = false;
+
+  selectedMessage: InboxMessage | null = null;
+  reply: ReplyDraft | null = null;
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    await this.checkEmbedderAvailability();
+
+    const probe = async (name: string, fn: () => Promise<string>) => {
+      try { return name in self ? await fn() : 'unavailable'; } catch { return 'unavailable'; }
+    };
+    this.detectorStatus = await probe('LanguageDetector', () => LanguageDetector.availability());
+    this.translatorStatus = await probe('Translator', () => Translator.availability({ sourceLanguage: 'fr', targetLanguage: 'en' }));
+    this.summarizerStatus = await probe('Summarizer', () => Summarizer.availability());
+    this.writerStatus = await probe('Writer', () => Writer.availability());
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Language Detector', status: this.detectorStatus },
+      { name: 'Translator', status: this.translatorStatus },
+      { name: 'Semantic Embedder', status: this.embedderStatus },
+      { name: 'Summarizer', status: this.summarizerStatus },
+      { name: 'Writer', status: this.writerStatus }
+    ];
+  }
+
+  get canProcess(): boolean {
+    return !this.isProcessing
+      && this.detectorStatus !== 'unavailable'
+      && this.translatorStatus !== 'unavailable'
+      && this.embedderStatus !== 'unavailable';
+  }
+
+  get canDigest(): boolean {
+    return this.processed && !this.isDigesting && this.summarizerStatus !== 'unavailable';
+  }
+
+  get canReply(): boolean {
+    return this.writerStatus !== 'unavailable';
+  }
+
+  languageName(code: string | null): string {
+    if (!code) return 'unknown';
+    return LANGUAGE_NAMES[code] ?? code;
+  }
+
+  folderByName(name: string | null): Folder | null {
+    return this.folders.find(f => f.name === name) ?? null;
+  }
+
+  folderCount(folder: Folder): number {
+    return this.inbox.filter(m => m.folder === folder.name).length;
+  }
+
+  stageIcon(message: InboxMessage, stage: 'detect' | 'translate' | 'triage'): string {
+    const order: PipelineStage[] = ['detecting', 'translating', 'triaging'];
+    const stageMap = { detect: 'detecting', translate: 'translating', triage: 'triaging' } as const;
+    const target = stageMap[stage];
+    if (message.stage === 'pending') return 'idle';
+    if (message.stage === 'done') return 'done';
+    if (message.stage === 'error') return 'error';
+    const currentIdx = order.indexOf(message.stage);
+    const targetIdx = order.indexOf(target);
+    if (targetIdx < currentIdx) return 'done';
+    if (targetIdx === currentIdx) return 'active';
+    return 'idle';
+  }
+
+  async processInbox() {
+    if (!this.canProcess) return;
+
+    this.isProcessing = true;
+    this.processed = false;
+    this.errorMessage = '';
+    this.digest = '';
+    this.selectedMessage = null;
+    this.reply = null;
+    const totalStart = performance.now();
+
+    try {
+      // Prepare shared resources once.
+      if (!this.detector) this.detector = await LanguageDetector.create();
+      await this.prepareFolderCentroids();
+
+      for (const message of this.inbox) {
+        await this.processMessage(message);
+      }
+
+      this.totalPipelineMs = Math.round(performance.now() - totalStart);
+      this.processed = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'The pipeline failed.';
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  private async prepareFolderCentroids() {
+    const allExamples = this.folders.flatMap(f => f.examples);
+    const vectors = await this.semanticEmbedder.embed(allExamples, 'classification', this.onDownloadProgress);
+    let cursor = 0;
+    for (const folder of this.folders) {
+      folder.centroid = this.semanticEmbedder.meanVector(vectors.slice(cursor, cursor + folder.examples.length));
+      cursor += folder.examples.length;
+    }
+  }
+
+  private async processMessage(message: InboxMessage) {
+    const start = performance.now();
+    try {
+      // Stage 1: detect the sender's language
+      message.stage = 'detecting';
+      let language = 'en';
+      const results = await this.detector.detect(message.body);
+      if (results?.length && results[0].detectedLanguage !== 'und') {
+        language = results[0].detectedLanguage;
+        message.detectedLanguage = language;
+        message.detectedConfidence = results[0].confidence;
+      }
+
+      // Stage 2: translate to English for the rest of the pipeline
+      message.stage = 'translating';
+      if (language === 'en') {
+        message.english = message.body;
+      } else {
+        const key = `${language}->en`;
+        if (!this.translators.has(key)) {
+          this.translators.set(key, await Translator.create({ sourceLanguage: language, targetLanguage: 'en' }));
+        }
+        message.english = await this.translators.get(key).translate(message.body);
+      }
+
+      // Stage 3: triage into a folder by nearest centroid
+      message.stage = 'triaging';
+      const vector = await this.semanticEmbedder.embedOne(message.english!, 'classification');
+      let best: { folder: Folder; score: number } | null = null;
+      for (const folder of this.folders) {
+        const score = this.semanticEmbedder.cosineSimilarity(vector, folder.centroid!);
+        if (!best || score > best.score) best = { folder, score };
+      }
+      message.folder = best!.folder.name;
+      message.folderScore = best!.score;
+
+      message.stage = 'done';
+      message.pipelineMs = Math.round(performance.now() - start);
+    } catch (e: any) {
+      message.stage = 'error';
+      this.errorMessage = e.message || `Failed to process the message from ${message.sender}.`;
+    }
+  }
+
+  async generateDigest() {
+    if (!this.canDigest) return;
+    this.isDigesting = true;
+    this.errorMessage = '';
+    try {
+      const summarizer = await Summarizer.create({
+        type: 'key-points',
+        format: 'plain-text',
+        length: 'medium'
+      });
+      const inboxText = this.inbox
+        .filter(m => m.english)
+        .map(m => `From ${m.sender} (${m.folder}): ${m.english}`)
+        .join('\n');
+      this.digest = await summarizer.summarize(inboxText, {
+        context: 'These are customer messages received today by the Nimbus support team.'
+      });
+      summarizer.destroy?.();
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Could not generate the digest.';
+    } finally {
+      this.isDigesting = false;
+    }
+  }
+
+  selectMessage(message: InboxMessage) {
+    if (message.stage !== 'done') return;
+    this.selectedMessage = message;
+    this.reply = null;
+  }
+
+  async draftReply(tone: 'formal' | 'neutral' | 'casual') {
+    const message = this.selectedMessage;
+    if (!message || !message.english || !this.canReply) return;
+
+    this.reply = { tone, english: '', translated: null, targetLanguage: message.detectedLanguage, isDrafting: true, showEnglish: false };
+    this.errorMessage = '';
+
+    try {
+      // Draft in English with the Writer API...
+      const writer = await Writer.create({
+        tone,
+        format: 'plain-text',
+        length: 'short',
+        sharedContext: 'You write replies on behalf of the Nimbus support team. Be helpful and specific, never invent account details, and sign off as "The Nimbus Team".'
+      });
+      const english = await writer.write(
+        `Reply to this customer message, filed under "${message.folder}": "${message.english}"`
+      );
+      writer.destroy?.();
+      this.reply.english = english;
+
+      // ...then answer the customer in THEIR language.
+      const language = message.detectedLanguage;
+      if (language && language !== 'en') {
+        const key = `en->${language}`;
+        if (!this.translators.has(key)) {
+          this.translators.set(key, await Translator.create({ sourceLanguage: 'en', targetLanguage: language }));
+        }
+        this.reply.translated = await this.translators.get(key).translate(english);
+      }
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Could not draft the reply.';
+      this.reply = null;
+    } finally {
+      if (this.reply) this.reply.isDrafting = false;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}


### PR DESCRIPTION
## Summary

Adds a new **Speech** category built on on-device Web Speech recognition (`processLocally: true`, quality tiers, contextual biasing), plus the first multi-API pipeline demos and a dedicated Proofreader API demo. Seven new demos, one upgraded:

| Demo | Route | APIs |
|---|---|---|
| Live Translated Captions | `/demos/live-translated-captions` | Web Speech + Language Detector + Translator |
| Speak to Fill | `/demos/speak-to-fill` | Web Speech + Prompt API (structured output) |
| ASR Quality Tier Lab | `/demos/asr-quality-tiers` | Web Speech (`command`/`dictation`/`conversation`) |
| Jargon Dictation | `/demos/contextual-biasing` | Web Speech (`SpeechRecognitionPhrase` boosts) |
| Polyglot Chat | `/demos/polyglot-chat` | Translator + Language Detector |
| Proofreader, Inline | `/demos/proofreader-inline` | Proofreader |
| Universal Inbox | `/demos/universal-inbox` | Language Detector + Translator + Semantic Embedder + Summarizer + Writer |
| Command Palette (upgrade) | `/demos/command-palette` | + mic button, `command` tier, live interim ranking |

## Highlights

- **Quality Tier Lab** records the same reference passage against each on-device model tier and scores it with a word-level edit-distance diff (substitutions/insertions/deletions highlighted inline) plus setup and sound-to-first-word latency.
- **Universal Inbox** chains five APIs per message with animated stage indicators, an inbox digest, and replies drafted by the Writer and translated back into the sender's language. Digest/reply degrade gracefully when the Summarizer/Writer are unavailable.
- **Proofreader, Inline** renders `startIndex`/`endIndex` corrections as wavy underlines with accept-one/accept-all, and surfaces `types`/`explanation` when the implementation returns them (with a note while Chrome's build doesn't yet).

## Plumbing

- `WebSpeechService` (availability/install per language+tier, configured recognizer factory, promise-based `listenOnce` with interim callback), `BaseSpeechDemoComponent`, and a generic `app-api-status` pill header for multi-API demos.
- `DemoApi` extended to all Built-In AI APIs; `DemoAvailabilityService` now probes Web Speech (on-device gate), Translator (representative pair), Language Detector, Summarizer, Writer, Rewriter, and Proofreader — the demos page filter chips and card availability badges pick these up.
- New `Speech` category (cyan) listed first; `translation`/`summarization` demos retro-tagged with their dedicated APIs.

## Testing

- `ng build` passes; all 7 new routes prerender through SSR (36 demo cards on the index). Mic and speech APIs are browser-gated and only start on user gesture.
- Live speech paths need a Chrome build with on-device Web Speech; the Proofreader demo needs `#proofreader-api`. Similarity/quality behaviors (tier accuracy spread, biasing effect) should be validated against the real models.

🤖 Generated with [Claude Code](https://claude.com/claude-code)