### PR TITLE
Add writing-API, vision, and TTS demos; put Embeddings first

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -137,6 +137,13 @@ import { ContextualBiasingDemoComponent } from './pages/demos/features/contextua
 import { PolyglotChatDemoComponent } from './pages/demos/features/polyglot-chat-demo.component';
 import { ProofreaderInlineDemoComponent } from './pages/demos/features/proofreader-inline-demo.component';
 import { UniversalInboxDemoComponent } from './pages/demos/features/universal-inbox-demo.component';
+import { TonePadDemoComponent } from './pages/demos/features/tone-pad-demo.component';
+import { SummarizerMatrixDemoComponent } from './pages/demos/features/summarizer-matrix-demo.component';
+import { ReplyComposerDemoComponent } from './pages/demos/features/reply-composer-demo.component';
+import { DictateAndPolishDemoComponent } from './pages/demos/features/dictate-and-polish-demo.component';
+import { CameraQaDemoComponent } from './pages/demos/features/camera-qa-demo.component';
+import { DrawAndGuessDemoComponent } from './pages/demos/features/draw-and-guess-demo.component';
+import { StoryTimeDemoComponent } from './pages/demos/features/story-time-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { TrackingDownloadPage } from './pages/docs/tracking-download/tracking-download.page';
@@ -250,6 +257,13 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     PolyglotChatDemoComponent,
     ProofreaderInlineDemoComponent,
     UniversalInboxDemoComponent,
+    TonePadDemoComponent,
+    SummarizerMatrixDemoComponent,
+    ReplyComposerDemoComponent,
+    DictateAndPolishDemoComponent,
+    CameraQaDemoComponent,
+    DrawAndGuessDemoComponent,
+    StoryTimeDemoComponent,
     AutoScrollDirective,
     CortexPage,
     CortexInsightsPage,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -52,6 +52,13 @@ import { ContextualBiasingDemoComponent } from './pages/demos/features/contextua
 import { PolyglotChatDemoComponent } from './pages/demos/features/polyglot-chat-demo.component';
 import { ProofreaderInlineDemoComponent } from './pages/demos/features/proofreader-inline-demo.component';
 import { UniversalInboxDemoComponent } from './pages/demos/features/universal-inbox-demo.component';
+import { TonePadDemoComponent } from './pages/demos/features/tone-pad-demo.component';
+import { SummarizerMatrixDemoComponent } from './pages/demos/features/summarizer-matrix-demo.component';
+import { ReplyComposerDemoComponent } from './pages/demos/features/reply-composer-demo.component';
+import { DictateAndPolishDemoComponent } from './pages/demos/features/dictate-and-polish-demo.component';
+import { CameraQaDemoComponent } from './pages/demos/features/camera-qa-demo.component';
+import { DrawAndGuessDemoComponent } from './pages/demos/features/draw-and-guess-demo.component';
+import { StoryTimeDemoComponent } from './pages/demos/features/story-time-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { DocsErrorsPage } from './pages/docs/errors/errors.page';
@@ -568,6 +575,55 @@ const routes: Routes = [
       {
         path: "demos/universal-inbox",
         component: UniversalInboxDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/tone-pad",
+        component: TonePadDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/summarizer-matrix",
+        component: SummarizerMatrixDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/reply-composer",
+        component: ReplyComposerDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/dictate-and-polish",
+        component: DictateAndPolishDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/camera-qa",
+        component: CameraQaDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/draw-and-guess",
+        component: DrawAndGuessDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/story-time",
+        component: StoryTimeDemoComponent,
         data: {
           route: RouteEnum.Demos
         }

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -145,6 +145,69 @@ recognition.start();`,
     initialPrompt: ''
   },
 
+  {
+    id: 'dictate-and-polish',
+    title: 'Dictate & Polish',
+    description: 'Speak your messy first draft, then let the Proofreader and Rewriter turn it into publishable text.',
+    category: 'Speech',
+    apis: ['Web Speech', 'Proofreader', 'Rewriter'],
+    icon: 'bi-soundwave',
+    onDeviceReason: 'Speak like a human, publish like an editor: dictation, proofreading, and rewriting chain together locally, so rough spoken thoughts never leave the device.',
+    codeSnippet: `// 1. Dictate on-device
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.continuous = true;
+recognition.onresult = (e) => (rawTranscript = collect(e));
+recognition.start();
+
+// 2. Fix punctuation, casing, and grammar with the Proofreader
+const proofreader = await Proofreader.create({ expectedInputLanguages: ["en"] });
+const { correctedInput } = await proofreader.proofread(rawTranscript);
+
+// 3. Reshape it with the Rewriter
+const rewriter = await Rewriter.create({
+  tone: "more-formal",   // or "more-casual"
+  length: "shorter",     // or "longer"
+  format: "plain-text"
+});
+const polished = await rewriter.rewrite(correctedInput);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'story-time',
+    title: 'Story Time',
+    description: 'The Writer invents a bedtime story from three ingredients, then the browser reads it aloud — highlighting each word as it speaks.',
+    category: 'Speech',
+    apis: ['Writer', 'Web Speech'],
+    icon: 'bi-moon-stars',
+    onDeviceReason: 'A complete storyteller with no servers: generation by the on-device Writer, narration by speechSynthesis, word-by-word karaoke highlighting from boundary events.',
+    codeSnippet: `// 1. Write the story on-device
+const writer = await Writer.create({
+  tone: "casual",
+  format: "plain-text",
+  length: "medium",
+  sharedContext: "You write warm bedtime stories for young children."
+});
+const stream = writer.writeStreaming(
+  "Write a bedtime story featuring a dragon, a submarine, and pancakes."
+);
+for await (const chunk of stream) story += chunk;
+
+// 2. Narrate it with word-by-word highlighting
+const utterance = new SpeechSynthesisUtterance(story);
+utterance.rate = 0.9;
+
+utterance.onboundary = (event) => {
+  // event.charIndex points at the word being spoken right now
+  highlightWordAt(event.charIndex);
+};
+
+speechSynthesis.speak(utterance);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+
   // MULTI-API
   {
     id: 'polyglot-chat',
@@ -211,6 +274,161 @@ for (const c of result.corrections) {
   // startIndex/endIndex point into the ORIGINAL string — perfect for underlines
   console.log(c.startIndex, c.endIndex, "→", c.correction, c.types, c.explanation);
 }`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'tone-pad',
+    title: 'Tone Pad',
+    description: 'A 3×3 pad of the Rewriter\'s option space: pick a tone and a length, and the same text reshapes live.',
+    category: 'Text Input',
+    apis: ['Rewriter'],
+    icon: 'bi-joystick',
+    onDeviceReason: 'Trying nine variations of a message costs nothing when rewriting happens on-device — preview every tone before you hit send, without your draft leaving the machine.',
+    codeSnippet: `// The Rewriter's option space is a grid:
+// tone:   more-casual | as-is | more-formal
+// length: shorter     | as-is | longer
+
+const rewriter = await Rewriter.create({
+  tone: "more-formal",
+  length: "shorter",
+  format: "plain-text"
+});
+
+const original =
+  "hey! quick heads up - the demo kinda broke on my machine, might wanna check before the meeting";
+
+const rewritten = await rewriter.rewrite(original);
+// "Please note the demo malfunctioned on my machine; I recommend
+//  verifying it before the meeting."
+
+rewriter.destroy();`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'summarizer-matrix',
+    title: 'Summarizer Options Matrix',
+    description: 'One article, every Summarizer option: tldr, key-points, teaser, and headline at each length, side by side.',
+    category: 'Text Input',
+    apis: ['Summarizer'],
+    icon: 'bi-grid-3x3-gap',
+    onDeviceReason: 'The fastest way to learn which type and length fit your product is to generate them all — free and instant when the Summarizer runs on-device.',
+    codeSnippet: `// Summarizer options:
+// type:   "tldr" | "key-points" | "teaser" | "headline"
+// length: "short" | "medium" | "long"
+
+for (const type of ["tldr", "key-points", "teaser", "headline"]) {
+  for (const length of ["short", "medium", "long"]) {
+    const summarizer = await Summarizer.create({
+      type,
+      length,
+      format: "plain-text"
+    });
+
+    const summary = await summarizer.summarize(articleText, {
+      context: "This is a technology news article."
+    });
+
+    renderCell(type, length, summary);
+    summarizer.destroy();
+  }
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'reply-composer',
+    title: 'Reply Composer',
+    description: 'Pick an intent — accept, decline, stall — and the Writer drafts the reply to a real email, streaming, with tone and length knobs.',
+    category: 'Text Input',
+    apis: ['Writer'],
+    icon: 'bi-reply',
+    onDeviceReason: 'Replies are drafted next to your inbox with zero upload: the incoming email is the Writer\'s sharedContext and never leaves the device.',
+    codeSnippet: `const writer = await Writer.create({
+  tone: "formal",              // formal | neutral | casual
+  length: "short",             // short | medium | long
+  format: "plain-text",
+  sharedContext: incomingEmail // the email being replied to
+});
+
+// The intent is the writing task
+const stream = writer.writeStreaming(
+  "Write a reply that politely declines the invitation but proposes an alternative."
+);
+
+for await (const chunk of stream) {
+  draft += chunk;
+}
+
+writer.destroy();`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'camera-qa',
+    title: 'Live Camera Q&A',
+    description: 'Point your camera at anything, freeze a frame, and ask the on-device model about what it sees.',
+    category: 'Image Input',
+    apis: ['Prompt API'],
+    icon: 'bi-camera-video',
+    onDeviceReason: 'Your camera feed is the most private data you have — frames go straight from the sensor to the on-device model, and never anywhere else.',
+    codeSnippet: `// 1. Show the camera
+const stream = await navigator.mediaDevices.getUserMedia({ video: true });
+videoElement.srcObject = stream;
+
+// 2. Freeze a frame when the user asks a question
+const bitmap = await createImageBitmap(videoElement);
+
+// 3. Ask the on-device model about it
+const session = await LanguageModel.create({
+  expectedInputs: [{ type: "image" }]
+});
+
+const answer = session.promptStreaming([{
+  role: "user",
+  content: [
+    { type: "text", value: "What am I holding in this picture?" },
+    { type: "image", value: bitmap }
+  ]
+}]);
+
+for await (const chunk of answer) {
+  console.log(chunk);
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'draw-and-guess',
+    title: 'Draw & Guess',
+    description: 'You sketch, Gemini Nano guesses: the model interprets your doodle after every stroke.',
+    category: 'Image Input',
+    apis: ['Prompt API'],
+    icon: 'bi-brush',
+    onDeviceReason: 'Guessing on every stroke only works when vision inference is local — no upload per doodle, no latency, no cost per guess.',
+    codeSnippet: `const session = await LanguageModel.create({
+  expectedInputs: [{ type: "image" }],
+  systemPrompt: "You are playing a drawing guessing game. " +
+    "Reply with only your single best guess for what the line drawing shows, in 1-3 words."
+});
+
+canvas.addEventListener("pointerup", async () => {
+  // After each stroke, let the model take a guess
+  const bitmap = await createImageBitmap(canvas);
+
+  const guess = await session.prompt([{
+    role: "user",
+    content: [
+      { type: "text", value: "What is this simple line drawing?" },
+      { type: "image", value: bitmap }
+    ]
+  }]);
+
+  if (guess.toLowerCase().includes(secretWord)) {
+    celebrate("The model guessed it!");
+  }
+});`,
     promptRunOptions: {},
     initialPrompt: ''
   },

--- a/webapp/src/app/pages/demos/demos.page.ts
+++ b/webapp/src/app/pages/demos/demos.page.ts
@@ -20,8 +20,8 @@ interface CategoryStyle {
 })
 export class DemosPage extends BasePage implements OnInit {
   demos: DemoExample[] = DEMOS_DATA;
-  categories: DemoCategory[] = ['Speech', 'Embeddings', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
-  apis: DemoApi[] = ['Prompt API', 'Semantic Embedder', 'Web Speech', 'Translator', 'Language Detector', 'Summarizer', 'Writer', 'Proofreader'];
+  categories: DemoCategory[] = ['Embeddings', 'Speech', 'Text Input', 'Image Input', 'Audio Input', 'Tools Calling', 'Mix-and-Match'];
+  apis: DemoApi[] = ['Prompt API', 'Semantic Embedder', 'Web Speech', 'Translator', 'Language Detector', 'Summarizer', 'Writer', 'Rewriter', 'Proofreader'];
 
   searchQuery = '';
   selectedCategory: DemoCategory | null = null;

--- a/webapp/src/app/pages/demos/features/camera-qa-demo.component.html
+++ b/webapp/src/app/pages/demos/features/camera-qa-demo.component.html
@@ -1,0 +1,134 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API with image input is not available in this browser.</span> Use a Chrome build with multimodal Gemini Nano enabled.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Camera panel -->
+      <div class="lg:flex-[3] w-full">
+        <div class="bg-[#101014] rounded-3xl shadow-xl border border-zinc-800 overflow-hidden relative aspect-video flex items-center justify-center">
+          @if (cameraState === 'live') {
+            <video #video autoplay playsinline muted class="w-full h-full object-cover"></video>
+            <button class="absolute top-4 right-4 px-3.5 py-1.5 rounded-full bg-black/50 hover:bg-black/70 text-white text-xs font-semibold backdrop-blur transition-colors border-none"
+                    (click)="stopCamera()">
+              <i class="bi bi-camera-video-off"></i> Stop
+            </button>
+            @if (state === 'Inferencing') {
+              <div class="absolute top-4 left-4 flex items-center gap-1.5 px-3 py-1.5 rounded-full bg-black/50 text-white text-xs font-semibold backdrop-blur">
+                <i class="bi bi-arrow-repeat animate-spin"></i> Analyzing frame...
+              </div>
+            }
+          } @else {
+            <div class="text-center p-8">
+              <i class="bi bi-camera-video text-5xl text-zinc-700"></i>
+              <p class="text-zinc-500 text-sm mt-3 mb-5 font-light max-w-sm">
+                @if (cameraState === 'denied') {
+                  Camera access was denied — update the site permission and try again.
+                } @else if (cameraState === 'unavailable') {
+                  No camera is available in this browser.
+                } @else {
+                  The feed stays on this device: frames go straight from the sensor to the on-device model.
+                }
+              </p>
+              @if (cameraState === 'idle' || cameraState === 'denied') {
+                <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-violet-600 hover:bg-violet-700 text-white font-medium shadow-md transition-all active:scale-95 border-none mx-auto"
+                        (click)="startCamera()">
+                  <i class="bi bi-camera-video"></i> Start Camera
+                </button>
+              } @else if (cameraState === 'starting') {
+                <span class="text-zinc-400 text-sm"><i class="bi bi-arrow-repeat animate-spin"></i> Starting camera...</span>
+              }
+            </div>
+          }
+        </div>
+
+        <!-- Question bar -->
+        <div class="mt-4 bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-4">
+          <div class="flex gap-3">
+            <input type="text"
+                   class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-violet-500/40"
+                   [(ngModel)]="question"
+                   (keydown.enter)="captureAndAsk()"
+                   [disabled]="cameraState !== 'live'"
+                   placeholder="Ask about what the camera sees..." />
+            @if (state === 'Inferencing') {
+              <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                      (click)="onCancel()">
+                <i class="bi bi-stop-fill"></i> Stop
+              </button>
+            } @else {
+              <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-violet-600 hover:bg-violet-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                      [disabled]="cameraState !== 'live' || !question.trim() || languageModelAvailability === 'unavailable'"
+                      (click)="captureAndAsk()">
+                <i class="bi bi-camera"></i> Capture & Ask
+              </button>
+            }
+          </div>
+          <div class="flex flex-wrap gap-2 mt-3">
+            @for (sample of sampleQuestions; track sample) {
+              <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                      [disabled]="cameraState !== 'live' || state === 'Inferencing'"
+                      (click)="useSample(sample)">
+                {{ sample }}
+              </button>
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- Snapshot + answer -->
+      <div class="lg:flex-[2] w-full flex flex-col gap-4">
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-3 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-image text-violet-500"></i> Frozen Frame
+            </span>
+          </div>
+          <div class="bg-slate-100 dark:bg-[#161616] flex items-center justify-center min-h-[120px]">
+            <canvas #snapshot class="w-full h-auto" [class.hidden]="!hasSnapshot"></canvas>
+            @if (!hasSnapshot) {
+              <span class="text-xs text-slate-400 dark:text-zinc-600 font-light p-6">The captured frame appears here.</span>
+            }
+          </div>
+        </div>
+
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden flex-grow min-h-[160px]">
+          <div class="px-5 py-3 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-stars text-amber-500"></i> Answer
+            </span>
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+          </div>
+          <div class="p-5 text-[15px] text-slate-800 dark:text-slate-200 leading-relaxed whitespace-pre-wrap flex-grow">
+            @if (answer) {
+              {{ answer }}
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">The model's answer about the frame appears here.</span>
+            }
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/camera-qa-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/camera-qa-demo.component.ts
@@ -1,0 +1,188 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+@Component({
+  selector: 'app-camera-qa-demo',
+  templateUrl: './camera-qa-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class CameraQaDemoComponent extends BaseDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'camera-qa')!;
+
+  @ViewChild('video') videoRef!: ElementRef<HTMLVideoElement>;
+  @ViewChild('snapshot') snapshotRef!: ElementRef<HTMLCanvasElement>;
+
+  cameraState: 'idle' | 'starting' | 'live' | 'denied' | 'unavailable' = 'idle';
+  hasSnapshot = false;
+
+  question = 'What do you see in this picture?';
+  answer = '';
+  errorMessage = '';
+
+  sampleQuestions = [
+    'What do you see in this picture?',
+    'What am I holding up to the camera?',
+    'Read any text visible in this image.',
+    'What color is the most prominent object?'
+  ];
+
+  private mediaStream: MediaStream | null = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability([{ type: 'image' }]);
+    if (!navigator.mediaDevices?.getUserMedia) {
+      this.cameraState = 'unavailable';
+    }
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API (image)', status: this.languageModelAvailability }];
+  }
+
+  async startCamera() {
+    if (this.cameraState === 'live' || this.cameraState === 'starting') return;
+    this.cameraState = 'starting';
+    this.errorMessage = '';
+    try {
+      this.mediaStream = await navigator.mediaDevices.getUserMedia({
+        video: { facingMode: 'environment', width: { ideal: 1280 }, height: { ideal: 720 } },
+        audio: false
+      });
+      this.cameraState = 'live';
+      // Let the video element render before attaching the stream.
+      setTimeout(() => {
+        if (this.videoRef?.nativeElement && this.mediaStream) {
+          this.videoRef.nativeElement.srcObject = this.mediaStream;
+        }
+      });
+    } catch (e: any) {
+      this.cameraState = e.name === 'NotAllowedError' ? 'denied' : 'unavailable';
+      this.errorMessage = e.name === 'NotAllowedError'
+        ? 'Camera access was denied. Allow the camera to use this demo.'
+        : (e.message || 'Could not start the camera.');
+    }
+  }
+
+  stopCamera() {
+    this.mediaStream?.getTracks().forEach(track => track.stop());
+    this.mediaStream = null;
+    this.cameraState = 'idle';
+  }
+
+  private captureFrame(): HTMLCanvasElement | null {
+    const video = this.videoRef?.nativeElement;
+    const canvas = this.snapshotRef?.nativeElement;
+    if (!video || !canvas || video.videoWidth === 0) return null;
+    canvas.width = video.videoWidth;
+    canvas.height = video.videoHeight;
+    canvas.getContext('2d')!.drawImage(video, 0, 0);
+    return canvas;
+  }
+
+  useSample(sample: string) {
+    this.question = sample;
+    this.captureAndAsk();
+  }
+
+  async captureAndAsk() {
+    const q = this.question.trim();
+    if (!q || this.cameraState !== 'live' || this.state === PromptInputStateEnum.Inferencing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    const canvas = this.captureFrame();
+    if (!canvas) {
+      this.errorMessage = 'Could not capture a frame — is the camera ready?';
+      return;
+    }
+    this.hasSnapshot = true;
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.answer = '';
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      const bitmap = await createImageBitmap(canvas);
+      const session = await LanguageModel.create({
+        expectedInputs: [{ type: 'image' }]
+      });
+
+      const stream = session.promptStreaming([{
+        role: 'user',
+        content: [
+          { type: 'text', value: q },
+          { type: 'image', value: bitmap }
+        ]
+      }], { signal: this.abortController.signal });
+
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - startTime);
+        }
+        this.answer += chunk;
+      }
+      this.totalTime = Math.round(performance.now() - startTime);
+      session.destroy?.();
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Could not answer the question.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  override ngOnDestroy() {
+    this.stopCamera();
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    const q = this.question.trim() || this.sampleQuestions[0];
+    return `// 1. Show the camera — the feed never leaves the device
+const stream = await navigator.mediaDevices.getUserMedia({
+  video: { facingMode: "environment" }
+});
+videoElement.srcObject = stream;
+
+// 2. Freeze a frame when the user asks
+canvas.getContext("2d").drawImage(videoElement, 0, 0);
+const bitmap = await createImageBitmap(canvas);
+
+// 3. Ask the on-device model about it
+const session = await LanguageModel.create({
+  expectedInputs: [{ type: "image" }]
+});
+
+const answer = session.promptStreaming([{
+  role: "user",
+  content: [
+    { type: "text", value: ${JSON.stringify(q)} },
+    { type: "image", value: bitmap }
+  ]
+}]);
+
+for await (const chunk of answer) {
+  render(chunk);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/dictate-and-polish-demo.component.html
+++ b/webapp/src/app/pages/demos/features/dictate-and-polish-demo.component.html
@@ -1,0 +1,119 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [showInstall]="true"
+      [isInstalling]="isInstalling"
+      (install)="installSpeechModel({ quality: 'dictation' })"
+      unavailableHint="<span class='font-semibold'>An API is unavailable.</span> Without the mic you can still load the sample dictation below and polish it with the Proofreader and Rewriter.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+
+      <!-- Raw dictation -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[340px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-soundwave text-cyan-500"></i> Raw Dictation
+          </span>
+          <div class="flex items-center gap-2">
+            @if (isListening) {
+              <button class="flex items-center gap-2 px-4 py-1.5 rounded-full bg-red-600 hover:bg-red-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="stopDictation()">
+                <span class="w-1.5 h-1.5 rounded-full bg-white animate-pulse"></span> Stop
+              </button>
+            } @else {
+              <button class="flex items-center gap-2 px-4 py-1.5 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 disabled:opacity-50 border-none"
+                      [disabled]="speechStatus !== 'available'"
+                      (click)="startDictation()">
+                <i class="bi bi-mic-fill"></i> {{ rawText ? 'Continue' : 'Dictate' }}
+              </button>
+            }
+            @if (rawText) {
+              <button class="text-xs font-medium text-slate-400 hover:text-red-500 dark:text-slate-500 dark:hover:text-red-400 bg-transparent border-none transition-colors"
+                      (click)="clearAll()">
+                Clear
+              </button>
+            }
+          </div>
+        </div>
+        <div class="p-5 flex-grow text-base text-slate-800 dark:text-slate-200 leading-relaxed">
+          {{ rawText }}
+          @if (interim) {
+            <span class="text-slate-400 dark:text-slate-500 italic">{{ rawText ? ' ' : '' }}{{ interim }}</span>
+          }
+          @if (!rawText && !interim) {
+            <span class="text-slate-400 dark:text-slate-500 font-light select-none">
+              Dictate freely — ums, tangents, and run-ons welcome. Or
+              <button class="text-cyan-600 dark:text-cyan-400 underline bg-transparent border-none p-0 font-light" (click)="useSample()">load a sample dictation</button>.
+            </span>
+          }
+        </div>
+        <!-- Polish actions -->
+        <div class="p-4 border-t border-slate-100 dark:border-zinc-700/50 flex flex-wrap gap-2">
+          @for (action of actions; track action.id) {
+            <button class="flex items-center gap-1.5 px-4 py-2 rounded-full text-xs font-semibold transition-all active:scale-95 border-none shadow-sm disabled:opacity-40"
+                    [ngClass]="activeAction === action ? 'bg-cyan-600 text-white' : 'bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-300'"
+                    [disabled]="!rawText.trim() || isPolishing || !actionAvailable(action)"
+                    (click)="polish(action)">
+              <i class="bi {{ action.icon }}"></i> {{ action.label }}
+              <span class="text-[9px] opacity-60 font-mono">{{ action.api }}</span>
+            </button>
+          }
+        </div>
+      </div>
+
+      <!-- Polished result -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border flex flex-col overflow-hidden min-h-[340px]"
+           [ngClass]="polishedText ? 'border-cyan-200 dark:border-cyan-900/50' : 'border-slate-200 dark:border-zinc-700'">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 flex justify-between items-center"
+             [ngClass]="polishedText ? 'bg-cyan-50/50 dark:bg-cyan-900/10' : 'bg-slate-50/50 dark:bg-[#161616]/50'">
+          <span class="text-sm font-bold uppercase tracking-wider flex items-center gap-2"
+                [ngClass]="polishedText ? 'text-cyan-700 dark:text-cyan-300' : 'text-slate-700 dark:text-slate-300'">
+            <i class="bi bi-stars text-amber-500"></i> Polished
+            @if (activeAction && polishedText) {
+              <span class="normal-case font-medium text-slate-400 dark:text-slate-500">— {{ activeAction.label }}</span>
+            }
+          </span>
+          <div class="flex items-center gap-2">
+            @if (polishTimeMs !== null && polishedText) {
+              <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+                {{ polishTimeMs }}ms
+              </span>
+            }
+            @if (polishedText && !isPolishing) {
+              <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      title="Use this as the new draft and keep polishing"
+                      (click)="keepPolished()">
+                <i class="bi bi-arrow-left"></i> Keep
+              </button>
+            }
+          </div>
+        </div>
+        <div class="p-5 flex-grow text-base text-slate-800 dark:text-slate-200 leading-relaxed whitespace-pre-wrap">
+          @if (isPolishing) {
+            <span class="text-cyan-500"><i class="bi bi-arrow-repeat animate-spin"></i> {{ activeAction?.label }}...</span>
+          } @else if (polishedText) {
+            {{ polishedText }}
+          } @else {
+            <span class="text-slate-400 dark:text-slate-500 font-light select-none">Pick a polish action — the cleaned-up version lands here. "Keep" it to chain another pass.</span>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/dictate-and-polish-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/dictate-and-polish-demo.component.ts
@@ -1,0 +1,230 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Proofreader: any;
+declare const Rewriter: any;
+
+interface PolishAction {
+  id: string;
+  label: string;
+  icon: string;
+  api: 'Proofreader' | 'Rewriter';
+  tone?: 'more-formal' | 'more-casual';
+  length?: 'shorter' | 'longer';
+}
+
+const ACTIONS: PolishAction[] = [
+  { id: 'proofread', label: 'Fix grammar & punctuation', icon: 'bi-patch-check', api: 'Proofreader' },
+  { id: 'formal', label: 'Make it formal', icon: 'bi-briefcase', api: 'Rewriter', tone: 'more-formal' },
+  { id: 'casual', label: 'Make it casual', icon: 'bi-emoji-smile', api: 'Rewriter', tone: 'more-casual' },
+  { id: 'shorter', label: 'Tighten it up', icon: 'bi-arrows-collapse', api: 'Rewriter', length: 'shorter' }
+];
+
+@Component({
+  selector: 'app-dictate-and-polish-demo',
+  templateUrl: './dictate-and-polish-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class DictateAndPolishDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'dictate-and-polish')!;
+
+  actions = ACTIONS;
+
+  rawText = '';
+  interim = '';
+  polishedText = '';
+  activeAction: PolishAction | null = null;
+  isPolishing = false;
+  polishTimeMs: number | null = null;
+
+  proofreaderStatus = 'loading...';
+  rewriterStatus = 'loading...';
+
+  sampleDictation =
+    'so um basically the idea is we take the quarterly numbers right and we put them in like a dashboard thing ' +
+    'so everyone can see them without asking me every time and also i think we should probably automate the report ' +
+    'because doing it by hand every month is honestly kind of a waste of my time';
+
+  private proofreader: any = null;
+  private rewriters = new Map<string, any>();
+
+  /** Text dictated before the current recognition session started. */
+  private sessionBase = '';
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    await this.checkSpeechAvailability({ quality: 'dictation' });
+
+    try {
+      this.proofreaderStatus = 'Proofreader' in self ? await Proofreader.availability() : 'unavailable';
+    } catch { this.proofreaderStatus = 'unavailable'; }
+    try {
+      this.rewriterStatus = 'Rewriter' in self ? await Rewriter.availability() : 'unavailable';
+    } catch { this.rewriterStatus = 'unavailable'; }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Web Speech (on-device)', status: this.speechStatus },
+      { name: 'Proofreader', status: this.proofreaderStatus },
+      { name: 'Rewriter', status: this.rewriterStatus }
+    ];
+  }
+
+  actionAvailable(action: PolishAction): boolean {
+    return action.api === 'Proofreader'
+      ? this.proofreaderStatus !== 'unavailable'
+      : this.rewriterStatus !== 'unavailable';
+  }
+
+  startDictation() {
+    if (this.isListening || this.speechStatus !== 'available') return;
+
+    this.errorMessage = '';
+    try {
+      this.recognition = this.webSpeech.createRecognizer({
+        quality: 'dictation',
+        continuous: true,
+        interimResults: true
+      });
+    } catch (e: any) {
+      this.errorMessage = e.message;
+      return;
+    }
+
+    const r = this.recognition;
+    this.isListening = true;
+
+    r.onresult = (event: any) => this.ngZone.run(() => {
+      let finalText = '';
+      let interim = '';
+      for (let i = 0; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) finalText += transcript + ' ';
+        else interim += transcript;
+      }
+      // Each recognition session resets the results list, so append to prior sessions.
+      if (finalText.trim()) this.rawText = this.mergeTranscript(finalText.trim());
+      this.interim = interim;
+    });
+
+    r.onerror = (event: any) => this.ngZone.run(() => {
+      this.errorMessage = event.error === 'not-allowed'
+        ? 'Microphone access was denied. Allow the mic to dictate.'
+        : `Recognition error: ${event.error}`;
+    });
+
+    r.onend = () => this.ngZone.run(() => {
+      this.isListening = false;
+      this.interim = '';
+      this.recognition = null;
+    });
+
+    this.sessionBase = this.rawText;
+    r.start();
+  }
+
+  private mergeTranscript(sessionFinal: string): string {
+    return (this.sessionBase ? this.sessionBase + ' ' : '') + sessionFinal;
+  }
+
+  stopDictation() {
+    this.stopRecognition();
+  }
+
+  useSample() {
+    this.rawText = this.sampleDictation;
+    this.polishedText = '';
+    this.activeAction = null;
+  }
+
+  clearAll() {
+    this.rawText = '';
+    this.polishedText = '';
+    this.interim = '';
+    this.activeAction = null;
+    this.polishTimeMs = null;
+  }
+
+  async polish(action: PolishAction) {
+    const input = this.rawText.trim();
+    if (!input || this.isPolishing || !this.actionAvailable(action)) return;
+
+    this.isPolishing = true;
+    this.activeAction = action;
+    this.errorMessage = '';
+    this.polishedText = '';
+    const start = performance.now();
+
+    try {
+      if (action.api === 'Proofreader') {
+        if (!this.proofreader) {
+          this.proofreader = await Proofreader.create({ expectedInputLanguages: ['en'] });
+        }
+        const result = await this.proofreader.proofread(input);
+        this.polishedText = result.correctedInput ?? result.correction ?? input;
+      } else {
+        const key = `${action.tone ?? 'as-is'}|${action.length ?? 'as-is'}`;
+        if (!this.rewriters.has(key)) {
+          this.rewriters.set(key, await Rewriter.create({
+            tone: action.tone ?? 'as-is',
+            length: action.length ?? 'as-is',
+            format: 'plain-text'
+          }));
+        }
+        this.polishedText = await this.rewriters.get(key).rewrite(input);
+      }
+      this.polishTimeMs = Math.round(performance.now() - start);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Polishing failed.';
+    } finally {
+      this.isPolishing = false;
+    }
+  }
+
+  /** Promote the polished text to be the new working draft. */
+  keepPolished() {
+    if (!this.polishedText) return;
+    this.rawText = this.polishedText;
+    this.polishedText = '';
+    this.activeAction = null;
+  }
+
+  override ngOnDestroy() {
+    this.proofreader?.destroy?.();
+    this.rewriters.forEach(rewriter => rewriter.destroy?.());
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    const action = this.activeAction ?? ACTIONS[0];
+    let polishCode: string;
+    if (action.api === 'Proofreader') {
+      polishCode = `const proofreader = await Proofreader.create({ expectedInputLanguages: ["en"] });
+const { correctedInput } = await proofreader.proofread(rawTranscript);`;
+    } else {
+      polishCode = `const rewriter = await Rewriter.create({
+  tone: "${action.tone ?? 'as-is'}",
+  length: "${action.length ?? 'as-is'}",
+  format: "plain-text"
+});
+const polished = await rewriter.rewrite(rawTranscript);`;
+    }
+    return `// 1. Dictate on-device — speech never leaves the machine
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.continuous = true;
+recognition.interimResults = true;
+recognition.onresult = (e) => (rawTranscript = collectFinalResults(e));
+recognition.start();
+
+// 2. Polish the raw transcript ("${action.label}")
+${polishCode}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/draw-and-guess-demo.component.html
+++ b/webapp/src/app/pages/demos/features/draw-and-guess-demo.component.html
@@ -1,0 +1,127 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API with image input is not available in this browser.</span> Use a Chrome build with multimodal Gemini Nano enabled.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Game bar -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-4">
+      <div class="flex items-center gap-3">
+        <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">Draw this:</span>
+        <span class="text-2xl font-extrabold text-violet-600 dark:text-violet-400 tracking-wide">{{ word }}</span>
+      </div>
+      <div class="flex-grow"></div>
+      <label class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 cursor-pointer">
+        <input type="checkbox" class="accent-violet-600" [(ngModel)]="guessOnStroke" />
+        Guess after every stroke
+      </label>
+      <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ wins }} / {{ rounds }} rounds won</span>
+      <button class="px-4 py-2 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-300 text-xs font-semibold border border-slate-200 dark:border-zinc-700 transition-colors"
+              (click)="newRound()">
+        <i class="bi bi-shuffle"></i> New Word
+      </button>
+    </div>
+
+    @if (won) {
+      <div class="mb-6 bg-emerald-50 border-2 border-emerald-300 dark:bg-emerald-900/15 dark:border-emerald-700 rounded-3xl p-6 text-center">
+        <div class="text-4xl mb-2">🎉</div>
+        <div class="text-xl font-bold text-emerald-700 dark:text-emerald-300">
+          The model guessed "{{ word }}" in {{ strokeCount }} {{ strokeCount === 1 ? 'stroke' : 'strokes' }}!
+        </div>
+        <button class="mt-4 px-6 py-2.5 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                (click)="newRound()">
+          <i class="bi bi-arrow-repeat"></i> Next Word
+        </button>
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Canvas -->
+      <div class="lg:flex-[3] w-full">
+        <div class="bg-[#ffffff] rounded-3xl shadow-sm border-2 border-dashed border-slate-300 dark:border-zinc-600 overflow-hidden relative">
+          <canvas #canvas width="640" height="440"
+                  class="w-full h-auto bg-white cursor-crosshair touch-none block"
+                  (pointerdown)="onPointerDown($event)"
+                  (pointermove)="onPointerMove($event)"
+                  (pointerup)="onPointerUp($event)"
+                  (pointercancel)="onPointerUp($event)"></canvas>
+          @if (!hasDrawing) {
+            <div class="absolute inset-0 flex items-center justify-center pointer-events-none">
+              <span class="text-slate-300 text-sm font-light">Sketch "{{ word }}" here — mouse, finger, or stylus</span>
+            </div>
+          }
+        </div>
+        <div class="flex items-center gap-3 mt-3">
+          <button class="px-4 py-2 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-300 text-xs font-semibold border border-slate-200 dark:border-zinc-700 transition-colors"
+                  (click)="clearCanvas()">
+            <i class="bi bi-eraser"></i> Clear
+          </button>
+          <button class="px-4 py-2 rounded-full bg-violet-600 hover:bg-violet-700 text-white text-xs font-semibold shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                  [disabled]="!hasDrawing || isGuessing || won || languageModelAvailability === 'unavailable'"
+                  (click)="guess()">
+            @if (isGuessing) {
+              <i class="bi bi-arrow-repeat animate-spin"></i> Thinking...
+            } @else {
+              <i class="bi bi-eye"></i> Guess Now
+            }
+          </button>
+          <span class="text-xs text-slate-400 dark:text-slate-500">{{ strokeCount }} {{ strokeCount === 1 ? 'stroke' : 'strokes' }}</span>
+        </div>
+      </div>
+
+      <!-- Guesses -->
+      <div class="lg:flex-[2] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[300px]">
+        <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-chat-square-dots text-violet-500"></i> Model Guesses
+          </span>
+          @if (isGuessing) {
+            <i class="bi bi-arrow-repeat animate-spin text-violet-400"></i>
+          }
+        </div>
+        <div class="p-4 flex flex-col gap-2 flex-grow">
+          @if (guesses.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light px-6">
+              {{ guessOnStroke ? 'Draw a stroke — the model guesses after each one.' : 'Draw something, then hit "Guess Now".' }}
+            </p>
+          }
+          @for (guess of guesses; track $index) {
+            <div class="flex items-center gap-3 px-4 py-2.5 rounded-xl border transition-all"
+                 [ngClass]="guess.correct
+                   ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/15'
+                   : $first
+                     ? 'border-violet-200 dark:border-violet-800 bg-violet-50/50 dark:bg-violet-900/10'
+                     : 'border-slate-200 dark:border-zinc-700 bg-slate-50/50 dark:bg-[#161616]/50'">
+              @if (guess.correct) {
+                <i class="bi bi-check-circle-fill text-emerald-500"></i>
+              } @else {
+                <i class="bi bi-question-circle text-slate-400"></i>
+              }
+              <span class="text-sm font-semibold flex-grow"
+                    [ngClass]="guess.correct ? 'text-emerald-700 dark:text-emerald-300' : 'text-slate-700 dark:text-slate-300'">
+                "{{ guess.text }}"
+              </span>
+              <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">{{ guess.timeMs }}ms</span>
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/draw-and-guess-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/draw-and-guess-demo.component.ts
@@ -1,0 +1,211 @@
+import { Component, ElementRef, OnInit, ViewChild } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageModel: any;
+
+interface GuessEntry {
+  text: string;
+  correct: boolean;
+  timeMs: number;
+}
+
+const WORDS = [
+  'cat', 'house', 'tree', 'bicycle', 'sun', 'fish', 'car', 'clock',
+  'star', 'boat', 'flower', 'cup', 'chair', 'umbrella', 'snowman',
+  'rocket', 'glasses', 'pizza', 'butterfly', 'ladder'
+];
+
+@Component({
+  selector: 'app-draw-and-guess-demo',
+  templateUrl: './draw-and-guess-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class DrawAndGuessDemoComponent extends BaseDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'draw-and-guess')!;
+
+  @ViewChild('canvas') canvasRef!: ElementRef<HTMLCanvasElement>;
+
+  word = '';
+  guesses: GuessEntry[] = [];
+  won = false;
+  wins = 0;
+  rounds = 0;
+  strokeCount = 0;
+  hasDrawing = false;
+
+  isGuessing = false;
+  guessOnStroke = true;
+  errorMessage = '';
+
+  private drawing = false;
+  private guessTimer: any = null;
+  private guessToken = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability([{ type: 'image' }]);
+    this.newRound();
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API (image)', status: this.languageModelAvailability }];
+  }
+
+  get latestGuess(): GuessEntry | null {
+    return this.guesses[0] ?? null;
+  }
+
+  newRound() {
+    let next = this.word;
+    while (next === this.word) {
+      next = WORDS[Math.floor(Math.random() * WORDS.length)];
+    }
+    this.word = next;
+    this.won = false;
+    this.guesses = [];
+    this.strokeCount = 0;
+    this.rounds++;
+    this.clearCanvas();
+  }
+
+  clearCanvas() {
+    const canvas = this.canvasRef?.nativeElement;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d')!;
+    ctx.fillStyle = '#ffffff';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    this.hasDrawing = false;
+  }
+
+  private canvasPoint(event: PointerEvent): { x: number; y: number } {
+    const canvas = this.canvasRef.nativeElement;
+    const rect = canvas.getBoundingClientRect();
+    return {
+      x: ((event.clientX - rect.left) / rect.width) * canvas.width,
+      y: ((event.clientY - rect.top) / rect.height) * canvas.height
+    };
+  }
+
+  onPointerDown(event: PointerEvent) {
+    if (this.won) return;
+    event.preventDefault();
+    const canvas = this.canvasRef.nativeElement;
+    canvas.setPointerCapture(event.pointerId);
+    this.drawing = true;
+    // A fresh canvas needs its white background before the first stroke.
+    if (!this.hasDrawing) this.clearCanvas();
+    const ctx = canvas.getContext('2d')!;
+    const point = this.canvasPoint(event);
+    ctx.strokeStyle = '#18181b';
+    ctx.lineWidth = 7;
+    ctx.lineCap = 'round';
+    ctx.lineJoin = 'round';
+    ctx.beginPath();
+    ctx.moveTo(point.x, point.y);
+    this.hasDrawing = true;
+  }
+
+  onPointerMove(event: PointerEvent) {
+    if (!this.drawing) return;
+    event.preventDefault();
+    const ctx = this.canvasRef.nativeElement.getContext('2d')!;
+    const point = this.canvasPoint(event);
+    ctx.lineTo(point.x, point.y);
+    ctx.stroke();
+  }
+
+  onPointerUp(event: PointerEvent) {
+    if (!this.drawing) return;
+    event.preventDefault();
+    this.drawing = false;
+    this.strokeCount++;
+
+    if (this.guessOnStroke && !this.won) {
+      clearTimeout(this.guessTimer);
+      this.guessTimer = setTimeout(() => this.guess(), 800);
+    }
+  }
+
+  async guess() {
+    if (this.isGuessing || this.won || !this.hasDrawing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    const token = ++this.guessToken;
+    this.isGuessing = true;
+    this.errorMessage = '';
+    const start = performance.now();
+
+    try {
+      const bitmap = await createImageBitmap(this.canvasRef.nativeElement);
+      const session = await LanguageModel.create({
+        expectedInputs: [{ type: 'image' }],
+        systemPrompt: 'You are playing a drawing guessing game. The image is a simple hand-drawn black-on-white doodle. Reply with ONLY your single best guess for what it shows, in one to three lowercase words. No punctuation, no explanations.'
+      });
+
+      const raw = await session.prompt([{
+        role: 'user',
+        content: [
+          { type: 'text', value: 'What is this simple line drawing?' },
+          { type: 'image', value: bitmap }
+        ]
+      }]);
+      session.destroy?.();
+
+      if (token !== this.guessToken) return; // a newer guess superseded this one
+
+      const text = raw.trim().toLowerCase().replace(/[.!?"']/g, '').split('\n')[0];
+      const correct = text.includes(this.word);
+      this.guesses.unshift({ text, correct, timeMs: Math.round(performance.now() - start) });
+      if (this.guesses.length > 8) this.guesses.pop();
+
+      if (correct) {
+        this.won = true;
+        this.wins++;
+        clearTimeout(this.guessTimer);
+      }
+    } catch (e: any) {
+      this.errorMessage = e.message || 'The model could not make a guess.';
+    } finally {
+      if (token === this.guessToken) this.isGuessing = false;
+    }
+  }
+
+  override ngOnDestroy() {
+    clearTimeout(this.guessTimer);
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const session = await LanguageModel.create({
+  expectedInputs: [{ type: "image" }],
+  systemPrompt: "You are playing a drawing guessing game. " +
+    "Reply with ONLY your best guess for the doodle, in 1-3 lowercase words."
+});
+
+// After each stroke, let the model take a guess
+canvas.addEventListener("pointerup", async () => {
+  const bitmap = await createImageBitmap(canvas);
+
+  const guess = await session.prompt([{
+    role: "user",
+    content: [
+      { type: "text", value: "What is this simple line drawing?" },
+      { type: "image", value: bitmap }
+    ]
+  }]);
+
+  // Current word: "${this.word || 'cat'}" — ${this.guesses.length} guesses so far this round
+  if (guess.toLowerCase().includes(secretWord)) {
+    celebrate("Guessed in ${this.strokeCount || 'N'} strokes!");
+  }
+});`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/reply-composer-demo.component.html
+++ b/webapp/src/app/pages/demos/features/reply-composer-demo.component.html
@@ -1,0 +1,121 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Writer', status: writerStatus }]"
+      unavailableHint="<span class='font-semibold'>The Writer API is not available in this browser.</span> Enable it in a recent Chrome build to compose replies.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Inbox side -->
+      <div class="lg:flex-[2] w-full flex flex-col gap-3">
+        <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-envelope text-indigo-500"></i> Incoming
+        </span>
+        @for (email of emails; track email.subject) {
+          <button class="text-left rounded-2xl border p-4 transition-all bg-transparent"
+                  [ngClass]="selectedEmail === email
+                    ? 'border-indigo-300 dark:border-indigo-700 bg-indigo-50/60 dark:bg-indigo-900/10 shadow-sm'
+                    : 'border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90 hover:border-slate-300 dark:hover:border-zinc-600'"
+                  (click)="selectEmail(email)">
+            <div class="text-xs font-bold text-slate-800 dark:text-slate-200">{{ email.from }}</div>
+            <div class="text-xs font-semibold text-slate-600 dark:text-slate-400 mt-0.5">{{ email.subject }}</div>
+            <p class="text-[11px] text-slate-500 dark:text-slate-500 m-0 mt-1.5 leading-relaxed"
+               [ngClass]="selectedEmail === email ? '' : 'line-clamp-2'">{{ email.body }}</p>
+          </button>
+        }
+      </div>
+
+      <!-- Composer side -->
+      <div class="lg:flex-[3] w-full flex flex-col gap-4">
+
+        <!-- Controls -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 flex flex-col gap-4">
+          <div>
+            <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Reply intent</span>
+            <div class="flex flex-wrap gap-2 mt-2">
+              @for (intent of intents; track intent.label) {
+                <button class="flex items-center gap-1.5 px-4 py-2 rounded-full text-xs font-semibold transition-all active:scale-95 border-none shadow-sm disabled:opacity-50"
+                        [ngClass]="selectedIntent === intent ? 'bg-indigo-600 text-white' : 'bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-300'"
+                        [disabled]="isWriting || writerStatus === 'unavailable'"
+                        (click)="compose(intent)">
+                  <i class="bi {{ intent.icon }}"></i> {{ intent.label }}
+                </button>
+              }
+            </div>
+          </div>
+
+          <div class="flex flex-wrap gap-x-8 gap-y-3">
+            <div>
+              <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Tone</span>
+              <div class="inline-flex bg-slate-200/50 dark:bg-zinc-800/80 p-1 rounded-xl ml-3">
+                @for (option of ['formal', 'neutral', 'casual']; track option) {
+                  <button class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors border-none outline-none"
+                          [ngClass]="tone === option ? 'bg-[#ffffff] dark:bg-zinc-700 text-slate-900 dark:text-white shadow-sm' : 'text-slate-500 dark:text-slate-400 bg-transparent hover:text-slate-800 dark:hover:text-slate-200'"
+                          (click)="tone = option === 'formal' ? 'formal' : option === 'casual' ? 'casual' : 'neutral'">
+                    {{ option }}
+                  </button>
+                }
+              </div>
+            </div>
+            <div>
+              <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Length</span>
+              <div class="inline-flex bg-slate-200/50 dark:bg-zinc-800/80 p-1 rounded-xl ml-3">
+                @for (option of ['short', 'medium', 'long']; track option) {
+                  <button class="px-3 py-1.5 text-xs font-medium rounded-lg transition-colors border-none outline-none"
+                          [ngClass]="length === option ? 'bg-[#ffffff] dark:bg-zinc-700 text-slate-900 dark:text-white shadow-sm' : 'text-slate-500 dark:text-slate-400 bg-transparent hover:text-slate-800 dark:hover:text-slate-200'"
+                          (click)="length = option === 'short' ? 'short' : option === 'long' ? 'long' : 'medium'">
+                    {{ option }}
+                  </button>
+                }
+              </div>
+            </div>
+          </div>
+        </div>
+
+        <!-- Draft -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[240px]">
+          <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-reply text-indigo-500"></i> Draft Reply
+              @if (selectedIntent) {
+                <span class="normal-case font-medium text-slate-400">— {{ selectedIntent.label }}, {{ tone }}, {{ length }}</span>
+              }
+            </span>
+            @if (isWriting) {
+              <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-red-600 hover:bg-red-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="cancel()">
+                <i class="bi bi-stop-fill"></i> Stop
+              </button>
+            }
+          </div>
+          <div class="p-5 text-[15px] text-slate-800 dark:text-slate-200 leading-relaxed whitespace-pre-wrap flex-grow">
+            @if (draft) {
+              {{ draft }}@if (isWriting) {<span class="inline-block w-0.5 h-4 bg-indigo-500 animate-pulse align-middle ml-0.5"></span>}
+            } @else if (isWriting) {
+              <span class="text-indigo-500"><i class="bi bi-arrow-repeat animate-spin"></i></span>
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">Pick an intent above — the reply streams here, written entirely on-device.</span>
+            }
+          </div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/reply-composer-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/reply-composer-demo.component.ts
@@ -1,0 +1,170 @@
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Writer: any;
+
+type WriterTone = 'formal' | 'neutral' | 'casual';
+type WriterLength = 'short' | 'medium' | 'long';
+
+interface IncomingEmail {
+  from: string;
+  subject: string;
+  body: string;
+}
+
+interface ReplyIntent {
+  label: string;
+  icon: string;
+  task: string;
+}
+
+const EMAILS: IncomingEmail[] = [
+  {
+    from: 'Nadia Osei — Horizon Conf',
+    subject: 'Speaking invitation: Horizon Conf 2026',
+    body: 'Hi! We would love to have you speak at Horizon Conf this November in Lisbon. It is a 30-minute slot on the main stage about on-device AI in the browser. We cover travel and accommodation. Could you let us know by Friday whether you are interested?'
+  },
+  {
+    from: 'Tom Delacroix — Vantage Ventures',
+    subject: 'Quick call next week?',
+    body: 'Hey, I have been following your work on browser AI and I think there is a very interesting investment angle here. Would you have 30 minutes next week for a quick call? I am flexible on timing — happy to work around your schedule.'
+  },
+  {
+    from: 'Rachel Kim — Product',
+    subject: 'Can we ship the beta this Friday?',
+    body: 'The team is pushing to release the beta this Friday, but QA has only covered about half the test matrix. I know marketing already announced the date. What do you want to do — ship with known gaps, or slip a week and take the heat?'
+  }
+];
+
+const INTENTS: ReplyIntent[] = [
+  { label: 'Accept', icon: 'bi-check-circle', task: 'Write a reply that warmly accepts the proposal and asks about the practical next steps.' },
+  { label: 'Decline politely', icon: 'bi-x-circle', task: 'Write a reply that politely declines, gives a brief credible reason, and leaves the door open for the future.' },
+  { label: 'Ask for more time', icon: 'bi-hourglass-split', task: 'Write a reply that asks for a few more days to decide, states when a final answer will come, and thanks them for their patience.' },
+  { label: 'Request details', icon: 'bi-question-circle', task: 'Write a reply that asks two or three sharp clarifying questions needed before a decision can be made.' }
+];
+
+@Component({
+  selector: 'app-reply-composer-demo',
+  templateUrl: './reply-composer-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ReplyComposerDemoComponent extends BasePage implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'reply-composer')!;
+
+  emails = EMAILS;
+  intents = INTENTS;
+
+  selectedEmail = EMAILS[0];
+  selectedIntent: ReplyIntent | null = null;
+  tone: WriterTone = 'neutral';
+  length: WriterLength = 'short';
+
+  writerStatus = 'loading...';
+  errorMessage = '';
+  draft = '';
+  isWriting = false;
+  ttft: number | null = null;
+  totalTime: number | null = null;
+
+  private abortController: AbortController | null = null;
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.writerStatus = 'Writer' in self ? await Writer.availability() : 'unavailable';
+    } catch {
+      this.writerStatus = 'unavailable';
+    }
+  }
+
+  selectEmail(email: IncomingEmail) {
+    this.selectedEmail = email;
+    this.draft = '';
+    this.selectedIntent = null;
+  }
+
+  async compose(intent: ReplyIntent) {
+    if (this.isWriting || this.writerStatus === 'unavailable') return;
+
+    this.selectedIntent = intent;
+    this.isWriting = true;
+    this.errorMessage = '';
+    this.draft = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      const writer = await Writer.create({
+        tone: this.tone,
+        length: this.length,
+        format: 'plain-text',
+        sharedContext: `You are replying to this email from ${this.selectedEmail.from} with the subject "${this.selectedEmail.subject}":\n\n${this.selectedEmail.body}`
+      });
+
+      const stream = writer.writeStreaming(intent.task, { signal: this.abortController.signal });
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - startTime);
+        }
+        this.draft += chunk;
+      }
+      this.totalTime = Math.round(performance.now() - startTime);
+      writer.destroy?.();
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Could not draft the reply.';
+      }
+    } finally {
+      this.isWriting = false;
+      this.abortController = null;
+    }
+  }
+
+  cancel() {
+    this.abortController?.abort();
+  }
+
+  get dynamicCodeSnippet(): string {
+    const intent = this.selectedIntent ?? INTENTS[1];
+    return `const writer = await Writer.create({
+  tone: "${this.tone}",              // formal | neutral | casual
+  length: "${this.length}",            // short | medium | long
+  format: "plain-text",
+
+  // The email being replied to is context, not the writing task
+  sharedContext: \`You are replying to this email from ${this.selectedEmail.from}:
+${this.selectedEmail.body.slice(0, 90)}…\`
+});
+
+// The intent is the task
+const stream = writer.writeStreaming(
+  ${JSON.stringify(intent.task)}
+);
+
+for await (const chunk of stream) {
+  draft += chunk;
+}
+
+writer.destroy();`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/story-time-demo.component.html
+++ b/webapp/src/app/pages/demos/features/story-time-demo.component.html
@@ -1,0 +1,120 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>An API is unavailable.</span> The Writer API generates the story; speechSynthesis narrates it. Narration quality depends on the voices installed on this device.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Ingredients -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Tonight's story must feature...</span>
+      <div class="flex flex-col sm:flex-row gap-3 mt-3">
+        @for (ingredient of ingredients; track trackByIndex($index); let i = $index) {
+          <input type="text"
+                 class="flex-1 bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-4 py-2.5 text-sm text-slate-800 dark:text-slate-200 text-center outline-none focus:ring-2 focus:ring-cyan-500/40"
+                 [(ngModel)]="ingredients[i]"
+                 placeholder="Ingredient {{ i + 1 }}..." />
+        }
+        <button class="flex items-center justify-center gap-2 px-6 py-2.5 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                [disabled]="isWriting || writerStatus === 'unavailable'"
+                (click)="writeStory()">
+          @if (isWriting) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Writing...
+          } @else {
+            <i class="bi bi-magic"></i> Write the Story
+          }
+        </button>
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        @for (set of ingredientSets; track $index) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                  (click)="useIngredients(set)">
+            {{ set.join(' · ') }}
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Story book -->
+    <div class="bg-[#fffdf5] dark:bg-[#1a1814] rounded-3xl shadow-sm border border-amber-200/60 dark:border-amber-900/30 overflow-hidden">
+      <div class="px-6 py-4 border-b border-amber-100 dark:border-amber-900/20 flex justify-between items-center flex-wrap gap-3">
+        <span class="text-sm font-bold text-amber-800 dark:text-amber-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-moon-stars"></i> Story Time
+        </span>
+
+        <!-- Narration controls -->
+        @if (story && !isWriting && synthesisSupported) {
+          <div class="flex items-center gap-3">
+            <div class="flex items-center gap-2">
+              <span class="text-[10px] font-semibold text-amber-700/70 dark:text-amber-400/70">speed</span>
+              <input type="range" min="0.6" max="1.4" step="0.05" class="w-20 accent-amber-600"
+                     [(ngModel)]="rate" [disabled]="isSpeaking" />
+            </div>
+            @if (!isSpeaking) {
+              <button class="flex items-center gap-2 px-5 py-2 rounded-full bg-amber-600 hover:bg-amber-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 border-none"
+                      (click)="narrate()">
+                <i class="bi bi-play-fill"></i> Read Aloud
+              </button>
+            } @else {
+              @if (isPaused) {
+                <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                        (click)="resumeNarration()">
+                  <i class="bi bi-play-fill"></i> Resume
+                </button>
+              } @else {
+                <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-amber-600 hover:bg-amber-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                        (click)="pauseNarration()">
+                  <i class="bi bi-pause-fill"></i> Pause
+                </button>
+              }
+              <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-slate-500 hover:bg-slate-600 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="stopNarration()">
+                <i class="bi bi-stop-fill"></i> Stop
+              </button>
+            }
+          </div>
+        }
+      </div>
+
+      <div class="p-6 md:p-8 min-h-[240px]">
+        @if (isWriting && !story) {
+          <p class="text-amber-700/60 dark:text-amber-400/60 font-light text-center m-auto py-8">
+            <i class="bi bi-arrow-repeat animate-spin"></i> The Writer is inventing tonight's story...
+          </p>
+        } @else if (!story) {
+          <p class="text-amber-700/50 dark:text-amber-400/50 font-light text-center py-8 m-0">
+            Pick three ingredients and the on-device Writer will weave them into a bedtime story.
+          </p>
+        } @else if (isWriting || storyWords.length === 0) {
+          <p class="font-serif text-lg leading-loose text-slate-800 dark:text-amber-50/90 whitespace-pre-wrap m-0">{{ story }}<span class="inline-block w-0.5 h-5 bg-amber-500 animate-pulse align-middle ml-0.5"></span></p>
+        } @else {
+          <p class="font-serif text-lg leading-loose text-slate-800 dark:text-amber-50/90 m-0">
+            @for (word of storyWords; track word.start) {
+              <span [ngClass]="$index === currentWordIndex ? 'bg-amber-300 dark:bg-amber-600/60 rounded px-0.5 text-slate-900 dark:text-white' : ''">{{ word.text }}</span>{{ ' ' }}
+            }
+          </p>
+          @if (isSpeaking && !boundaryEventsSeen) {
+            <p class="text-[11px] text-amber-700/50 dark:text-amber-400/50 m-0 mt-4">
+              <i class="bi bi-info-circle"></i> This voice does not emit word boundary events, so the karaoke highlight stays off — narration still plays.
+            </p>
+          }
+        }
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/story-time-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/story-time-demo.component.ts
@@ -1,0 +1,242 @@
+import { Component, Inject, NgZone, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Writer: any;
+
+interface StoryWord {
+  text: string;
+  start: number;
+}
+
+@Component({
+  selector: 'app-story-time-demo',
+  templateUrl: './story-time-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class StoryTimeDemoComponent extends BasePage implements OnInit, OnDestroy {
+  demo = DEMOS_DATA.find(d => d.id === 'story-time')!;
+
+  ingredients: string[] = ['a dragon', 'a submarine', 'pancakes'];
+  ingredientSets: string[][] = [
+    ['a dragon', 'a submarine', 'pancakes'],
+    ['a shy robot', 'a lighthouse', 'a birthday cake'],
+    ['a penguin', 'a hot air balloon', 'a treasure map']
+  ];
+
+  writerStatus = 'loading...';
+  synthesisSupported = false;
+  errorMessage = '';
+
+  story = '';
+  storyWords: StoryWord[] = [];
+  currentWordIndex = -1;
+  boundaryEventsSeen = false;
+
+  isWriting = false;
+  isSpeaking = false;
+  isPaused = false;
+  rate = 0.95;
+
+  ttft: number | null = null;
+  totalTime: number | null = null;
+
+  private abortController: AbortController | null = null;
+  private currentUtterance: any = null;
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object,
+    private readonly ngZone: NgZone
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    this.synthesisSupported = 'speechSynthesis' in window;
+    try {
+      this.writerStatus = 'Writer' in self ? await Writer.availability() : 'unavailable';
+    } catch {
+      this.writerStatus = 'unavailable';
+    }
+  }
+
+  override ngOnDestroy() {
+    this.stopNarration();
+    this.abortController?.abort();
+    super.ngOnDestroy();
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Writer', status: this.writerStatus },
+      { name: 'Speech Synthesis', status: this.synthesisSupported ? 'available' : 'unavailable' }
+    ];
+  }
+
+  useIngredients(set: string[]) {
+    this.ingredients = [...set];
+  }
+
+  trackByIndex(index: number): number {
+    return index;
+  }
+
+  private get cleanedIngredients(): string[] {
+    return this.ingredients.map(i => i.trim()).filter(i => i.length > 0);
+  }
+
+  async writeStory() {
+    const ingredients = this.cleanedIngredients;
+    if (ingredients.length === 0 || this.isWriting || this.writerStatus === 'unavailable') return;
+
+    this.stopNarration();
+    this.isWriting = true;
+    this.errorMessage = '';
+    this.story = '';
+    this.storyWords = [];
+    this.currentWordIndex = -1;
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      const writer = await Writer.create({
+        tone: 'casual',
+        format: 'plain-text',
+        length: 'medium',
+        sharedContext: 'You write warm, gentle bedtime stories for children aged four to eight. Simple words, short sentences, a happy ending, around 200 words.'
+      });
+
+      const stream = writer.writeStreaming(
+        `Write a bedtime story featuring ${ingredients.join(', ')}.`,
+        { signal: this.abortController.signal }
+      );
+
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - startTime);
+        }
+        this.story += chunk;
+      }
+      this.totalTime = Math.round(performance.now() - startTime);
+      writer.destroy?.();
+
+      this.storyWords = this.splitIntoWords(this.story);
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Could not write the story.';
+      }
+    } finally {
+      this.isWriting = false;
+      this.abortController = null;
+    }
+  }
+
+  /** Splits the story into words while remembering each word's character offset. */
+  private splitIntoWords(text: string): StoryWord[] {
+    const words: StoryWord[] = [];
+    const regex = /\S+/g;
+    let match: RegExpExecArray | null;
+    while ((match = regex.exec(text)) !== null) {
+      words.push({ text: match[0], start: match.index });
+    }
+    return words;
+  }
+
+  narrate() {
+    if (!this.story || !this.synthesisSupported || this.isSpeaking) return;
+
+    const synth = (window as any).speechSynthesis;
+    synth.cancel();
+
+    const utterance = new (window as any).SpeechSynthesisUtterance(this.story);
+    utterance.rate = this.rate;
+    utterance.pitch = 1.05;
+
+    utterance.onstart = () => this.ngZone.run(() => {
+      this.isSpeaking = true;
+      this.isPaused = false;
+    });
+
+    // Boundary events drive the karaoke highlight: charIndex → word index.
+    utterance.onboundary = (event: any) => this.ngZone.run(() => {
+      this.boundaryEventsSeen = true;
+      const index = this.storyWords.findIndex(
+        (word, i) => event.charIndex >= word.start &&
+          (i === this.storyWords.length - 1 || event.charIndex < this.storyWords[i + 1].start)
+      );
+      if (index >= 0) this.currentWordIndex = index;
+    });
+
+    const finish = () => this.ngZone.run(() => {
+      this.isSpeaking = false;
+      this.isPaused = false;
+      this.currentWordIndex = -1;
+    });
+    utterance.onend = finish;
+    utterance.onerror = finish;
+
+    this.currentUtterance = utterance;
+    synth.speak(utterance);
+  }
+
+  pauseNarration() {
+    (window as any).speechSynthesis?.pause();
+    this.isPaused = true;
+  }
+
+  resumeNarration() {
+    (window as any).speechSynthesis?.resume();
+    this.isPaused = false;
+  }
+
+  stopNarration() {
+    if (typeof window !== 'undefined' && 'speechSynthesis' in window) {
+      (window as any).speechSynthesis.cancel();
+    }
+    this.isSpeaking = false;
+    this.isPaused = false;
+    this.currentWordIndex = -1;
+  }
+
+  get dynamicCodeSnippet(): string {
+    const ingredients = this.cleanedIngredients.join(', ') || 'a dragon, a submarine, pancakes';
+    return `// 1. Write the story on-device
+const writer = await Writer.create({
+  tone: "casual",
+  format: "plain-text",
+  length: "medium",
+  sharedContext: "You write warm bedtime stories for young children."
+});
+
+const stream = writer.writeStreaming(
+  "Write a bedtime story featuring ${ingredients}."
+);
+for await (const chunk of stream) story += chunk;
+
+// 2. Narrate it with word-by-word karaoke highlighting
+const utterance = new SpeechSynthesisUtterance(story);
+utterance.rate = ${this.rate};
+
+utterance.onboundary = (event) => {
+  // charIndex points into the utterance text at the word being spoken
+  highlightWordAt(event.charIndex);
+};
+
+speechSynthesis.speak(utterance);
+// speechSynthesis.pause() / .resume() / .cancel()`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/summarizer-matrix-demo.component.html
+++ b/webapp/src/app/pages/demos/features/summarizer-matrix-demo.component.html
@@ -1,0 +1,85 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Summarizer', status: summarizerStatus }]"
+      unavailableHint="<span class='font-semibold'>The Summarizer API is not available in this browser.</span> Enable it in a recent Chrome build to generate the matrix.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Article -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden mb-6">
+      <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center flex-wrap gap-2">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-file-earmark-text text-emerald-500"></i> Source Article
+        </span>
+        <div class="flex items-center gap-3">
+          <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ filledCount }}/12 cells</span>
+          <button class="flex items-center gap-2 px-5 py-2 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                  [disabled]="isGeneratingAll || filledCount === 12 || summarizerStatus === 'unavailable' || !article.trim()"
+                  (click)="generateAll()">
+            @if (isGeneratingAll) {
+              <i class="bi bi-arrow-repeat animate-spin"></i> Generating... ({{ filledCount }}/12)
+            } @else {
+              <i class="bi bi-grid-3x3-gap"></i> Generate All 12
+            }
+          </button>
+        </div>
+      </div>
+      <textarea
+        class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 resize-none p-5 leading-relaxed text-sm min-h-[140px] max-h-[220px]"
+        [(ngModel)]="article"
+        (ngModelChange)="onArticleChanged()"
+        placeholder="Paste an article to summarize..."></textarea>
+    </div>
+
+    <!-- Matrix: one column per type -->
+    <div class="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-4 gap-4">
+      @for (type of types; track type) {
+        <div class="flex flex-col gap-3">
+          <div class="text-center">
+            <div class="text-sm font-bold text-slate-800 dark:text-slate-200 font-mono">{{ type }}</div>
+            <div class="text-[10px] text-slate-400 dark:text-slate-500">{{ typeHints[type] }}</div>
+          </div>
+          @for (length of lengths; track length) {
+            @let matrixCell = cell(type, length);
+            <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[110px]">
+              <div class="px-3.5 py-2 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex items-center justify-between">
+                <span class="text-[10px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">{{ length }}</span>
+                @if (matrixCell.timeMs !== null) {
+                  <span class="text-[9px] font-mono text-slate-300 dark:text-zinc-600">{{ matrixCell.timeMs }}ms</span>
+                } @else if (!matrixCell.isGenerating) {
+                  <button class="text-[10px] font-semibold text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 bg-transparent border-none transition-colors disabled:opacity-40"
+                          [disabled]="summarizerStatus === 'unavailable' || isGeneratingAll"
+                          (click)="generateCell(matrixCell)">
+                    generate
+                  </button>
+                }
+              </div>
+              <div class="p-3.5 text-xs text-slate-600 dark:text-slate-400 leading-relaxed whitespace-pre-wrap flex-grow max-h-[220px] overflow-y-auto">
+                @if (matrixCell.isGenerating) {
+                  <span class="text-emerald-500"><i class="bi bi-arrow-repeat animate-spin"></i> summarizing...</span>
+                } @else if (matrixCell.text) {
+                  {{ matrixCell.text }}
+                } @else {
+                  <span class="text-slate-300 dark:text-zinc-600 font-light">—</span>
+                }
+              </div>
+            </div>
+          }
+        </div>
+      }
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/summarizer-matrix-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/summarizer-matrix-demo.component.ts
@@ -1,0 +1,162 @@
+import { Component, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Summarizer: any;
+
+type SummaryType = 'tldr' | 'key-points' | 'teaser' | 'headline';
+type SummaryLength = 'short' | 'medium' | 'long';
+
+interface MatrixCell {
+  type: SummaryType;
+  length: SummaryLength;
+  text: string | null;
+  isGenerating: boolean;
+  timeMs: number | null;
+}
+
+const SAMPLE_ARTICLE = `Browsers are quietly becoming AI platforms. Over the past two years, Chrome has shipped a family of Built-In AI APIs that expose on-device models to any web page: a general-purpose language model behind the Prompt API, task-specific endpoints for summarizing, writing, rewriting, proofreading, and translating text, an embedding model for semantic search, and on-device speech recognition through the Web Speech API.
+
+The engineering bet behind the effort is that many AI features do not need a frontier model in a data center. Summarizing an email thread, correcting grammar as someone types, translating a chat message, or ranking help articles by meaning are all tasks that small, specialized models handle well — and they are exactly the tasks where privacy, latency, and cost matter most. When the model runs on the user's own hardware, keystrokes never leave the device, responses begin in milliseconds, and developers pay nothing per call.
+
+The approach also changes how web developers ship AI. Instead of every site bundling its own multi-hundred-megabyte model, the browser downloads a shared model once and every origin uses it. Availability APIs let pages detect whether a capability is ready, trigger a download when the user opts in, and fall back to server-side inference where necessary.
+
+Skeptics point out real limits: on-device models are smaller and less capable than their cloud counterparts, hardware requirements exclude older devices, and cross-browser standardization is still in its early days at the W3C. But the direction is set. The most interesting question is no longer whether browsers will ship AI, but which interactions become possible when intelligence is a free, private, always-available part of the web platform.`;
+
+@Component({
+  selector: 'app-summarizer-matrix-demo',
+  templateUrl: './summarizer-matrix-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SummarizerMatrixDemoComponent extends BasePage implements OnInit, OnDestroy {
+  demo = DEMOS_DATA.find(d => d.id === 'summarizer-matrix')!;
+
+  article = SAMPLE_ARTICLE;
+  summarizerStatus = 'loading...';
+  errorMessage = '';
+
+  readonly types: SummaryType[] = ['headline', 'teaser', 'tldr', 'key-points'];
+  readonly lengths: SummaryLength[] = ['short', 'medium', 'long'];
+
+  readonly typeHints: Record<SummaryType, string> = {
+    'headline': 'One attention-grabbing line',
+    'teaser': 'A hook that invites reading on',
+    'tldr': 'The whole thing, compressed',
+    'key-points': 'The main facts as bullets'
+  };
+
+  cells: MatrixCell[] = this.types.flatMap(type =>
+    this.lengths.map(length => ({ type, length, text: null, isGenerating: false, timeMs: null }))
+  );
+
+  isGeneratingAll = false;
+
+  private summarizers = new Map<string, any>();
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.summarizerStatus = 'Summarizer' in self ? await Summarizer.availability() : 'unavailable';
+    } catch {
+      this.summarizerStatus = 'unavailable';
+    }
+  }
+
+  override ngOnDestroy() {
+    this.summarizers.forEach(summarizer => summarizer.destroy?.());
+    super.ngOnDestroy();
+  }
+
+  cell(type: SummaryType, length: SummaryLength): MatrixCell {
+    return this.cells.find(c => c.type === type && c.length === length)!;
+  }
+
+  onArticleChanged() {
+    this.cells.forEach(cell => {
+      cell.text = null;
+      cell.timeMs = null;
+    });
+  }
+
+  get filledCount(): number {
+    return this.cells.filter(c => c.text !== null).length;
+  }
+
+  async generateCell(cell: MatrixCell) {
+    if (cell.isGenerating || this.summarizerStatus === 'unavailable' || !this.article.trim()) return;
+
+    cell.isGenerating = true;
+    this.errorMessage = '';
+    const start = performance.now();
+    try {
+      const key = `${cell.type}|${cell.length}`;
+      if (!this.summarizers.has(key)) {
+        this.summarizers.set(key, await Summarizer.create({
+          type: cell.type,
+          length: cell.length,
+          format: 'plain-text'
+        }));
+      }
+      cell.text = await this.summarizers.get(key).summarize(this.article, {
+        context: 'This is a technology article about browsers and on-device AI.'
+      });
+      cell.timeMs = Math.round(performance.now() - start);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Summarization failed.';
+    } finally {
+      cell.isGenerating = false;
+    }
+  }
+
+  async generateAll() {
+    if (this.isGeneratingAll) return;
+    this.isGeneratingAll = true;
+    try {
+      for (const cell of this.cells) {
+        if (cell.text === null) await this.generateCell(cell);
+      }
+    } finally {
+      this.isGeneratingAll = false;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `// Summarizer options:
+// type:   "headline" | "teaser" | "tldr" | "key-points"
+// length: "short" | "medium" | "long"
+// format: "plain-text" | "markdown"
+
+for (const type of ["headline", "teaser", "tldr", "key-points"]) {
+  for (const length of ["short", "medium", "long"]) {
+    const summarizer = await Summarizer.create({
+      type,
+      length,
+      format: "plain-text"
+    });
+
+    const summary = await summarizer.summarize(articleText, {
+      context: "This is a technology article about browsers and on-device AI."
+    });
+
+    renderCell(type, length, summary);
+    summarizer.destroy();
+  }
+}
+
+// ${this.filledCount}/12 combinations generated so far in this session`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/tone-pad-demo.component.html
+++ b/webapp/src/app/pages/demos/features/tone-pad-demo.component.html
@@ -1,0 +1,102 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Rewriter', status: rewriterStatus }]"
+      unavailableHint="<span class='font-semibold'>The Rewriter API is not available in this browser.</span> Enable the Rewriter API in a recent Chrome build to use the pad.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Input -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden mb-6">
+      <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center flex-wrap gap-2">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-pencil text-sky-500"></i> Your Message
+        </span>
+        <button class="flex items-center gap-2 px-5 py-2 rounded-full bg-sky-600 hover:bg-sky-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                [disabled]="isGeneratingAll || pendingCount === 0 || rewriterStatus === 'unavailable' || !text.trim()"
+                (click)="generateAll()">
+          @if (isGeneratingAll) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Rewriting... ({{ 8 - pendingCount }}/8)
+          } @else {
+            <i class="bi bi-grid-3x3-gap"></i> Fill the Pad
+          }
+        </button>
+      </div>
+      <textarea
+        class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-800 dark:text-slate-200 resize-none p-5 leading-relaxed text-base min-h-[80px]"
+        [(ngModel)]="text"
+        (ngModelChange)="onTextChanged()"
+        placeholder="Type a message to reshape..."></textarea>
+    </div>
+
+    <!-- The pad -->
+    <div class="flex flex-col items-center gap-2 mb-6">
+      <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest">
+        ← more casual · tone · more formal →
+      </div>
+      <div class="flex items-center gap-2 w-full">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-widest shrink-0" style="writing-mode: vertical-rl; transform: rotate(180deg);">
+          ← shorter · length · longer →
+        </div>
+        <div class="grid grid-cols-3 gap-3 flex-grow">
+          @for (row of grid; track $index) {
+            @for (cell of row; track cellLabel(cell)) {
+              <button class="text-left rounded-2xl border p-3.5 min-h-[120px] transition-all flex flex-col gap-1.5 relative bg-transparent"
+                      [ngClass]="selected === cell
+                        ? 'border-sky-400 dark:border-sky-600 ring-2 ring-sky-200 dark:ring-sky-900/60 bg-sky-50/60 dark:bg-sky-900/10'
+                        : isCenter(cell)
+                          ? 'border-slate-300 dark:border-zinc-600 bg-slate-50 dark:bg-[#161616] hover:border-slate-400'
+                          : 'border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90 hover:border-sky-300 dark:hover:border-sky-800 hover:shadow-md'"
+                      (click)="selectCell(cell)">
+                <span class="text-[9px] font-bold uppercase tracking-wider"
+                      [ngClass]="isCenter(cell) ? 'text-slate-500 dark:text-slate-400' : 'text-sky-600 dark:text-sky-400'">
+                  {{ cellLabel(cell) }}
+                  @if (cell.timeMs !== null) {
+                    <span class="font-mono text-slate-300 dark:text-zinc-600 normal-case ml-1">{{ cell.timeMs }}ms</span>
+                  }
+                </span>
+                @if (cell.isGenerating) {
+                  <span class="m-auto text-sky-500"><i class="bi bi-arrow-repeat animate-spin text-lg"></i></span>
+                } @else if (displayText(cell)) {
+                  <span class="text-[11px] text-slate-600 dark:text-slate-400 leading-snug line-clamp-4">{{ displayText(cell) }}</span>
+                } @else {
+                  <span class="m-auto text-slate-300 dark:text-zinc-600 text-xs font-light">click to rewrite</span>
+                }
+              </button>
+            }
+          }
+        </div>
+      </div>
+    </div>
+
+    <!-- Selected preview -->
+    @if (selected) {
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-sky-200 dark:border-sky-900/50 overflow-hidden">
+        <div class="px-5 py-3.5 border-b border-sky-100 dark:border-sky-900/30 bg-sky-50/50 dark:bg-sky-900/10 flex items-center gap-2">
+          <i class="bi bi-joystick text-sky-500"></i>
+          <span class="text-xs font-bold text-sky-700 dark:text-sky-300 uppercase tracking-wider">{{ cellLabel(selected) }}</span>
+          <span class="text-[10px] text-slate-400 dark:text-slate-500">tone: {{ selected.tone }} · length: {{ selected.length }}</span>
+        </div>
+        <div class="p-5 text-base text-slate-800 dark:text-slate-200 leading-relaxed">
+          @if (selected.isGenerating) {
+            <i class="bi bi-arrow-repeat animate-spin text-sky-400"></i>
+          } @else {
+            {{ displayText(selected) || '—' }}
+          }
+        </div>
+      </div>
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/tone-pad-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/tone-pad-demo.component.ts
@@ -1,0 +1,176 @@
+import { Component, Inject, OnDestroy, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const Rewriter: any;
+
+type RewriterTone = 'as-is' | 'more-formal' | 'more-casual';
+type RewriterLength = 'as-is' | 'shorter' | 'longer';
+
+interface PadCell {
+  tone: RewriterTone;
+  length: RewriterLength;
+  text: string | null;
+  isGenerating: boolean;
+  timeMs: number | null;
+}
+
+const SAMPLE_TEXT =
+  'hey! quick heads up - the demo kinda broke on my machine this morning, might wanna take a look before the big meeting so we don\'t look silly';
+
+@Component({
+  selector: 'app-tone-pad-demo',
+  templateUrl: './tone-pad-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class TonePadDemoComponent extends BasePage implements OnInit, OnDestroy {
+  demo = DEMOS_DATA.find(d => d.id === 'tone-pad')!;
+
+  text = SAMPLE_TEXT;
+  rewriterStatus = 'loading...';
+  errorMessage = '';
+
+  readonly tones: RewriterTone[] = ['more-casual', 'as-is', 'more-formal'];
+  readonly lengths: RewriterLength[] = ['shorter', 'as-is', 'longer'];
+
+  grid: PadCell[][] = this.lengths.map(length =>
+    this.tones.map(tone => ({ tone, length, text: null, isGenerating: false, timeMs: null }))
+  );
+
+  selected: PadCell | null = null;
+  isGeneratingAll = false;
+  generatedCount = 0;
+
+  private rewriters = new Map<string, any>();
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.rewriterStatus = 'Rewriter' in self ? await Rewriter.availability() : 'unavailable';
+    } catch {
+      this.rewriterStatus = 'unavailable';
+    }
+  }
+
+  override ngOnDestroy() {
+    this.rewriters.forEach(rewriter => rewriter.destroy?.());
+    super.ngOnDestroy();
+  }
+
+  isCenter(cell: PadCell): boolean {
+    return cell.tone === 'as-is' && cell.length === 'as-is';
+  }
+
+  cellLabel(cell: PadCell): string {
+    if (this.isCenter(cell)) return 'original';
+    const tone = cell.tone === 'as-is' ? '' : cell.tone.replace('more-', '');
+    const length = cell.length === 'as-is' ? '' : cell.length;
+    return [tone, length].filter(Boolean).join(' · ');
+  }
+
+  toneAxisLabel(tone: RewriterTone): string {
+    return tone === 'more-casual' ? 'More casual' : tone === 'more-formal' ? 'More formal' : 'Same tone';
+  }
+
+  lengthAxisLabel(length: RewriterLength): string {
+    return length === 'shorter' ? 'Shorter' : length === 'longer' ? 'Longer' : 'Same length';
+  }
+
+  onTextChanged() {
+    this.grid.flat().forEach(cell => {
+      cell.text = null;
+      cell.timeMs = null;
+    });
+    this.selected = null;
+  }
+
+  async selectCell(cell: PadCell) {
+    this.selected = cell;
+    if (!this.isCenter(cell) && cell.text === null && !cell.isGenerating) {
+      await this.generateCell(cell);
+    }
+  }
+
+  async generateCell(cell: PadCell) {
+    if (this.isCenter(cell) || this.rewriterStatus === 'unavailable' || !this.text.trim()) return;
+
+    cell.isGenerating = true;
+    this.errorMessage = '';
+    const start = performance.now();
+    try {
+      const key = `${cell.tone}|${cell.length}`;
+      if (!this.rewriters.has(key)) {
+        this.rewriters.set(key, await Rewriter.create({
+          tone: cell.tone,
+          length: cell.length,
+          format: 'plain-text'
+        }));
+      }
+      cell.text = await this.rewriters.get(key).rewrite(this.text);
+      cell.timeMs = Math.round(performance.now() - start);
+      this.generatedCount++;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Rewrite failed.';
+    } finally {
+      cell.isGenerating = false;
+    }
+  }
+
+  async generateAll() {
+    if (this.isGeneratingAll) return;
+    this.isGeneratingAll = true;
+    try {
+      for (const cell of this.grid.flat()) {
+        if (!this.isCenter(cell) && cell.text === null) {
+          await this.generateCell(cell);
+        }
+      }
+    } finally {
+      this.isGeneratingAll = false;
+    }
+  }
+
+  displayText(cell: PadCell): string {
+    return this.isCenter(cell) ? this.text : (cell.text ?? '');
+  }
+
+  get pendingCount(): number {
+    return this.grid.flat().filter(cell => !this.isCenter(cell) && cell.text === null).length;
+  }
+
+  get dynamicCodeSnippet(): string {
+    const cell = this.selected && !this.isCenter(this.selected) ? this.selected : null;
+    const tone = cell?.tone ?? 'more-formal';
+    const length = cell?.length ?? 'shorter';
+    return `// The Rewriter's option space is a grid:
+// tone:   more-casual | as-is | more-formal
+// length: shorter     | as-is | longer
+
+const rewriter = await Rewriter.create({
+  tone: "${tone}",
+  length: "${length}",
+  format: "plain-text"
+});
+
+const original = ${JSON.stringify(this.text.length > 120 ? this.text.slice(0, 120) + '…' : this.text)};
+
+const rewritten = await rewriter.rewrite(original);
+${cell?.text ? `// "${cell.text.slice(0, 100).replace(/"/g, '\\"')}${cell.text.length > 100 ? '…' : ''}"` : 'console.log(rewritten);'}
+
+rewriter.destroy();`;
+  }
+}


### PR DESCRIPTION
## Summary

Tranche 2 of the demo expansion: dedicated demos for the writing APIs (Rewriter gets its first demo and joins the filter chips), the two big multimodal Prompt API experiences, and the speechSynthesis side of Web Speech. Also moves **Embeddings back to the first category** on the demos page, with Speech second.

| Demo | Route | APIs |
|---|---|---|
| Tone Pad | `/demos/tone-pad` | Rewriter (3×3 tone × length pad) |
| Summarizer Options Matrix | `/demos/summarizer-matrix` | Summarizer (all 12 type × length combos) |
| Reply Composer | `/demos/reply-composer` | Writer (intent chips + tone/length knobs, streaming) |
| Dictate & Polish | `/demos/dictate-and-polish` | Web Speech + Proofreader + Rewriter |
| Live Camera Q&A | `/demos/camera-qa` | Prompt API (getUserMedia frame → image prompt) |
| Draw & Guess | `/demos/draw-and-guess` | Prompt API (canvas doodle guessing game) |
| Story Time | `/demos/story-time` | Writer + speechSynthesis (karaoke word highlighting) |

## Highlights

- **Tone Pad** makes the Rewriter's enum space tactile: nine cells around the original message, filled on click or all at once, with a preview panel and live code snippet reflecting the selected cell.
- **Dictate & Polish** chains three APIs: continuous dictation accumulates across recognition sessions, then one-click Proofreader or Rewriter passes clean it up — "Keep" promotes the result for another pass.
- **Draw & Guess** creates a fresh session per guess to keep context bounded, guesses after every stroke (debounced) with a per-round win/loss record.
- **Story Time** maps `onboundary` charIndex events onto pre-split word offsets for karaoke highlighting, with a graceful note when the active voice doesn't emit boundary events.
- Writer/Rewriter/Summarizer instances are cached per option combination and destroyed on component teardown.

## Testing

- `ng build` passes; all 7 new routes prerender through SSR (43 demo cards on the index).
- Camera and mic paths start only on user gesture and stop tracks on destroy; typed fallbacks exist where sensible (Dictate & Polish sample, Reply Composer needs no mic).
- Worth validating against real models: Rewriter tone/length fidelity across the pad, Summarizer matrix generation time for all 12 cells, and Draw & Guess accuracy on simple doodles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)