### PR TITLE
Add tool calling, dev-tool, and clone() demos

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -144,6 +144,12 @@ import { DictateAndPolishDemoComponent } from './pages/demos/features/dictate-an
 import { CameraQaDemoComponent } from './pages/demos/features/camera-qa-demo.component';
 import { DrawAndGuessDemoComponent } from './pages/demos/features/draw-and-guess-demo.component';
 import { StoryTimeDemoComponent } from './pages/demos/features/story-time-demo.component';
+import { ToolCallingDemoComponent } from './pages/demos/features/tool-calling-demo.component';
+import { ScreenshotToCodeDemoComponent } from './pages/demos/features/screenshot-to-code-demo.component';
+import { RegexLabDemoComponent } from './pages/demos/features/regex-lab-demo.component';
+import { CsvQaDemoComponent } from './pages/demos/features/csv-qa-demo.component';
+import { SessionBranchingDemoComponent } from './pages/demos/features/session-branching-demo.component';
+import { LocalizationQaDemoComponent } from './pages/demos/features/localization-qa-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { TrackingDownloadPage } from './pages/docs/tracking-download/tracking-download.page';
@@ -264,6 +270,12 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     CameraQaDemoComponent,
     DrawAndGuessDemoComponent,
     StoryTimeDemoComponent,
+    ToolCallingDemoComponent,
+    ScreenshotToCodeDemoComponent,
+    RegexLabDemoComponent,
+    CsvQaDemoComponent,
+    SessionBranchingDemoComponent,
+    LocalizationQaDemoComponent,
     AutoScrollDirective,
     CortexPage,
     CortexInsightsPage,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -59,6 +59,12 @@ import { DictateAndPolishDemoComponent } from './pages/demos/features/dictate-an
 import { CameraQaDemoComponent } from './pages/demos/features/camera-qa-demo.component';
 import { DrawAndGuessDemoComponent } from './pages/demos/features/draw-and-guess-demo.component';
 import { StoryTimeDemoComponent } from './pages/demos/features/story-time-demo.component';
+import { ToolCallingDemoComponent } from './pages/demos/features/tool-calling-demo.component';
+import { ScreenshotToCodeDemoComponent } from './pages/demos/features/screenshot-to-code-demo.component';
+import { RegexLabDemoComponent } from './pages/demos/features/regex-lab-demo.component';
+import { CsvQaDemoComponent } from './pages/demos/features/csv-qa-demo.component';
+import { SessionBranchingDemoComponent } from './pages/demos/features/session-branching-demo.component';
+import { LocalizationQaDemoComponent } from './pages/demos/features/localization-qa-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { DocsErrorsPage } from './pages/docs/errors/errors.page';
@@ -624,6 +630,48 @@ const routes: Routes = [
       {
         path: "demos/story-time",
         component: StoryTimeDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/tool-calling",
+        component: ToolCallingDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/screenshot-to-code",
+        component: ScreenshotToCodeDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/regex-lab",
+        component: RegexLabDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/csv-qa",
+        component: CsvQaDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/session-branching",
+        component: SessionBranchingDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/localization-qa",
+        component: LocalizationQaDemoComponent,
         data: {
           route: RouteEnum.Demos
         }

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -433,6 +433,36 @@ canvas.addEventListener("pointerup", async () => {
     initialPrompt: ''
   },
   {
+    id: 'localization-qa',
+    title: 'Localization QA',
+    description: 'Scan a locale file for strings left in the wrong language, then fix the stragglers with one click.',
+    category: 'Mix-and-Match',
+    apis: ['Language Detector', 'Translator'],
+    icon: 'bi-file-earmark-diff',
+    onDeviceReason: 'A practical build-time tool running in a tab: the Language Detector audits every string locally and the Translator patches the misses — no localization service required.',
+    codeSnippet: `const detector = await LanguageDetector.create();
+const expected = "fr"; // this is supposed to be fr.json
+
+const issues = [];
+for (const [key, value] of Object.entries(localeStrings)) {
+  const [top] = await detector.detect(value);
+  if (top.detectedLanguage !== expected && top.confidence > 0.5) {
+    issues.push({ key, value, found: top.detectedLanguage, confidence: top.confidence });
+  }
+}
+
+// Fix a straggler: translate it into the expected language
+async function fix(issue) {
+  const translator = await Translator.create({
+    sourceLanguage: issue.found,
+    targetLanguage: expected
+  });
+  localeStrings[issue.key] = await translator.translate(issue.value);
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
     id: 'universal-inbox',
     title: 'Universal Inbox',
     description: 'A five-API pipeline: detect each message\'s language, translate it, triage it into folders, digest the inbox, and draft replies in the sender\'s language.',
@@ -1093,6 +1123,188 @@ const result = await session.prompt([{
   },
 
   // TOOLS CALLING
+  {
+    id: 'tool-calling',
+    title: 'Tool Calling: Smart Home',
+    description: 'Real function calling: tell the model what you want and watch it invoke JavaScript tools that drive a live dashboard.',
+    category: 'Tools Calling',
+    apis: ['Prompt API'],
+    icon: 'bi-house-gear',
+    onDeviceReason: 'The agentic loop — reason, call a function, read the result, respond — runs entirely on-device. Your smart-home state and commands never leave the browser.',
+    codeSnippet: `const session = await LanguageModel.create({
+  systemPrompt: "You control a smart home. Use the tools to fulfil requests.",
+  tools: [
+    {
+      name: "setLight",
+      description: "Turn a room's light on or off.",
+      inputSchema: {
+        type: "object",
+        properties: {
+          room: { type: "string", enum: ["living room", "bedroom", "kitchen"] },
+          on: { type: "boolean" }
+        },
+        required: ["room", "on"]
+      },
+      async execute({ room, on }) {
+        home.lights[room] = on;        // really updates the dashboard
+        return JSON.stringify({ ok: true, room, on });
+      }
+    },
+    {
+      name: "setThermostat",
+      description: "Set the target temperature in Celsius.",
+      inputSchema: {
+        type: "object",
+        properties: { temperature: { type: "number" } },
+        required: ["temperature"]
+      },
+      async execute({ temperature }) {
+        home.thermostat = temperature;
+        return JSON.stringify({ ok: true, temperature });
+      }
+    }
+  ]
+});
+
+// The model decides which tools to call, in what order
+const reply = await session.prompt("Make the living room cozy and warm for movie night.");`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'csv-qa',
+    title: 'CSV Q&A',
+    description: 'Paste a CSV and ask questions in plain English — answers come back structured, with the reasoning shown.',
+    category: 'Tools Calling',
+    apis: ['Prompt API'],
+    icon: 'bi-table',
+    onDeviceReason: 'Business data is exactly what should not be pasted into a cloud chatbot. Here the spreadsheet is analyzed by the on-device model and never leaves the tab.',
+    codeSnippet: `const schema = {
+  type: "object",
+  properties: {
+    answer: { type: "string" },
+    reasoning: { type: "string" }
+  },
+  required: ["answer", "reasoning"],
+  additionalProperties: false
+};
+
+const session = await LanguageModel.create({
+  systemPrompt: "You answer questions about CSV data accurately. " +
+    "Show your calculation in the reasoning field."
+});
+
+const result = await session.prompt(
+  \`CSV data:\\n\${csvText}\\n\\nQuestion: Which region had the highest total revenue?\`,
+  { responseConstraint: schema }
+);
+
+const { answer, reasoning } = JSON.parse(result);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'screenshot-to-code',
+    title: 'Screenshot → UI Code',
+    description: 'Drop a UI screenshot and the multimodal model rebuilds it as HTML — rendered live next to the original.',
+    category: 'Image Input',
+    apis: ['Prompt API'],
+    icon: 'bi-window-split',
+    onDeviceReason: 'Design mockups and internal screenshots are sensitive by default. On-device vision turns them into code without uploading a single pixel.',
+    codeSnippet: `const session = await LanguageModel.create({
+  expectedInputs: [{ type: "image" }],
+  systemPrompt: "You convert UI screenshots into clean, semantic HTML " +
+    "with inline CSS styles. Output ONLY the HTML, no explanations."
+});
+
+const bitmap = await createImageBitmap(screenshotFile);
+
+const stream = session.promptStreaming([{
+  role: "user",
+  content: [
+    { type: "text", value: "Rebuild this UI as HTML with inline styles." },
+    { type: "image", value: bitmap }
+  ]
+}]);
+
+let html = "";
+for await (const chunk of stream) html += chunk;
+
+// Render the result safely in a sandboxed iframe
+iframe.sandbox = "";
+iframe.srcdoc = html;`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'regex-lab',
+    title: 'Regex Lab',
+    description: 'Describe a pattern in English, get a regex with an explanation — and test it live with match highlighting.',
+    category: 'Text Input',
+    apis: ['Prompt API'],
+    icon: 'bi-asterisk',
+    onDeviceReason: 'A regex assistant that lives in your dev workflow: instant, offline, and free to iterate against as many test strings as you like.',
+    codeSnippet: `const schema = {
+  type: "object",
+  properties: {
+    pattern: { type: "string" },
+    flags: { type: "string" },
+    explanation: { type: "string" }
+  },
+  required: ["pattern", "flags", "explanation"],
+  additionalProperties: false
+};
+
+const session = await LanguageModel.create({
+  systemPrompt: "You write JavaScript regular expressions. " +
+    "Return the pattern WITHOUT surrounding slashes."
+});
+
+const result = await session.prompt(
+  "Write a regex that matches ISO dates like 2026-07-29.",
+  { responseConstraint: schema }
+);
+
+const { pattern, flags, explanation } = JSON.parse(result);
+const regex = new RegExp(pattern, flags.includes("g") ? flags : flags + "g");
+
+for (const match of testString.matchAll(regex)) {
+  highlight(match.index, match[0]);
+}`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'session-branching',
+    title: 'Branching Conversations',
+    description: 'Fork one conversation into two futures with session.clone() — both branches inherit the context, then diverge side by side.',
+    category: 'Text Input',
+    apis: ['Prompt API'],
+    icon: 'bi-signpost-2',
+    onDeviceReason: 'Cloning a session copies its context without re-processing a single token — exploring multiple continuations is instant and free when the model is local.',
+    codeSnippet: `const session = await LanguageModel.create();
+
+// Build up shared context once
+const base = await session.prompt(
+  "We're naming a new open-source library for on-device AI benchmarks. Suggest a direction."
+);
+
+// Fork the conversation — each clone inherits the full history
+const optimist = await session.clone();
+const skeptic = await session.clone();
+
+// The branches diverge from the same starting point
+const [praise, critique] = await Promise.all([
+  optimist.prompt("Build on your suggestion enthusiastically. What makes it great?"),
+  skeptic.prompt("Now be brutally honest. What's wrong with your suggestion?")
+]);
+
+// The original session is untouched by either branch
+optimist.destroy();
+skeptic.destroy();`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
   {
     id: 'structured-json',
     title: 'Structured JSON Output',

--- a/webapp/src/app/pages/demos/features/csv-qa-demo.component.html
+++ b/webapp/src/app/pages/demos/features/csv-qa-demo.component.html
@@ -1,0 +1,123 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API is not available in this browser.</span> Use a recent Chrome build with Gemini Nano enabled.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Question bar -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="flex gap-3">
+        <input type="text"
+               class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-emerald-500/40"
+               [(ngModel)]="question"
+               (keydown.enter)="ask()"
+               placeholder="Ask a question about the data below..." />
+        @if (state === 'Inferencing') {
+          <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                  (click)="onCancel()">
+            <i class="bi bi-stop-fill"></i> Stop
+          </button>
+        } @else {
+          <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                  [disabled]="!question.trim() || languageModelAvailability === 'unavailable'"
+                  (click)="ask()">
+            <i class="bi bi-search"></i> Ask
+          </button>
+        }
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        @for (sample of sampleQuestions; track sample) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                  [disabled]="state === 'Inferencing'"
+                  (click)="useSample(sample)">
+            {{ sample }}
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Answer -->
+    @if (answer || state === 'Inferencing') {
+      <div class="mb-6 bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-emerald-200 dark:border-emerald-900/50 overflow-hidden">
+        <div class="px-5 py-3.5 border-b border-emerald-100 dark:border-emerald-900/30 bg-emerald-50/50 dark:bg-emerald-900/10 flex justify-between items-center">
+          <span class="text-xs font-bold text-emerald-700 dark:text-emerald-300 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-check-square"></i> Answer
+          </span>
+          @if (state === 'Inferencing') {
+            <app-latency-loader></app-latency-loader>
+          }
+        </div>
+        <div class="p-5">
+          @if (answer) {
+            <p class="text-lg font-semibold text-slate-800 dark:text-slate-200 m-0">{{ answer }}</p>
+            @if (reasoning) {
+              <div class="mt-3 pt-3 border-t border-slate-100 dark:border-zinc-800">
+                <span class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Reasoning</span>
+                <p class="text-sm text-slate-600 dark:text-slate-400 m-0 mt-1 leading-relaxed whitespace-pre-wrap">{{ reasoning }}</p>
+              </div>
+            }
+          } @else {
+            <span class="text-sm text-emerald-600 dark:text-emerald-400"><i class="bi bi-arrow-repeat animate-spin"></i> Analyzing the data...</span>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Data -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+      <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+        <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-table text-emerald-500"></i> Your Data — {{ dataRows.length }} rows
+        </span>
+        <button class="text-[11px] font-semibold text-emerald-600 dark:text-emerald-400 hover:text-emerald-700 bg-transparent border-none transition-colors"
+                (click)="showData = !showData">
+          {{ showData ? 'edit as CSV' : 'show as table' }}
+        </button>
+      </div>
+
+      @if (showData) {
+        <div class="overflow-x-auto">
+          <table class="w-full text-sm">
+            <thead>
+              <tr class="bg-slate-50/80 dark:bg-[#161616]/80">
+                @for (header of headerRow; track header) {
+                  <th class="px-4 py-2.5 text-left text-[11px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">{{ header }}</th>
+                }
+              </tr>
+            </thead>
+            <tbody>
+              @for (row of dataRows; track $index) {
+                <tr class="border-t border-slate-100 dark:border-zinc-800">
+                  @for (cell of row; track $index) {
+                    <td class="px-4 py-2 text-xs text-slate-600 dark:text-slate-400 font-mono whitespace-nowrap">{{ cell }}</td>
+                  }
+                </tr>
+              }
+            </tbody>
+          </table>
+        </div>
+      } @else {
+        <textarea
+          class="w-full bg-transparent border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 resize-none p-5 text-xs font-mono leading-relaxed min-h-[260px]"
+          [(ngModel)]="csvText"
+          placeholder="Paste CSV data with a header row..."></textarea>
+      }
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/csv-qa-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/csv-qa-demo.component.ts
@@ -1,0 +1,160 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+const ANSWER_SCHEMA = {
+  type: 'object',
+  properties: {
+    answer: { type: 'string' },
+    reasoning: { type: 'string' }
+  },
+  required: ['answer', 'reasoning'],
+  additionalProperties: false
+};
+
+const SAMPLE_CSV = `date,region,product,units,revenue
+2026-06-02,Europe,Falcon Drone,12,14400
+2026-06-05,Americas,Falcon Drone,8,9600
+2026-06-09,Asia,Comet Camera,25,11250
+2026-06-11,Europe,Comet Camera,18,8100
+2026-06-14,Americas,Nimbus Speaker,40,7200
+2026-06-17,Asia,Falcon Drone,15,18000
+2026-06-20,Europe,Nimbus Speaker,22,3960
+2026-06-23,Americas,Comet Camera,30,13500
+2026-06-26,Asia,Nimbus Speaker,55,9900
+2026-06-28,Europe,Falcon Drone,9,10800
+2026-07-01,Americas,Falcon Drone,14,16800
+2026-07-03,Asia,Comet Camera,20,9000`;
+
+@Component({
+  selector: 'app-csv-qa-demo',
+  templateUrl: './csv-qa-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class CsvQaDemoComponent extends BaseDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'csv-qa')!;
+
+  csvText = SAMPLE_CSV;
+  question = '';
+  answer = '';
+  reasoning = '';
+  errorMessage = '';
+  showData = true;
+
+  sampleQuestions = [
+    'Which region had the highest total revenue?',
+    'What is the total revenue for the Falcon Drone?',
+    'Which product sold the most units overall?',
+    'What was the average revenue per order in June?'
+  ];
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API', status: this.languageModelAvailability }];
+  }
+
+  get parsedRows(): string[][] {
+    return this.csvText
+      .trim()
+      .split('\n')
+      .map(line => line.split(',').map(cell => cell.trim()))
+      .filter(row => row.length > 1);
+  }
+
+  get headerRow(): string[] {
+    return this.parsedRows[0] ?? [];
+  }
+
+  get dataRows(): string[][] {
+    return this.parsedRows.slice(1);
+  }
+
+  useSample(sample: string) {
+    this.question = sample;
+    this.ask();
+  }
+
+  async ask() {
+    const question = this.question.trim();
+    if (!question || !this.csvText.trim() || this.state === PromptInputStateEnum.Inferencing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.answer = '';
+    this.reasoning = '';
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+    const startTime = performance.now();
+
+    try {
+      const session = await LanguageModel.create({
+        systemPrompt:
+          'You answer questions about CSV data accurately and carefully. ' +
+          'Work through the relevant rows step by step in the reasoning field, showing the numbers you add up. ' +
+          'Keep the answer field short and direct.'
+      });
+
+      const response = await session.prompt(
+        `CSV data:\n${this.csvText.trim()}\n\nQuestion: ${question}`,
+        { responseConstraint: ANSWER_SCHEMA, signal: this.abortController.signal }
+      );
+      session.destroy?.();
+
+      this.totalTime = Math.round(performance.now() - startTime);
+      this.ttft = this.totalTime;
+
+      const result = JSON.parse(response);
+      this.answer = result.answer;
+      this.reasoning = result.reasoning;
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Could not answer the question.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const question = this.question.trim() || this.sampleQuestions[0];
+    return `const schema = {
+  type: "object",
+  properties: {
+    answer: { type: "string" },
+    reasoning: { type: "string" }
+  },
+  required: ["answer", "reasoning"],
+  additionalProperties: false
+};
+
+const session = await LanguageModel.create({
+  systemPrompt: "You answer questions about CSV data accurately. " +
+    "Show your calculation in the reasoning field."
+});
+
+// ${this.dataRows.length} rows of private business data — never uploaded
+const result = await session.prompt(
+  \`CSV data:\\n\${csvText}\\n\\nQuestion: ${question.replace(/`/g, '')}\`,
+  { responseConstraint: schema }
+);
+
+const { answer, reasoning } = JSON.parse(result);${this.answer ? `\n// answer: "${this.answer.slice(0, 80).replace(/"/g, '\\"')}${this.answer.length > 80 ? '…' : ''}"` : ''}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/localization-qa-demo.component.html
+++ b/webapp/src/app/pages/demos/features/localization-qa-demo.component.html
@@ -1,0 +1,137 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>An API is unavailable.</span> The Language Detector powers the scan; the Translator powers the one-click fixes. Language pairs download on first use.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Controls -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-4">
+      <div class="flex items-center gap-2 font-mono text-sm">
+        <i class="bi bi-file-earmark-code text-slate-400"></i>
+        <span class="font-bold text-slate-800 dark:text-slate-200">{{ fileName }}</span>
+      </div>
+      <div class="flex items-center gap-2">
+        <span class="text-xs font-semibold text-slate-500 dark:text-slate-400">should be entirely in</span>
+        <select [(ngModel)]="expectedLanguage" (ngModelChange)="onExpectedChanged()"
+                class="bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-lg px-3 py-2 text-sm font-semibold text-slate-700 dark:text-slate-300 outline-none cursor-pointer">
+          @for (lang of expectedLanguages; track lang.code) {
+            <option [value]="lang.code">{{ lang.label }}</option>
+          }
+        </select>
+      </div>
+      <div class="flex-grow"></div>
+      @if (hasScanned) {
+        <div class="flex items-center gap-2">
+          @if (issueCount > 0) {
+            <span class="text-xs font-bold px-3 py-1.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+              {{ issueCount }} {{ issueCount === 1 ? 'issue' : 'issues' }}
+            </span>
+            @if (translatorStatus !== 'unavailable') {
+              <button class="flex items-center gap-1.5 px-4 py-2 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                      (click)="fixAll()">
+                <i class="bi bi-magic"></i> Fix All
+              </button>
+            }
+          } @else {
+            <span class="text-xs font-bold px-3 py-1.5 rounded-full bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400">
+              <i class="bi bi-check-circle"></i> All strings in {{ languageLabel(expectedLanguage) }}{{ fixedCount > 0 ? ' — ' + fixedCount + ' fixed' : '' }}
+            </span>
+          }
+        </div>
+      }
+      <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+              [disabled]="isScanning || detectorStatus === 'unavailable'"
+              (click)="scan()">
+        @if (isScanning) {
+          <i class="bi bi-arrow-repeat animate-spin"></i> Scanning...
+        } @else {
+          <i class="bi bi-search"></i> {{ hasScanned ? 'Re-scan' : 'Scan File' }}
+        }
+      </button>
+    </div>
+
+    <!-- Entries table -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+      <div class="overflow-x-auto">
+        <table class="w-full">
+          <thead>
+            <tr class="bg-slate-50/80 dark:bg-[#161616]/80">
+              <th class="px-5 py-3 text-left text-[11px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Key</th>
+              <th class="px-5 py-3 text-left text-[11px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Value</th>
+              <th class="px-5 py-3 text-left text-[11px] font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider whitespace-nowrap">Detected</th>
+              <th class="px-5 py-3"></th>
+            </tr>
+          </thead>
+          <tbody>
+            @for (entry of entries; track entry.key) {
+              <tr class="border-t border-slate-100 dark:border-zinc-800 transition-colors"
+                  [ngClass]="{
+                    'bg-amber-50/60 dark:bg-amber-900/10': entry.status === 'wrong-language',
+                    'bg-emerald-50/50 dark:bg-emerald-900/10': entry.status === 'fixed'
+                  }">
+                <td class="px-5 py-3 font-mono text-xs text-slate-500 dark:text-slate-400 whitespace-nowrap">{{ entry.key }}</td>
+                <td class="px-5 py-3 text-sm text-slate-700 dark:text-slate-300">
+                  {{ entry.value }}
+                  @if (entry.status === 'fixed' && entry.previousValue) {
+                    <div class="text-[11px] text-slate-400 dark:text-slate-500 line-through mt-0.5">{{ entry.previousValue }}</div>
+                  }
+                </td>
+                <td class="px-5 py-3 whitespace-nowrap">
+                  @if (entry.detectedLanguage) {
+                    <span class="text-[11px] font-semibold px-2 py-1 rounded-md"
+                          [ngClass]="entry.status === 'wrong-language'
+                            ? 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400'
+                            : 'bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-slate-400'">
+                      {{ languageLabel(entry.detectedLanguage) }}
+                      @if (entry.confidence !== null && entry.status !== 'fixed') {
+                        {{ (entry.confidence * 100).toFixed(0) }}%
+                      }
+                    </span>
+                  } @else {
+                    <span class="text-xs text-slate-300 dark:text-zinc-600">—</span>
+                  }
+                </td>
+                <td class="px-5 py-3 text-right whitespace-nowrap">
+                  @if (entry.status === 'wrong-language') {
+                    <button class="px-3.5 py-1.5 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white text-[11px] font-semibold shadow-sm transition-all active:scale-95 disabled:opacity-50 border-none"
+                            [disabled]="entry.isFixing || translatorStatus === 'unavailable'"
+                            (click)="fix(entry)">
+                      @if (entry.isFixing) {
+                        <i class="bi bi-arrow-repeat animate-spin"></i>
+                      } @else {
+                        Translate to {{ languageLabel(expectedLanguage) }}
+                      }
+                    </button>
+                  } @else if (entry.status === 'fixed') {
+                    <span class="text-[11px] font-bold text-emerald-600 dark:text-emerald-400"><i class="bi bi-check-circle-fill"></i> Fixed</span>
+                  } @else if (entry.status === 'ok' && hasScanned) {
+                    <i class="bi bi-check text-emerald-500"></i>
+                  }
+                </td>
+              </tr>
+            }
+          </tbody>
+        </table>
+      </div>
+      @if (scanTimeMs !== null) {
+        <div class="px-5 py-2.5 border-t border-slate-100 dark:border-zinc-800 text-[11px] text-slate-400 dark:text-slate-500">
+          {{ entries.length }} strings audited on-device in {{ scanTimeMs }}ms
+        </div>
+      }
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/localization-qa-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/localization-qa-demo.component.ts
@@ -1,0 +1,225 @@
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageDetector: any;
+declare const Translator: any;
+
+interface LocaleEntry {
+  key: string;
+  value: string;
+  detectedLanguage: string | null;
+  confidence: number | null;
+  status: 'pending' | 'ok' | 'wrong-language' | 'fixed';
+  previousValue: string | null;
+  isFixing: boolean;
+}
+
+const SAMPLE_LOCALE: Record<string, string> = {
+  'nav.home': 'Accueil',
+  'nav.settings': 'Paramètres',
+  'nav.profile': 'Profil',
+  'button.save': 'Enregistrer les modifications',
+  'button.cancel': 'Cancel',
+  'dialog.delete.title': 'Supprimer ce document ?',
+  'dialog.delete.body': 'Cette action est irréversible. Le document sera définitivement supprimé.',
+  'toast.saved': 'Your changes have been saved successfully',
+  'error.network': 'La connexion au serveur a échoué. Veuillez réessayer.',
+  'error.quota': 'Speicherplatz ist voll. Bitte löschen Sie einige Dateien.',
+  'settings.language': 'Langue de l\'interface',
+  'settings.notifications': 'Recevoir des notifications par e-mail',
+  'onboarding.welcome': 'Bienvenue ! Commençons par configurer votre espace de travail.',
+  'footer.terms': 'Terms of service and privacy policy'
+};
+
+const EXPECTED_LANGUAGES = [
+  { code: 'fr', label: 'French' },
+  { code: 'en', label: 'English' },
+  { code: 'es', label: 'Spanish' },
+  { code: 'de', label: 'German' }
+];
+
+@Component({
+  selector: 'app-localization-qa-demo',
+  templateUrl: './localization-qa-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class LocalizationQaDemoComponent extends BasePage implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'localization-qa')!;
+
+  expectedLanguages = EXPECTED_LANGUAGES;
+  expectedLanguage = 'fr';
+  fileName = 'fr.json';
+
+  entries: LocaleEntry[] = Object.entries(SAMPLE_LOCALE).map(([key, value]) => ({
+    key,
+    value,
+    detectedLanguage: null,
+    confidence: null,
+    status: 'pending',
+    previousValue: null,
+    isFixing: false
+  }));
+
+  detectorStatus = 'loading...';
+  translatorStatus = 'loading...';
+  errorMessage = '';
+
+  isScanning = false;
+  hasScanned = false;
+  scanTimeMs: number | null = null;
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.detectorStatus = 'LanguageDetector' in self ? await LanguageDetector.availability() : 'unavailable';
+    } catch { this.detectorStatus = 'unavailable'; }
+    try {
+      this.translatorStatus = 'Translator' in self
+        ? await Translator.availability({ sourceLanguage: 'en', targetLanguage: this.expectedLanguage })
+        : 'unavailable';
+    } catch { this.translatorStatus = 'unavailable'; }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Language Detector', status: this.detectorStatus },
+      { name: 'Translator', status: this.translatorStatus }
+    ];
+  }
+
+  get issueCount(): number {
+    return this.entries.filter(e => e.status === 'wrong-language').length;
+  }
+
+  get fixedCount(): number {
+    return this.entries.filter(e => e.status === 'fixed').length;
+  }
+
+  languageLabel(code: string | null): string {
+    if (!code) return '?';
+    return this.expectedLanguages.find(l => l.code === code)?.label ?? code;
+  }
+
+  onExpectedChanged() {
+    this.fileName = `${this.expectedLanguage}.json`;
+    this.entries.forEach(entry => {
+      if (entry.status !== 'fixed') {
+        entry.status = 'pending';
+        entry.detectedLanguage = null;
+        entry.confidence = null;
+      }
+    });
+    this.hasScanned = false;
+  }
+
+  async scan() {
+    if (this.isScanning || this.detectorStatus === 'unavailable') return;
+
+    this.isScanning = true;
+    this.errorMessage = '';
+    const start = performance.now();
+
+    try {
+      if (!this.detector) this.detector = await LanguageDetector.create();
+
+      for (const entry of this.entries) {
+        const results = await this.detector.detect(entry.value);
+        const top = results?.[0];
+        if (top && top.detectedLanguage !== 'und') {
+          entry.detectedLanguage = top.detectedLanguage;
+          entry.confidence = top.confidence;
+          entry.status = top.detectedLanguage === this.expectedLanguage || top.confidence < 0.5
+            ? 'ok'
+            : 'wrong-language';
+        } else {
+          entry.detectedLanguage = null;
+          entry.confidence = null;
+          entry.status = 'ok';
+        }
+      }
+
+      this.scanTimeMs = Math.round(performance.now() - start);
+      this.hasScanned = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'The scan failed.';
+    } finally {
+      this.isScanning = false;
+    }
+  }
+
+  async fix(entry: LocaleEntry) {
+    if (entry.status !== 'wrong-language' || entry.isFixing || !entry.detectedLanguage) return;
+    if (this.translatorStatus === 'unavailable') {
+      this.errorMessage = 'The Translator API is unavailable — cannot fix strings.';
+      return;
+    }
+
+    entry.isFixing = true;
+    this.errorMessage = '';
+    try {
+      const key = `${entry.detectedLanguage}->${this.expectedLanguage}`;
+      if (!this.translators.has(key)) {
+        this.translators.set(key, await Translator.create({
+          sourceLanguage: entry.detectedLanguage,
+          targetLanguage: this.expectedLanguage
+        }));
+      }
+      entry.previousValue = entry.value;
+      entry.value = await this.translators.get(key).translate(entry.previousValue);
+      entry.status = 'fixed';
+      entry.detectedLanguage = this.expectedLanguage;
+    } catch (e: any) {
+      this.errorMessage = e.message || `Could not translate "${entry.key}" — is the ${entry.detectedLanguage}→${this.expectedLanguage} pair available?`;
+    } finally {
+      entry.isFixing = false;
+    }
+  }
+
+  async fixAll() {
+    for (const entry of this.entries.filter(e => e.status === 'wrong-language')) {
+      await this.fix(entry);
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const detector = await LanguageDetector.create();
+const expected = "${this.expectedLanguage}"; // auditing ${this.fileName}
+
+// Audit every string locally — no localization service involved
+const issues = [];
+for (const [key, value] of Object.entries(localeStrings)) {
+  const [top] = await detector.detect(value);
+  if (top.detectedLanguage !== expected && top.confidence >= 0.5) {
+    issues.push({ key, value, found: top.detectedLanguage });
+  }
+}
+${this.hasScanned ? `// → found ${this.issueCount + this.fixedCount} strings not in ${this.languageLabel(this.expectedLanguage)}` : ''}
+
+// Fix a straggler: translate it into the expected language
+async function fix(issue) {
+  const translator = await Translator.create({
+    sourceLanguage: issue.found,
+    targetLanguage: expected
+  });
+  localeStrings[issue.key] = await translator.translate(issue.value);
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/regex-lab-demo.component.html
+++ b/webapp/src/app/pages/demos/features/regex-lab-demo.component.html
@@ -1,0 +1,132 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API is not available in this browser.</span> You can still edit the pattern and flags manually — the live tester works without the model.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Description input -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="flex gap-3">
+        <input type="text"
+               class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-sky-500/40"
+               [(ngModel)]="description"
+               (keydown.enter)="generate()"
+               placeholder="Describe what to match, in plain English..." />
+        <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-sky-600 hover:bg-sky-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                [disabled]="!description.trim() || state === 'Inferencing' || languageModelAvailability === 'unavailable'"
+                (click)="generate()">
+          @if (state === 'Inferencing') {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Writing...
+          } @else {
+            <i class="bi bi-asterisk"></i> Generate
+          }
+        </button>
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        @for (sample of sampleRequests; track sample) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors"
+                  (click)="useSample(sample)">
+            {{ sample }}
+          </button>
+        }
+      </div>
+    </div>
+
+    <!-- Pattern editor -->
+    <div class="bg-[#101014] rounded-2xl shadow-lg border border-zinc-800 p-4 mb-3 flex items-center gap-2 font-mono text-lg">
+      <span class="text-zinc-500">/</span>
+      <input type="text"
+             class="flex-grow bg-transparent border-none outline-none text-emerald-400 placeholder-zinc-600 min-w-0"
+             [(ngModel)]="pattern"
+             (ngModelChange)="runTest()"
+             placeholder="pattern" />
+      <span class="text-zinc-500">/</span>
+      <input type="text"
+             class="w-16 bg-transparent border-none outline-none text-sky-400 placeholder-zinc-600"
+             [(ngModel)]="flags"
+             (ngModelChange)="runTest()"
+             placeholder="flags" />
+    </div>
+
+    @if (regexError) {
+      <div class="mb-3 text-xs text-red-500 font-mono px-2">{{ regexError }}</div>
+    }
+    @if (explanation && hasGenerated) {
+      <div class="mb-6 bg-sky-50 border border-sky-200 dark:bg-sky-900/10 dark:border-sky-900/30 rounded-2xl p-4 text-sm text-sky-900 dark:text-sky-100/90">
+        <i class="bi bi-lightbulb text-sky-500"></i> {{ explanation }}
+      </div>
+    }
+
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Test string with highlights -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Test String</span>
+          <span class="text-xs font-semibold" [ngClass]="matches.length > 0 ? 'text-emerald-600 dark:text-emerald-400' : 'text-slate-400 dark:text-slate-500'">
+            {{ matches.length }} {{ matches.length === 1 ? 'match' : 'matches' }}
+          </span>
+        </div>
+        <!-- Highlighted preview -->
+        <div class="p-4 text-sm font-mono leading-relaxed whitespace-pre-wrap border-b border-slate-100 dark:border-zinc-800 min-h-[120px]">
+          @if (segments.length > 0) {
+            @for (segment of segments; track $index) {
+              @if (segment.isMatch) {
+                <span class="bg-emerald-200/70 dark:bg-emerald-600/40 text-emerald-900 dark:text-emerald-200 rounded-sm">{{ segment.text }}</span>
+              } @else {
+                <span class="text-slate-600 dark:text-slate-400">{{ segment.text }}</span>
+              }
+            }
+          } @else {
+            <span class="text-slate-600 dark:text-slate-400">{{ testString }}</span>
+          }
+        </div>
+        <textarea
+          class="w-full bg-slate-50/60 dark:bg-[#161616]/60 border-none outline-none focus:ring-0 text-slate-700 dark:text-slate-300 resize-none p-4 text-xs font-mono leading-relaxed min-h-[110px]"
+          [(ngModel)]="testString"
+          (ngModelChange)="runTest()"
+          placeholder="Edit the test string..."></textarea>
+      </div>
+
+      <!-- Match details -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col max-h-[420px]">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider">Matches</span>
+        </div>
+        <div class="overflow-y-auto p-3 flex flex-col gap-1.5 flex-grow">
+          @if (matches.length === 0) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 m-auto text-center font-light px-6">
+              {{ hasGenerated || pattern ? 'No matches in the test string.' : 'Generate a regex (or type one) to see its matches.' }}
+            </p>
+          }
+          @for (match of matches; track $index) {
+            <div class="flex items-center gap-3 px-3.5 py-2 rounded-lg bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700">
+              <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500 w-10 shrink-0">@{{ match.index }}</span>
+              <code class="text-xs font-semibold text-emerald-700 dark:text-emerald-400 break-all">{{ match.match }}</code>
+              @if (match.groups.length > 0) {
+                <span class="ml-auto text-[10px] font-mono text-slate-400 dark:text-slate-500 truncate shrink-0" title="Capture groups">
+                  [{{ match.groups.join(', ') }}]
+                </span>
+              }
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/regex-lab-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/regex-lab-demo.component.ts
@@ -1,0 +1,197 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+interface TestSegment {
+  text: string;
+  isMatch: boolean;
+}
+
+interface MatchDetail {
+  match: string;
+  index: number;
+  groups: string[];
+}
+
+const REGEX_SCHEMA = {
+  type: 'object',
+  properties: {
+    pattern: { type: 'string' },
+    flags: { type: 'string' },
+    explanation: { type: 'string' }
+  },
+  required: ['pattern', 'flags', 'explanation'],
+  additionalProperties: false
+};
+
+const SAMPLE_TEST_STRING = `Contact us at support@example.com or sales@webai.studio for help.
+The launch is planned for 2026-07-29, with a fallback on 2026-08-15.
+Call +1 (555) 123-4567 or 555-987-6543 before 5pm.
+Brand colors: #4f46e5, #10b981 and #FFF.
+This this sentence has has some duplicate words words.`;
+
+@Component({
+  selector: 'app-regex-lab-demo',
+  templateUrl: './regex-lab-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class RegexLabDemoComponent extends BaseDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'regex-lab')!;
+
+  description = '';
+  pattern = '';
+  flags = 'g';
+  explanation = '';
+  testString = SAMPLE_TEST_STRING;
+
+  segments: TestSegment[] = [];
+  matches: MatchDetail[] = [];
+  regexError = '';
+  errorMessage = '';
+  hasGenerated = false;
+
+  sampleRequests = [
+    'match email addresses',
+    'ISO dates like 2026-07-29',
+    'US phone numbers in any common format',
+    'hex color codes',
+    'the same word repeated twice in a row'
+  ];
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API', status: this.languageModelAvailability }];
+  }
+
+  useSample(sample: string) {
+    this.description = sample;
+    this.generate();
+  }
+
+  async generate() {
+    const description = this.description.trim();
+    if (!description || this.state === PromptInputStateEnum.Inferencing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+    const startTime = performance.now();
+
+    try {
+      const session = await LanguageModel.create({
+        systemPrompt:
+          'You write JavaScript regular expressions. Return the pattern WITHOUT surrounding slashes. ' +
+          'Prefer readable, robust patterns over clever ones. Explain the pattern in one or two plain sentences.'
+      });
+
+      const response = await session.prompt(
+        `Write a regex that matches: ${description}`,
+        { responseConstraint: REGEX_SCHEMA, signal: this.abortController.signal }
+      );
+      session.destroy?.();
+
+      this.totalTime = Math.round(performance.now() - startTime);
+      this.ttft = this.totalTime;
+
+      const result = JSON.parse(response);
+      this.pattern = result.pattern;
+      this.flags = result.flags || 'g';
+      this.explanation = result.explanation;
+      this.hasGenerated = true;
+      this.runTest();
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Could not generate the regex.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  /** Rebuilds the highlighted segments from the current pattern, flags, and test string. */
+  runTest() {
+    this.regexError = '';
+    this.segments = [];
+    this.matches = [];
+
+    const pattern = this.pattern.trim();
+    if (!pattern || !this.testString) return;
+
+    let regex: RegExp;
+    try {
+      // Matching requires the global flag; add it without mutating the displayed flags.
+      const flags = this.flags.includes('g') ? this.flags : this.flags + 'g';
+      regex = new RegExp(pattern, flags);
+    } catch (e: any) {
+      this.regexError = e.message;
+      this.segments = [{ text: this.testString, isMatch: false }];
+      return;
+    }
+
+    let cursor = 0;
+    for (const match of this.testString.matchAll(regex)) {
+      const index = match.index ?? 0;
+      if (match[0].length === 0) break; // guard against zero-length match loops
+      if (index > cursor) {
+        this.segments.push({ text: this.testString.slice(cursor, index), isMatch: false });
+      }
+      this.segments.push({ text: match[0], isMatch: true });
+      this.matches.push({ match: match[0], index, groups: match.slice(1).map(g => g ?? '') });
+      cursor = index + match[0].length;
+      if (this.matches.length >= 200) break;
+    }
+    if (cursor < this.testString.length) {
+      this.segments.push({ text: this.testString.slice(cursor), isMatch: false });
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    const description = this.description.trim() || this.sampleRequests[0];
+    return `const schema = {
+  type: "object",
+  properties: {
+    pattern: { type: "string" },
+    flags: { type: "string" },
+    explanation: { type: "string" }
+  },
+  required: ["pattern", "flags", "explanation"],
+  additionalProperties: false
+};
+
+const session = await LanguageModel.create({
+  systemPrompt: "You write JavaScript regular expressions. " +
+    "Return the pattern WITHOUT surrounding slashes."
+});
+
+const result = await session.prompt(
+  ${JSON.stringify('Write a regex that matches: ' + description)},
+  { responseConstraint: schema }
+);
+
+const { pattern, flags, explanation } = JSON.parse(result);
+${this.hasGenerated ? `// → /${this.pattern}/${this.flags}` : ''}
+const regex = new RegExp(pattern, flags.includes("g") ? flags : flags + "g");
+
+for (const match of testString.matchAll(regex)) {
+  highlight(match.index, match[0]); ${this.matches.length ? `// ${this.matches.length} matches in the tester below` : ''}
+}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/screenshot-to-code-demo.component.html
+++ b/webapp/src/app/pages/demos/features/screenshot-to-code-demo.component.html
@@ -1,0 +1,102 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API with image input is not available in this browser.</span> Use a Chrome build with multimodal Gemini Nano enabled.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Controls -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-3">
+      <label class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-700 dark:text-slate-300 text-sm font-medium border border-slate-200 dark:border-zinc-700 cursor-pointer transition-colors">
+        <i class="bi bi-upload"></i> Upload Screenshot
+        <input type="file" accept="image/*" class="hidden" (change)="onFileSelected($event)" />
+      </label>
+      <button class="px-5 py-2.5 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-700 dark:text-slate-300 text-sm font-medium border border-slate-200 dark:border-zinc-700 transition-colors"
+              (click)="useSampleScreenshot()">
+        <i class="bi bi-image"></i> Use Sample Mockup
+      </button>
+      <div class="flex-grow"></div>
+      @if (state === 'Inferencing') {
+        <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                (click)="onCancel()">
+          <i class="bi bi-stop-fill"></i> Stop
+        </button>
+      } @else {
+        <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-violet-600 hover:bg-violet-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                [disabled]="!imageUrl || languageModelAvailability === 'unavailable'"
+                (click)="generate()">
+          <i class="bi bi-code-slash"></i> Generate HTML
+        </button>
+      }
+    </div>
+
+    <!-- Side by side -->
+    <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      <!-- Original -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[320px]">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-image text-violet-500"></i> Original Screenshot
+          </span>
+        </div>
+        <div class="flex-grow flex items-center justify-center bg-slate-50 dark:bg-[#161616] p-4">
+          @if (imageUrl) {
+            <img [src]="imageUrl" alt="Uploaded screenshot" class="max-w-full max-h-[400px] rounded-lg shadow-sm" />
+          } @else {
+            <span class="text-sm text-slate-400 dark:text-zinc-600 font-light">Upload a UI screenshot, or use the sample mockup.</span>
+          }
+        </div>
+      </div>
+
+      <!-- Rebuilt -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden flex flex-col min-h-[320px]">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-window text-violet-500"></i> Rebuilt as HTML
+          </span>
+          <div class="flex items-center gap-3">
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+            @if (renderedHtml) {
+              <button class="text-[11px] font-semibold text-violet-600 dark:text-violet-400 hover:text-violet-700 bg-transparent border-none transition-colors"
+                      (click)="showCode = !showCode">
+                {{ showCode ? 'show preview' : 'show code' }}
+              </button>
+            }
+          </div>
+        </div>
+        <div class="flex-grow bg-slate-50 dark:bg-[#161616]">
+          @if (state === 'Inferencing') {
+            <pre class="p-4 m-0 text-[11px] leading-relaxed text-slate-500 dark:text-slate-400 font-mono whitespace-pre-wrap max-h-[400px] overflow-y-auto">{{ generatedHtml }}<span class="inline-block w-1.5 h-3 bg-violet-500 animate-pulse"></span></pre>
+          } @else if (renderedHtml && !showCode) {
+            <iframe sandbox="" [srcdoc]="renderedHtml" class="w-full h-full min-h-[400px] border-0 bg-white" title="Rebuilt UI preview"></iframe>
+          } @else if (generatedHtml && showCode) {
+            <div class="h-[400px]">
+              <app-code-editor [code]="generatedHtml" [language]="'html'" [height]="'400px'"></app-code-editor>
+            </div>
+          } @else {
+            <div class="h-full flex items-center justify-center p-6">
+              <span class="text-sm text-slate-400 dark:text-zinc-600 font-light">The generated markup streams in here, then renders in a sandboxed iframe.</span>
+            </div>
+          }
+        </div>
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/screenshot-to-code-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/screenshot-to-code-demo.component.ts
@@ -1,0 +1,175 @@
+import { Component, OnInit, inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { DomSanitizer, SafeHtml } from '@angular/platform-browser';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+@Component({
+  selector: 'app-screenshot-to-code-demo',
+  templateUrl: './screenshot-to-code-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ScreenshotToCodeDemoComponent extends BaseDemoComponent implements OnInit {
+  private readonly sanitizer = inject(DomSanitizer);
+
+  demo = DEMOS_DATA.find(d => d.id === 'screenshot-to-code')!;
+
+  imageUrl: string | null = null;
+  generatedHtml = '';
+  renderedHtml: SafeHtml | null = null;
+  showCode = false;
+  errorMessage = '';
+
+  private imageBitmap: ImageBitmap | null = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability([{ type: 'image' }]);
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API (image)', status: this.languageModelAvailability }];
+  }
+
+  async onFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (!file) return;
+    try {
+      this.imageBitmap = await createImageBitmap(file);
+      this.imageUrl = URL.createObjectURL(file);
+      this.generatedHtml = '';
+      this.renderedHtml = null;
+    } catch (e: any) {
+      this.errorMessage = 'Could not read that file as an image.';
+    }
+  }
+
+  /** Draws a sample "sign-in card" mockup so the demo works with zero assets. */
+  async useSampleScreenshot() {
+    const canvas = this.document.createElement('canvas');
+    canvas.width = 480;
+    canvas.height = 420;
+    const ctx = canvas.getContext('2d')!;
+
+    // Page background + card
+    ctx.fillStyle = '#eef2f7';
+    ctx.fillRect(0, 0, 480, 420);
+    ctx.fillStyle = '#ffffff';
+    ctx.beginPath();
+    (ctx as any).roundRect(60, 40, 360, 340, 16);
+    ctx.fill();
+
+    // Title + subtitle
+    ctx.fillStyle = '#1e293b';
+    ctx.font = 'bold 24px sans-serif';
+    ctx.fillText('Welcome back', 100, 100);
+    ctx.fillStyle = '#64748b';
+    ctx.font = '14px sans-serif';
+    ctx.fillText('Sign in to your account', 100, 126);
+
+    // Inputs
+    for (const [label, y] of [['Email', 160], ['Password', 230]] as [string, number][]) {
+      ctx.fillStyle = '#475569';
+      ctx.font = 'bold 12px sans-serif';
+      ctx.fillText(label, 100, y);
+      ctx.strokeStyle = '#cbd5e1';
+      ctx.lineWidth = 1.5;
+      ctx.beginPath();
+      (ctx as any).roundRect(100, y + 10, 280, 40, 8);
+      ctx.stroke();
+    }
+
+    // Button
+    ctx.fillStyle = '#4f46e5';
+    ctx.beginPath();
+    (ctx as any).roundRect(100, 310, 280, 44, 22);
+    ctx.fill();
+    ctx.fillStyle = '#ffffff';
+    ctx.font = 'bold 15px sans-serif';
+    ctx.textAlign = 'center';
+    ctx.fillText('Sign in', 240, 338);
+    ctx.textAlign = 'left';
+
+    this.imageBitmap = await createImageBitmap(canvas);
+    this.imageUrl = canvas.toDataURL('image/png');
+    this.generatedHtml = '';
+    this.renderedHtml = null;
+  }
+
+  async generate() {
+    if (!this.imageBitmap || this.state === PromptInputStateEnum.Inferencing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.generatedHtml = '';
+    this.renderedHtml = null;
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+
+    const startTime = performance.now();
+    let firstTokenTime: number | null = null;
+
+    try {
+      const session = await LanguageModel.create({
+        expectedInputs: [{ type: 'image' }],
+        systemPrompt:
+          'You convert UI screenshots into clean, semantic HTML that reproduces the layout as closely as possible. ' +
+          'Use ONLY inline CSS styles (no classes, no external stylesheets, no scripts). ' +
+          'Output ONLY the HTML markup — no explanations, no markdown fences.'
+      });
+
+      const stream = session.promptStreaming([{
+        role: 'user',
+        content: [
+          { type: 'text', value: 'Rebuild this UI as HTML with inline styles.' },
+          { type: 'image', value: this.imageBitmap }
+        ]
+      }], { signal: this.abortController.signal });
+
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - startTime);
+        }
+        this.generatedHtml += chunk;
+      }
+      this.totalTime = Math.round(performance.now() - startTime);
+      session.destroy?.();
+
+      this.renderResult();
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'Generation failed.';
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  private renderResult() {
+    // Strip markdown fences if the model added them despite instructions.
+    const html = this.generatedHtml
+      .replace(/^```(?:html)?\s*/i, '')
+      .replace(/```\s*$/, '')
+      .trim();
+    this.generatedHtml = html;
+    // Rendered inside a sandboxed iframe (no scripts, no same-origin access).
+    this.renderedHtml = this.sanitizer.bypassSecurityTrustHtml(html);
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/session-branching-demo.component.html
+++ b/webapp/src/app/pages/demos/features/session-branching-demo.component.html
@@ -1,0 +1,121 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API is not available in this browser.</span> Use a recent Chrome build with Gemini Nano enabled.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Base conversation -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden mb-4">
+      <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-chat-square-text text-indigo-500"></i> Shared Context
+        </span>
+        @if (isBaseStreaming) {
+          <button class="flex items-center gap-1.5 px-3.5 py-1.5 rounded-full bg-red-600 hover:bg-red-700 text-white text-xs font-semibold shadow-sm transition-all active:scale-95 border-none"
+                  (click)="cancel()">
+            <i class="bi bi-stop-fill"></i> Stop
+          </button>
+        }
+      </div>
+      <div class="p-5">
+        <div class="flex gap-3">
+          <textarea
+            class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-2xl px-4 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40 resize-none min-h-[70px]"
+            [(ngModel)]="basePrompt"
+            placeholder="A prompt that builds up context worth forking..."></textarea>
+          <button class="self-end flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                  [disabled]="!basePrompt.trim() || isBaseStreaming || branchesRunning || languageModelAvailability === 'unavailable'"
+                  (click)="runBase()">
+            @if (isBaseStreaming) {
+              <i class="bi bi-arrow-repeat animate-spin"></i>
+            } @else {
+              <i class="bi bi-play-fill"></i>
+            }
+            Run
+          </button>
+        </div>
+
+        @if (baseResponse) {
+          <div class="mt-4 rounded-2xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-4 text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap">
+            {{ baseResponse }}@if (isBaseStreaming) {<span class="inline-block w-0.5 h-4 bg-indigo-500 animate-pulse align-middle ml-0.5"></span>}
+          </div>
+        }
+      </div>
+    </div>
+
+    <!-- Fork point -->
+    <div class="flex flex-col items-center mb-4">
+      <div class="w-px h-6 bg-slate-300 dark:bg-zinc-600"></div>
+      <button class="flex items-center gap-2 px-8 py-3 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold shadow-lg transition-all active:scale-95 disabled:opacity-40 border-none"
+              [disabled]="!baseDone || branchesRunning"
+              (click)="fork()">
+        @if (branchesRunning) {
+          <i class="bi bi-arrow-repeat animate-spin"></i> Branching...
+        } @else {
+          <i class="bi bi-signpost-2"></i> session.clone() × 2
+        }
+      </button>
+      @if (!baseDone && !isBaseStreaming) {
+        <span class="text-[11px] text-slate-400 dark:text-slate-500 mt-2">Run the base prompt first, then fork it.</span>
+      } @else if (baseDone) {
+        <span class="text-[11px] text-slate-400 dark:text-slate-500 mt-2">Both clones inherit the conversation above without re-processing it.</span>
+      }
+      <div class="flex w-full max-w-lg justify-between px-16 mt-1">
+        <div class="w-px h-5 bg-slate-300 dark:bg-zinc-600 rotate-[-25deg] origin-top"></div>
+        <div class="w-px h-5 bg-slate-300 dark:bg-zinc-600 rotate-[25deg] origin-top"></div>
+      </div>
+    </div>
+
+    <!-- Branches -->
+    <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
+      @for (branch of branches; track branch.label) {
+        <div class="rounded-3xl shadow-sm border overflow-hidden flex flex-col min-h-[220px]"
+             [ngClass]="branch.accentClass === 'emerald'
+               ? 'bg-[#ffffff] dark:bg-zinc-800/90 border-emerald-200 dark:border-emerald-900/50'
+               : 'bg-[#ffffff] dark:bg-zinc-800/90 border-rose-200 dark:border-rose-900/50'">
+          <div class="px-5 py-3.5 border-b flex justify-between items-center"
+               [ngClass]="branch.accentClass === 'emerald'
+                 ? 'border-emerald-100 dark:border-emerald-900/30 bg-emerald-50/50 dark:bg-emerald-900/10'
+                 : 'border-rose-100 dark:border-rose-900/30 bg-rose-50/50 dark:bg-rose-900/10'">
+            <span class="text-xs font-bold uppercase tracking-wider flex items-center gap-2"
+                  [ngClass]="branch.accentClass === 'emerald' ? 'text-emerald-700 dark:text-emerald-300' : 'text-rose-700 dark:text-rose-300'">
+              <i class="bi {{ branch.icon }}"></i> {{ branch.label }}
+            </span>
+            @if (branch.timeMs !== null) {
+              <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">{{ branch.timeMs }}ms</span>
+            }
+          </div>
+          <div class="px-5 py-2.5 border-b border-slate-100 dark:border-zinc-800">
+            <input type="text"
+                   class="w-full bg-transparent border-none outline-none focus:ring-0 text-xs italic text-slate-500 dark:text-slate-400"
+                   [(ngModel)]="branch.prompt"
+                   [disabled]="branchesRunning" />
+          </div>
+          <div class="p-5 text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap flex-grow">
+            @if (branch.response) {
+              {{ branch.response }}@if (branch.isStreaming) {<span class="inline-block w-0.5 h-4 animate-pulse align-middle ml-0.5" [ngClass]="branch.accentClass === 'emerald' ? 'bg-emerald-500' : 'bg-rose-500'"></span>}
+            } @else if (branch.isStreaming) {
+              <i class="bi bi-arrow-repeat animate-spin" [ngClass]="branch.accentClass === 'emerald' ? 'text-emerald-400' : 'text-rose-400'"></i>
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">This branch's continuation appears here.</span>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/session-branching-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/session-branching-demo.component.ts
@@ -1,0 +1,184 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+interface Branch {
+  label: string;
+  icon: string;
+  accentClass: string;
+  prompt: string;
+  response: string;
+  isStreaming: boolean;
+  timeMs: number | null;
+}
+
+@Component({
+  selector: 'app-session-branching-demo',
+  templateUrl: './session-branching-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class SessionBranchingDemoComponent extends BaseDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'session-branching')!;
+
+  basePrompt = 'We\'re naming a new open-source library for on-device AI benchmarks. Suggest one name and explain it in two sentences.';
+  baseResponse = '';
+  isBaseStreaming = false;
+  baseDone = false;
+  errorMessage = '';
+
+  branches: Branch[] = [
+    {
+      label: 'The Optimist',
+      icon: 'bi-sun',
+      accentClass: 'emerald',
+      prompt: 'Build on your suggestion enthusiastically. What makes it great, and what should we do next?',
+      response: '',
+      isStreaming: false,
+      timeMs: null
+    },
+    {
+      label: 'The Skeptic',
+      icon: 'bi-cloud-lightning',
+      accentClass: 'rose',
+      prompt: 'Now be brutally honest about your own suggestion. What is wrong with it, and what would be better?',
+      response: '',
+      isStreaming: false,
+      timeMs: null
+    }
+  ];
+
+  branchesRunning = false;
+  branchesDone = false;
+
+  private baseSession: any = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API', status: this.languageModelAvailability }];
+  }
+
+  async runBase() {
+    const prompt = this.basePrompt.trim();
+    if (!prompt || this.isBaseStreaming || this.branchesRunning) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    this.isBaseStreaming = true;
+    this.baseDone = false;
+    this.branchesDone = false;
+    this.errorMessage = '';
+    this.baseResponse = '';
+    this.branches.forEach(branch => {
+      branch.response = '';
+      branch.timeMs = null;
+    });
+    this.abortController = new AbortController();
+
+    try {
+      this.baseSession?.destroy?.();
+      this.baseSession = await LanguageModel.create();
+
+      const stream = this.baseSession.promptStreaming(prompt, { signal: this.abortController.signal });
+      for await (const chunk of stream) {
+        this.baseResponse += chunk;
+      }
+      this.baseDone = true;
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'The base prompt failed.';
+      }
+    } finally {
+      this.isBaseStreaming = false;
+      this.abortController = null;
+    }
+  }
+
+  async fork() {
+    if (!this.baseDone || this.branchesRunning || !this.baseSession) return;
+
+    this.branchesRunning = true;
+    this.branchesDone = false;
+    this.errorMessage = '';
+    this.branches.forEach(branch => {
+      branch.response = '';
+      branch.timeMs = null;
+      branch.isStreaming = true;
+    });
+
+    try {
+      // Both branches stream concurrently, each from its own clone of the
+      // shared context — the base session itself stays untouched.
+      await Promise.all(this.branches.map(branch => this.runBranch(branch)));
+      this.branchesDone = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Branching failed.';
+    } finally {
+      this.branchesRunning = false;
+      this.branches.forEach(branch => (branch.isStreaming = false));
+    }
+  }
+
+  private async runBranch(branch: Branch) {
+    const start = performance.now();
+    try {
+      const clone = await this.baseSession.clone();
+      const stream = clone.promptStreaming(branch.prompt);
+      for await (const chunk of stream) {
+        branch.response += chunk;
+      }
+      branch.timeMs = Math.round(performance.now() - start);
+      clone.destroy?.();
+    } catch (e: any) {
+      branch.response = branch.response || `[${e.message}]`;
+    } finally {
+      branch.isStreaming = false;
+    }
+  }
+
+  cancel() {
+    this.abortController?.abort();
+  }
+
+  override ngOnDestroy() {
+    this.baseSession?.destroy?.();
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const session = await LanguageModel.create();
+
+// Build up shared context once
+const base = await session.prompt(
+  ${JSON.stringify(this.basePrompt.trim() || 'Suggest a name for the library.')}
+);
+
+// Fork the conversation — each clone inherits the FULL history
+// without re-processing a single token of it
+const optimist = await session.clone();
+const skeptic = await session.clone();
+
+// The branches diverge from the same starting point, in parallel
+const [praise, critique] = await Promise.all([
+  optimist.prompt(${JSON.stringify(this.branches[0].prompt)}),
+  skeptic.prompt(${JSON.stringify(this.branches[1].prompt)})
+]);
+
+// The original session is untouched by either branch —
+// you can keep prompting it, or fork it again
+optimist.destroy();
+skeptic.destroy();`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/tool-calling-demo.component.html
+++ b/webapp/src/app/pages/demos/features/tool-calling-demo.component.html
@@ -1,0 +1,168 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet"
+  [ttft]="ttft"
+  [totalTime]="totalTime">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Prompt API is not available.</span> Tool calling additionally requires a Chrome build where the Prompt API supports the <code class='font-mono text-xs'>tools</code> option — if commands answer without any tool calls appearing in the log, this build doesn't support it yet.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Command bar -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="flex gap-3">
+        <input type="text"
+               class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-emerald-500/40"
+               [(ngModel)]="command"
+               (keydown.enter)="send()"
+               placeholder="Tell the house what you want..." />
+        @if (state === 'Inferencing') {
+          <button class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-red-600 hover:bg-red-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                  (click)="onCancel()">
+            <i class="bi bi-stop-fill"></i> Stop
+          </button>
+        } @else {
+          <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-emerald-600 hover:bg-emerald-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                  [disabled]="!command.trim() || languageModelAvailability === 'unavailable'"
+                  (click)="send()">
+            <i class="bi bi-send"></i> Send
+          </button>
+        }
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        @for (sample of sampleCommands; track sample) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                  [disabled]="state === 'Inferencing'"
+                  (click)="useSample(sample)">
+            {{ sample }}
+          </button>
+        }
+      </div>
+    </div>
+
+    <div class="flex flex-col xl:flex-row gap-6 items-start">
+
+      <!-- Dashboard -->
+      <div class="xl:flex-[3] w-full flex flex-col gap-4">
+        <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
+          @for (room of rooms; track room) {
+            <button class="rounded-3xl border p-5 text-center transition-all duration-300 bg-transparent"
+                    [ngClass]="home.lights[room]
+                      ? 'border-amber-300 dark:border-amber-600 bg-amber-50 dark:bg-amber-900/20 shadow-[0_0_30px_rgba(251,191,36,0.25)]'
+                      : 'border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90'"
+                    (click)="toggleLight(room)"
+                    title="Click to toggle manually">
+              <i class="bi text-3xl transition-colors"
+                 [ngClass]="home.lights[room] ? 'bi-lightbulb-fill text-amber-400' : 'bi-lightbulb text-slate-300 dark:text-zinc-600'"></i>
+              <div class="text-sm font-bold text-slate-800 dark:text-slate-200 mt-2 capitalize">{{ room }}</div>
+              <div class="text-[10px] font-semibold uppercase tracking-wider mt-0.5"
+                   [ngClass]="home.lights[room] ? 'text-amber-600 dark:text-amber-400' : 'text-slate-400 dark:text-zinc-600'">
+                {{ home.lights[room] ? 'On' : 'Off' }}
+              </div>
+            </button>
+          }
+        </div>
+
+        <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <!-- Thermostat -->
+          <div class="rounded-3xl border border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90 p-5 text-center">
+            <i class="bi bi-thermometer-half text-2xl"
+               [ngClass]="home.thermostat >= 23 ? 'text-orange-500' : home.thermostat <= 17 ? 'text-sky-500' : 'text-slate-400'"></i>
+            <div class="text-4xl font-extrabold text-slate-800 dark:text-slate-200 mt-1">
+              {{ home.thermostat }}<span class="text-lg text-slate-400">°C</span>
+            </div>
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mt-1">Thermostat</div>
+          </div>
+
+          <!-- Music -->
+          <div class="rounded-3xl border p-5 text-center transition-all"
+               [ngClass]="home.music.playing ? 'border-indigo-300 dark:border-indigo-700 bg-indigo-50 dark:bg-indigo-900/15' : 'border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90'">
+            @if (home.music.playing) {
+              <div class="flex items-end justify-center gap-1 h-8">
+                <span class="w-1.5 bg-indigo-500 rounded-full animate-pulse" style="height: 60%"></span>
+                <span class="w-1.5 bg-indigo-500 rounded-full animate-pulse" style="height: 100%; animation-delay: 150ms"></span>
+                <span class="w-1.5 bg-indigo-500 rounded-full animate-pulse" style="height: 40%; animation-delay: 300ms"></span>
+                <span class="w-1.5 bg-indigo-500 rounded-full animate-pulse" style="height: 80%; animation-delay: 450ms"></span>
+              </div>
+              <div class="text-sm font-bold text-indigo-700 dark:text-indigo-300 mt-1 capitalize">{{ home.music.genre }}</div>
+            } @else {
+              <i class="bi bi-music-note-beamed text-2xl text-slate-300 dark:text-zinc-600 leading-8"></i>
+              <div class="text-sm font-bold text-slate-400 dark:text-zinc-600 mt-1">Silence</div>
+            }
+            <div class="text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-slate-500 mt-1">Speakers</div>
+          </div>
+        </div>
+
+        <!-- Assistant reply -->
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+          <div class="px-5 py-3 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+            <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+              <i class="bi bi-robot text-emerald-500"></i> Assistant
+            </span>
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+          </div>
+          <div class="p-4 text-sm text-slate-800 dark:text-slate-200 leading-relaxed min-h-[52px] whitespace-pre-wrap">
+            @if (assistantReply) {
+              {{ assistantReply }}
+            } @else if (state === 'Inferencing') {
+              <span class="text-emerald-600 dark:text-emerald-400"><i class="bi bi-gear animate-spin inline-block"></i> Working the tools...</span>
+            } @else {
+              <span class="text-slate-400 dark:text-slate-500 font-light select-none">Give the house an instruction — the model chooses which tools to call.</span>
+            }
+          </div>
+        </div>
+      </div>
+
+      <!-- Tool call log -->
+      <div class="xl:flex-[2] w-full bg-[#101014] rounded-3xl shadow-xl border border-zinc-800 overflow-hidden flex flex-col min-h-[380px]">
+        <div class="px-5 py-3.5 border-b border-zinc-800 flex justify-between items-center">
+          <span class="text-xs font-bold text-zinc-400 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-terminal"></i> Tool Calls
+          </span>
+          <div class="flex items-center gap-3">
+            <span class="text-[10px] font-mono text-zinc-500">{{ totalToolCalls }} total</span>
+            @if (totalToolCalls > 0) {
+              <button class="text-[10px] font-medium text-zinc-500 hover:text-zinc-300 bg-transparent border-none transition-colors"
+                      (click)="resetSession()">
+                reset session
+              </button>
+            }
+          </div>
+        </div>
+        <div class="p-4 flex flex-col gap-2.5 flex-grow overflow-y-auto font-mono text-xs">
+          @if (toolCalls.length === 0) {
+            <p class="text-zinc-600 m-auto text-center font-sans font-light text-sm px-6">
+              Every function the model invokes appears here with its arguments and result.
+            </p>
+          }
+          @for (call of toolCalls; track $index) {
+            <div class="rounded-xl bg-zinc-900/80 border border-zinc-800 p-3">
+              <div class="flex items-center gap-2">
+                <span class="text-emerald-400">ƒ</span>
+                <span class="text-sky-400 font-semibold">{{ call.tool }}</span>
+                <span class="text-zinc-500 truncate">({{ call.args }})</span>
+                <span class="text-zinc-600 ml-auto shrink-0">+{{ call.timeMs }}ms</span>
+              </div>
+              <div class="text-zinc-500 mt-1 pl-5 truncate">→ {{ call.result }}</div>
+            </div>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/tool-calling-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/tool-calling-demo.component.ts
@@ -1,0 +1,245 @@
+import { Component, NgZone, OnInit, inject } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseDemoComponent } from '../components/base-demo/base-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+
+type Room = 'living room' | 'bedroom' | 'kitchen';
+
+interface HomeState {
+  lights: Record<Room, boolean>;
+  thermostat: number;
+  music: { playing: boolean; genre: string | null };
+}
+
+interface ToolCall {
+  tool: string;
+  args: string;
+  result: string;
+  timeMs: number;
+}
+
+@Component({
+  selector: 'app-tool-calling-demo',
+  templateUrl: './tool-calling-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ToolCallingDemoComponent extends BaseDemoComponent implements OnInit {
+  private readonly ngZone = inject(NgZone);
+
+  demo = DEMOS_DATA.find(d => d.id === 'tool-calling')!;
+
+  readonly rooms: Room[] = ['living room', 'bedroom', 'kitchen'];
+
+  home: HomeState = {
+    lights: { 'living room': false, 'bedroom': false, 'kitchen': false },
+    thermostat: 20,
+    music: { playing: false, genre: null }
+  };
+
+  command = '';
+  assistantReply = '';
+  toolCalls: ToolCall[] = [];
+  totalToolCalls = 0;
+  errorMessage = '';
+
+  sampleCommands = [
+    'Make the living room cozy and warm for movie night.',
+    'Turn everything off, I\'m heading out.',
+    'It\'s freezing in here!',
+    'Put on some jazz in the kitchen and dim the rest.'
+  ];
+
+  private session: any = null;
+  private commandStartTime = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [{ name: 'Prompt API (tool use)', status: this.languageModelAvailability }];
+  }
+
+  toggleLight(room: Room) {
+    this.home.lights[room] = !this.home.lights[room];
+  }
+
+  get lightsOnCount(): number {
+    return this.rooms.filter(room => this.home.lights[room]).length;
+  }
+
+  private logCall(tool: string, args: any, result: any): void {
+    this.ngZone.run(() => {
+      this.toolCalls.unshift({
+        tool,
+        args: JSON.stringify(args),
+        result: JSON.stringify(result),
+        timeMs: Math.round(performance.now() - this.commandStartTime)
+      });
+      this.totalToolCalls++;
+      if (this.toolCalls.length > 12) this.toolCalls.pop();
+    });
+  }
+
+  private buildTools(): any[] {
+    return [
+      {
+        name: 'getHomeState',
+        description: 'Read the current state of every device in the home.',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        execute: async () => {
+          const result = this.home;
+          this.logCall('getHomeState', {}, result);
+          return JSON.stringify(result);
+        }
+      },
+      {
+        name: 'setLight',
+        description: 'Turn the light in one room on or off.',
+        inputSchema: {
+          type: 'object',
+          properties: {
+            room: { type: 'string', enum: this.rooms },
+            on: { type: 'boolean' }
+          },
+          required: ['room', 'on'],
+          additionalProperties: false
+        },
+        execute: async ({ room, on }: { room: Room; on: boolean }) => {
+          const result = { ok: this.rooms.includes(room), room, on };
+          if (result.ok) {
+            this.ngZone.run(() => (this.home.lights[room] = on));
+          }
+          this.logCall('setLight', { room, on }, result);
+          return JSON.stringify(result);
+        }
+      },
+      {
+        name: 'setThermostat',
+        description: 'Set the home\'s target temperature in Celsius, between 10 and 30.',
+        inputSchema: {
+          type: 'object',
+          properties: { temperature: { type: 'number', minimum: 10, maximum: 30 } },
+          required: ['temperature'],
+          additionalProperties: false
+        },
+        execute: async ({ temperature }: { temperature: number }) => {
+          const clamped = Math.min(30, Math.max(10, Math.round(temperature)));
+          this.ngZone.run(() => (this.home.thermostat = clamped));
+          const result = { ok: true, temperature: clamped };
+          this.logCall('setThermostat', { temperature }, result);
+          return JSON.stringify(result);
+        }
+      },
+      {
+        name: 'playMusic',
+        description: 'Start playing music of a given genre on the home speakers.',
+        inputSchema: {
+          type: 'object',
+          properties: { genre: { type: 'string' } },
+          required: ['genre'],
+          additionalProperties: false
+        },
+        execute: async ({ genre }: { genre: string }) => {
+          this.ngZone.run(() => (this.home.music = { playing: true, genre }));
+          const result = { ok: true, playing: true, genre };
+          this.logCall('playMusic', { genre }, result);
+          return JSON.stringify(result);
+        }
+      },
+      {
+        name: 'stopMusic',
+        description: 'Stop the music.',
+        inputSchema: { type: 'object', properties: {}, additionalProperties: false },
+        execute: async () => {
+          this.ngZone.run(() => (this.home.music = { playing: false, genre: null }));
+          const result = { ok: true, playing: false };
+          this.logCall('stopMusic', {}, result);
+          return JSON.stringify(result);
+        }
+      }
+    ];
+  }
+
+  useSample(sample: string) {
+    this.command = sample;
+    this.send();
+  }
+
+  async send() {
+    const command = this.command.trim();
+    if (!command || this.state === PromptInputStateEnum.Inferencing) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable in this browser.';
+      return;
+    }
+
+    this.state = PromptInputStateEnum.Inferencing;
+    this.assistantReply = '';
+    this.errorMessage = '';
+    this.ttft = null;
+    this.totalTime = null;
+    this.abortController = new AbortController();
+    this.commandStartTime = performance.now();
+
+    let firstTokenTime: number | null = null;
+
+    try {
+      // One persistent session: follow-ups like "now turn it back off" keep working.
+      if (!this.session) {
+        this.session = await LanguageModel.create({
+          systemPrompt:
+            'You are a smart home assistant. Use the available tools to fulfil the user\'s requests, ' +
+            'then confirm briefly what you did. Call getHomeState first when the current state matters. ' +
+            'Temperatures are in Celsius; "cozy and warm" is around 23.',
+          tools: this.buildTools()
+        });
+      }
+
+      const stream = this.session.promptStreaming(command, { signal: this.abortController.signal });
+      for await (const chunk of stream) {
+        if (!firstTokenTime) {
+          firstTokenTime = performance.now();
+          this.ttft = Math.round(firstTokenTime - this.commandStartTime);
+        }
+        this.assistantReply += chunk;
+      }
+      this.totalTime = Math.round(performance.now() - this.commandStartTime);
+      this.command = '';
+    } catch (e: any) {
+      if (e.name !== 'AbortError') {
+        this.errorMessage = e.message || 'The command failed.';
+        // A create() rejection usually means this build has no tool-use support.
+        this.session?.destroy?.();
+        this.session = null;
+      }
+    } finally {
+      this.state = PromptInputStateEnum.Ready;
+      this.abortController = null;
+    }
+  }
+
+  resetSession() {
+    this.session?.destroy?.();
+    this.session = null;
+    this.toolCalls = [];
+    this.totalToolCalls = 0;
+    this.assistantReply = '';
+  }
+
+  override ngOnDestroy() {
+    this.session?.destroy?.();
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}


### PR DESCRIPTION
## Summary

Tranche 3: the **Tools Calling category gets real function calling**, plus five developer-workflow demos. Six new demos, 49 total on the index.

| Demo | Route | APIs |
|---|---|---|
| Tool Calling: Smart Home | `/demos/tool-calling` | Prompt API (`tools` + `execute`) |
| CSV Q&A | `/demos/csv-qa` | Prompt API (structured output) |
| Screenshot → UI Code | `/demos/screenshot-to-code` | Prompt API (image) |
| Regex Lab | `/demos/regex-lab` | Prompt API (structured output) |
| Branching Conversations | `/demos/session-branching` | Prompt API (`clone()`) |
| Localization QA | `/demos/localization-qa` | Language Detector + Translator |

## Highlights

- **Smart Home** exposes five tools (`getHomeState`, `setLight`, `setThermostat`, `playMusic`, `stopMusic`) whose `execute` callbacks mutate a live dashboard — lights glow, the thermostat moves, the speakers animate — while a terminal-style log shows every call with args, result, and timing. A persistent session keeps "now turn it back off" working. The unavailable-hint explains how to tell when a build lacks tool-use support.
- **Screenshot → UI Code** ships a zero-asset sample: a sign-in mockup drawn programmatically on a canvas, so the demo works without uploading anything. Output is inline-styled HTML rendered in a fully sandboxed iframe (no scripts), with a code/preview toggle backed by the ACE editor.
- **Regex Lab**'s tester is model-independent: pattern and flags stay editable after generation, matches re-highlight live, zero-length-match loops are guarded, and capture groups are listed per match.
- **Branching Conversations** visualizes what `clone()` actually gives you: both forks stream concurrently from inherited context while the base session stays untouched.
- **Localization QA** is a practical build-tool: scan a locale file for wrong-language strings (with confidences), fix stragglers via cached per-pair translators, before/after shown inline.

## Testing

- `ng build` passes; all 6 routes prerender through SSR (49 demo cards on the index).
- Tool calling needs a Chrome build where `LanguageModel.create({ tools })` is supported — worth validating the call log against your channel. CSV arithmetic accuracy and screenshot fidelity are model-dependent and are honest showcases of current Nano capability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)