### PR TITLE
Add Omnibox, Moderation Cascade, Study Kit, Photo Search, and game demos

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -150,6 +150,12 @@ import { RegexLabDemoComponent } from './pages/demos/features/regex-lab-demo.com
 import { CsvQaDemoComponent } from './pages/demos/features/csv-qa-demo.component';
 import { SessionBranchingDemoComponent } from './pages/demos/features/session-branching-demo.component';
 import { LocalizationQaDemoComponent } from './pages/demos/features/localization-qa-demo.component';
+import { OmniboxDemoComponent } from './pages/demos/features/omnibox-demo.component';
+import { ModerationCascadeDemoComponent } from './pages/demos/features/moderation-cascade-demo.component';
+import { StudyKitDemoComponent } from './pages/demos/features/study-kit-demo.component';
+import { PhotoSearchDemoComponent } from './pages/demos/features/photo-search-demo.component';
+import { TongueTwisterDemoComponent } from './pages/demos/features/tongue-twister-demo.component';
+import { MysteryLanguageDemoComponent } from './pages/demos/features/mystery-language-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { TrackingDownloadPage } from './pages/docs/tracking-download/tracking-download.page';
@@ -276,6 +282,12 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     CsvQaDemoComponent,
     SessionBranchingDemoComponent,
     LocalizationQaDemoComponent,
+    OmniboxDemoComponent,
+    ModerationCascadeDemoComponent,
+    StudyKitDemoComponent,
+    PhotoSearchDemoComponent,
+    TongueTwisterDemoComponent,
+    MysteryLanguageDemoComponent,
     AutoScrollDirective,
     CortexPage,
     CortexInsightsPage,

--- a/webapp/src/app/app-routing-module.ts
+++ b/webapp/src/app/app-routing-module.ts
@@ -65,6 +65,12 @@ import { RegexLabDemoComponent } from './pages/demos/features/regex-lab-demo.com
 import { CsvQaDemoComponent } from './pages/demos/features/csv-qa-demo.component';
 import { SessionBranchingDemoComponent } from './pages/demos/features/session-branching-demo.component';
 import { LocalizationQaDemoComponent } from './pages/demos/features/localization-qa-demo.component';
+import { OmniboxDemoComponent } from './pages/demos/features/omnibox-demo.component';
+import { ModerationCascadeDemoComponent } from './pages/demos/features/moderation-cascade-demo.component';
+import { StudyKitDemoComponent } from './pages/demos/features/study-kit-demo.component';
+import { PhotoSearchDemoComponent } from './pages/demos/features/photo-search-demo.component';
+import { TongueTwisterDemoComponent } from './pages/demos/features/tongue-twister-demo.component';
+import { MysteryLanguageDemoComponent } from './pages/demos/features/mystery-language-demo.component';
 import { GetStartedPage } from './pages/docs/get-started/get-started.page';
 import { CheckAvailabilityPage } from './pages/docs/check-availability/check-availability.page';
 import { DocsErrorsPage } from './pages/docs/errors/errors.page';
@@ -672,6 +678,48 @@ const routes: Routes = [
       {
         path: "demos/localization-qa",
         component: LocalizationQaDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/omnibox",
+        component: OmniboxDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/moderation-cascade",
+        component: ModerationCascadeDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/study-kit",
+        component: StudyKitDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/photo-search",
+        component: PhotoSearchDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/tongue-twister",
+        component: TongueTwisterDemoComponent,
+        data: {
+          route: RouteEnum.Demos
+        }
+      },
+      {
+        path: "demos/mystery-language",
+        component: MysteryLanguageDemoComponent,
         data: {
           route: RouteEnum.Demos
         }

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -4,6 +4,36 @@ import { AttachmentTypeEnum } from '../enums/attachment-type.enum';
 export const DEMOS_DATA: DemoExample[] = [
   // SPEECH
   {
+    id: 'tongue-twister',
+    title: 'Tongue Twister Trial',
+    description: 'Say "she sells seashells" as fast as you can — the on-device recognizer scores how much of it survived.',
+    category: 'Speech',
+    apis: ['Web Speech'],
+    icon: 'bi-stopwatch',
+    onDeviceReason: 'A pronunciation game with zero backend: every attempt is transcribed and scored locally, so you can embarrass yourself in complete privacy.',
+    codeSnippet: `const twister = "She sells seashells by the seashore.";
+
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.interimResults = true;
+
+recognition.onresult = (event) => {
+  const transcript = [...event.results].map(r => r[0].transcript).join("");
+
+  // Score with word error rate against the target sentence
+  const accuracy = 1 - wordErrorRate(twister, transcript);
+
+  if (accuracy >= 0.95) rank = "🏆 Tongue Master";
+  else if (accuracy >= 0.85) rank = "🥈 Silver Tongue";
+  else if (accuracy >= 0.70) rank = "Getting There";
+  else rank = "🙃 Tongue Tied";
+};
+
+recognition.start(); // now say it FAST`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
     id: 'live-translated-captions',
     title: 'Live Translated Captions',
     description: 'Speak into the mic: on-device captions appear instantly, and a second track renders them live in another language.',
@@ -209,6 +239,146 @@ speechSynthesis.speak(utterance);`,
   },
 
   // MULTI-API
+  {
+    id: 'omnibox',
+    title: 'The Omnibox',
+    description: 'One input, every API: whatever you paste is intent-routed to the right tool — translate, summarize, proofread, rewrite, or answer.',
+    category: 'Mix-and-Match',
+    apis: ['Semantic Embedder', 'Language Detector', 'Translator', 'Summarizer', 'Proofreader', 'Rewriter', 'Prompt API'],
+    icon: 'bi-input-cursor-text',
+    onDeviceReason: 'The router itself is AI: language detection and embedding similarity pick the destination in milliseconds, then the chosen API runs — a whole product surface with zero server calls.',
+    codeSnippet: `// Route exemplars define each destination
+const routes = {
+  summarize: ["Condense this long text", "Give me the key points of this article"],
+  proofread: ["Fix the typos and grammar in this", "Correct my writing mistakes"],
+  rewrite:   ["Make this sound more professional", "Rephrase this politely"],
+  answer:    ["What is the capital of France?", "How does photosynthesis work?"]
+};
+// Embed the exemplars once; a route's centroid is its mean vector
+
+async function route(input) {
+  // Rule 1: foreign language wins — translate it
+  const [lang] = await detector.detect(input);
+  if (lang.detectedLanguage !== "en" && lang.confidence > 0.6) {
+    return { route: "translate", from: lang.detectedLanguage };
+  }
+
+  // Rule 2: otherwise, nearest intent centroid decides
+  const { embeddings: [e] } = await embedder.embed(input);
+  const best = Object.entries(centroids)
+    .map(([name, c]) => ({ name, score: cosineSimilarity(e.values, c) }))
+    .sort((a, b) => b.score - a.score)[0];
+
+  return { route: best.name, score: best.score };
+}
+
+// Then dispatch: Translator, Summarizer, Proofreader, Rewriter, or the Prompt API`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'moderation-cascade',
+    title: 'Moderation Cascade',
+    description: 'The production pattern for cheap moderation: embeddings clear the obvious 90% in microseconds, the LLM judges only the borderline.',
+    category: 'Embeddings',
+    apis: ['Semantic Embedder', 'Prompt API'],
+    icon: 'bi-funnel',
+    onDeviceReason: 'Cascades are how real systems afford moderation — and on-device they cost literally nothing. Watch the counters: most comments never touch the language model.',
+    codeSnippet: `// Stage 1: embedding classifier (microseconds, runs on everything)
+const { embeddings: [e] } = await embedder.embed(comment);
+const scores = {
+  benign: cosineSimilarity(e.values, centroids.benign),
+  toxic:  cosineSimilarity(e.values, centroids.toxic),
+  spam:   cosineSimilarity(e.values, centroids.spam)
+};
+const [top, second] = Object.entries(scores).sort((a, b) => b[1] - a[1]);
+const margin = top[1] - second[1];
+
+if (margin >= 0.05) {
+  return top[0]; // confident — the LLM never runs
+}
+
+// Stage 2: LLM judge (only for the borderline few)
+const verdict = await session.prompt(
+  \`Is this comment benign, toxic, or spam? Comment: "\${comment}"\`,
+  { responseConstraint: {
+      type: "object",
+      properties: {
+        verdict: { type: "string", enum: ["benign", "toxic", "spam"] },
+        reason: { type: "string" }
+      },
+      required: ["verdict", "reason"]
+  }}
+);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'photo-search',
+    title: 'Photo Semantic Search',
+    description: 'Drop in your photos, and search them by meaning — "food on a table", "someone smiling" — without one pixel leaving your device.',
+    category: 'Image Input',
+    apis: ['Prompt API', 'Semantic Embedder'],
+    icon: 'bi-images',
+    onDeviceReason: 'Cloud photo search means uploading your life. Here the vision model captions each photo locally, the captions are embedded locally, and queries rank them locally.',
+    codeSnippet: `// 1. Index: caption every photo with the vision model, embed the captions
+const session = await LanguageModel.create({ expectedInputs: [{ type: "image" }] });
+const embedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+
+for (const photo of photos) {
+  const bitmap = await createImageBitmap(photo.file);
+  photo.caption = await session.prompt([{
+    role: "user",
+    content: [
+      { type: "text", value: "Describe this photo in one factual sentence." },
+      { type: "image", value: bitmap }
+    ]
+  }]);
+  const { embeddings: [e] } = await embedder.embed(photo.caption);
+  photo.vector = e.values;
+}
+
+// 2. Search: embed the query, rank photos by cosine similarity
+const queryEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-query" });
+const { embeddings: [q] } = await queryEmbedder.embed("food on a table");
+
+photos.sort((a, b) =>
+  cosineSimilarity(q.values, b.vector) - cosineSimilarity(q.values, a.vector)
+);`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'mystery-language',
+    title: 'Mystery Language',
+    description: 'Guess which language the snippet is written in — then see if you beat the Language Detector\'s confidence-ranked answer.',
+    category: 'Text Input',
+    apis: ['Language Detector', 'Translator'],
+    icon: 'bi-question-diamond',
+    onDeviceReason: 'A trivia game that doubles as an API showcase: ranked detections with confidences, revealed instantly and offline — plus a translation of what the snippet actually says.',
+    codeSnippet: `const detector = await LanguageDetector.create();
+
+// The player guesses first...
+const playerGuess = "it"; // Italian?
+
+// ...then the detector shows its ranked answer
+const results = await detector.detect("Chi dorme non piglia pesci.");
+// [{ detectedLanguage: "it", confidence: 0.98 }, ...]
+
+const [top] = results;
+if (playerGuess === top.detectedLanguage) score.player++;
+if (top.confidence > 0.5) score.detector++;
+
+// Reveal what it means with the Translator
+const translator = await Translator.create({
+  sourceLanguage: top.detectedLanguage,
+  targetLanguage: "en"
+});
+console.log(await translator.translate("Chi dorme non piglia pesci."));
+// "He who sleeps doesn't catch fish."`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
   {
     id: 'polyglot-chat',
     title: 'Polyglot Chat',
@@ -459,6 +629,48 @@ async function fix(issue) {
   });
   localeStrings[issue.key] = await translator.translate(issue.value);
 }`,
+    promptRunOptions: {},
+    initialPrompt: ''
+  },
+  {
+    id: 'study-kit',
+    title: 'Lecture Study Kit',
+    description: 'Drop a lecture recording: transcript, key-point notes, a Q&A chat over the content, and auto-generated flashcards.',
+    category: 'Audio Input',
+    apis: ['Prompt API', 'Summarizer', 'Semantic Embedder'],
+    icon: 'bi-mortarboard',
+    onDeviceReason: 'A lecture is an hour of your professor\'s voice — big, personal, and slow to upload. The whole study pipeline runs where the recording already is: on your machine.',
+    codeSnippet: `// 1. Transcribe the recording with the multimodal Prompt API
+const session = await LanguageModel.create({ expectedInputs: [{ type: "audio" }] });
+const transcript = await session.prompt([{
+  role: "user",
+  content: [
+    { type: "text", value: "Transcribe this lecture exactly as spoken." },
+    { type: "audio", value: audioFile }
+  ]
+}]);
+
+// 2. Key-point notes with the Summarizer
+const summarizer = await Summarizer.create({ type: "key-points", length: "long" });
+const notes = await summarizer.summarize(transcript);
+
+// 3. Index the transcript for Q&A (RAG over the lecture)
+const chunks = splitIntoChunks(transcript);
+const docEmbedder = await SemanticEmbedder.create({ taskType: "retrieval-document" });
+const { embeddings } = await docEmbedder.embed(chunks);
+
+// 4. Flashcards via structured output
+const cards = await session.prompt(
+  "Create 4 flashcards from this lecture:\\n" + transcript,
+  { responseConstraint: {
+      type: "array",
+      items: {
+        type: "object",
+        properties: { question: { type: "string" }, answer: { type: "string" } },
+        required: ["question", "answer"]
+      }
+  }}
+);`,
     promptRunOptions: {},
     initialPrompt: ''
   },

--- a/webapp/src/app/core/utils/word-diff.util.ts
+++ b/webapp/src/app/core/utils/word-diff.util.ts
@@ -1,0 +1,56 @@
+export interface WordDiffToken {
+  text: string;
+  kind: 'match' | 'sub' | 'ins' | 'del';
+}
+
+export interface WordDiffResult {
+  tokens: WordDiffToken[];
+  substitutions: number;
+  insertions: number;
+  deletions: number;
+  /** Word error rate relative to the reference; accuracy = 1 - wer. */
+  wer: number;
+}
+
+export function tokenizeWords(text: string): string[] {
+  return text
+    .toLowerCase()
+    .replace(/[^\p{L}\p{N}\s'-]/gu, '')
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+/** Word-level alignment via edit distance, backtraced into per-token diff ops. */
+export function diffWords(reference: string[], hypothesis: string[]): WordDiffResult {
+  const n = reference.length, m = hypothesis.length;
+  const d: number[][] = Array.from({ length: n + 1 }, () => new Array(m + 1).fill(0));
+  for (let i = 0; i <= n; i++) d[i][0] = i;
+  for (let j = 0; j <= m; j++) d[0][j] = j;
+  for (let i = 1; i <= n; i++) {
+    for (let j = 1; j <= m; j++) {
+      const substitution = d[i - 1][j - 1] + (reference[i - 1] === hypothesis[j - 1] ? 0 : 1);
+      d[i][j] = Math.min(substitution, d[i - 1][j] + 1, d[i][j - 1] + 1);
+    }
+  }
+
+  const tokens: WordDiffToken[] = [];
+  let i = n, j = m, substitutions = 0, insertions = 0, deletions = 0;
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && d[i][j] === d[i - 1][j - 1] && reference[i - 1] === hypothesis[j - 1]) {
+      tokens.unshift({ text: hypothesis[j - 1], kind: 'match' });
+      i--; j--;
+    } else if (i > 0 && j > 0 && d[i][j] === d[i - 1][j - 1] + 1) {
+      tokens.unshift({ text: hypothesis[j - 1], kind: 'sub' });
+      substitutions++; i--; j--;
+    } else if (j > 0 && d[i][j] === d[i][j - 1] + 1) {
+      tokens.unshift({ text: hypothesis[j - 1], kind: 'ins' });
+      insertions++; j--;
+    } else {
+      tokens.unshift({ text: reference[i - 1], kind: 'del' });
+      deletions++; i--;
+    }
+  }
+
+  const wer = n > 0 ? (substitutions + insertions + deletions) / n : 0;
+  return { tokens, substitutions, insertions, deletions, wer };
+}

--- a/webapp/src/app/pages/demos/components/api-status/api-status.component.html
+++ b/webapp/src/app/pages/demos/components/api-status/api-status.component.html
@@ -28,6 +28,15 @@
         }
       </button>
     }
+
+    @if (isDownloading) {
+      <div class="flex items-center gap-2 text-sm font-medium text-indigo-600 dark:text-indigo-400">
+        <div class="w-32 h-2 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+          <div class="h-full bg-indigo-500 rounded-full transition-all" [style.width.%]="downloadProgress"></div>
+        </div>
+        {{ downloadProgress }}%
+      </div>
+    }
   </div>
 
   @if (hasUnavailable && unavailableHint) {

--- a/webapp/src/app/pages/demos/components/api-status/api-status.component.ts
+++ b/webapp/src/app/pages/demos/components/api-status/api-status.component.ts
@@ -19,6 +19,8 @@ export class ApiStatusComponent {
   @Input() apis: ApiStatusPill[] = [];
   @Input() showInstall = false;
   @Input() isInstalling = false;
+  @Input() isDownloading = false;
+  @Input() downloadProgress = 0;
   @Input() unavailableHint = '';
   @Output() install = new EventEmitter<void>();
 

--- a/webapp/src/app/pages/demos/features/moderation-cascade-demo.component.html
+++ b/webapp/src/app/pages/demos/features/moderation-cascade-demo.component.html
@@ -1,0 +1,126 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress"
+      unavailableHint="<span class='font-semibold'>The cascade needs the Semantic Embedder.</span> Without the Prompt API, borderline comments are resolved by embeddings alone instead of escalating.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Scoreboard -->
+    <div class="grid grid-cols-2 lg:grid-cols-4 gap-3 mb-6">
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Resolved by Embeddings</div>
+        <div class="text-2xl font-bold text-indigo-600 dark:text-indigo-400">{{ embeddingResolved }} <span class="text-sm font-medium text-slate-400">({{ resolvedPercentByEmbeddings }}%)</span></div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Escalated to LLM</div>
+        <div class="text-2xl font-bold text-slate-700 dark:text-slate-300">{{ llmResolved }}</div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Avg Stage-1 Time</div>
+        <div class="text-2xl font-bold text-emerald-600 dark:text-emerald-400">{{ averageEmbeddingMs !== null ? averageEmbeddingMs + 'ms' : 'N/A' }}</div>
+      </div>
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl p-4 border border-slate-200 dark:border-zinc-700 shadow-sm">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">Avg LLM Judge Time</div>
+        <div class="text-2xl font-bold text-slate-700 dark:text-slate-300">{{ averageLlmMs !== null ? averageLlmMs + 'ms' : 'N/A' }}</div>
+      </div>
+    </div>
+
+    <!-- Controls -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6 flex flex-wrap items-center gap-4">
+      <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+              [disabled]="isProcessing || embedderStatus === 'unavailable'"
+              (click)="processAll()">
+        @if (isProcessing) {
+          <i class="bi bi-arrow-repeat animate-spin"></i> Moderating...
+        } @else {
+          <i class="bi bi-funnel"></i> {{ processed ? 'Re-run Moderation' : 'Moderate the Queue' }}
+        }
+      </button>
+      <div class="flex items-center gap-3 flex-grow max-w-sm">
+        <span class="text-xs font-semibold text-slate-500 dark:text-slate-400 whitespace-nowrap">Escalation margin</span>
+        <input type="range" min="0.01" max="0.15" step="0.01" class="flex-grow accent-indigo-600"
+               [(ngModel)]="marginThreshold" [disabled]="isProcessing" />
+        <span class="text-xs font-mono font-bold text-indigo-600 dark:text-indigo-400 w-10">{{ marginThreshold.toFixed(2) }}</span>
+      </div>
+      <span class="text-[11px] text-slate-400 dark:text-slate-500">Higher margin → more comments escalate to the judge.</span>
+    </div>
+
+    <!-- Comment queue -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+      <div class="px-5 py-4 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+        <span class="text-sm font-bold text-slate-700 dark:text-slate-300 uppercase tracking-wider flex items-center gap-2">
+          <i class="bi bi-chat-square-text text-indigo-500"></i> Comment Queue — {{ comments.length }}
+        </span>
+      </div>
+
+      <div class="divide-y divide-slate-100 dark:divide-zinc-800">
+        @for (comment of comments; track comment.id) {
+          <div class="px-5 py-3.5 flex items-start gap-3">
+            <div class="flex-grow min-w-0">
+              <div class="flex items-center gap-2 flex-wrap">
+                <span class="text-xs font-bold text-slate-500 dark:text-slate-400">&#64;{{ comment.author }}</span>
+                @if (comment.verdict) {
+                  <span class="text-[10px] font-bold px-2 py-0.5 rounded-md uppercase tracking-wider {{ verdictChipClass(comment.verdict) }}">
+                    {{ comment.verdict }}
+                  </span>
+                }
+                @if (comment.resolvedBy === 'embeddings') {
+                  <span class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-indigo-100 dark:bg-indigo-900/30 text-indigo-600 dark:text-indigo-400" title="Resolved by the embedding classifier — the LLM never ran">
+                    <i class="bi bi-lightning-charge-fill"></i> embeddings
+                  </span>
+                } @else if (comment.resolvedBy === 'llm') {
+                  <span class="text-[10px] font-semibold px-1.5 py-0.5 rounded bg-slate-200/70 dark:bg-zinc-800 text-slate-600 dark:text-slate-300" title="Borderline — escalated to the LLM judge">
+                    <i class="bi bi-cpu"></i> LLM judge
+                  </span>
+                }
+                <div class="flex-grow"></div>
+                @if (comment.margin !== null) {
+                  <span class="text-[9px] font-mono text-slate-300 dark:text-zinc-600" title="Stage-1 confidence margin">m={{ comment.margin.toFixed(3) }}</span>
+                }
+                @if (comment.timeMs !== null) {
+                  <span class="text-[9px] font-mono text-slate-400 dark:text-slate-500">{{ comment.timeMs }}ms</span>
+                }
+                @if (comment.isProcessing) {
+                  <i class="bi bi-arrow-repeat animate-spin text-indigo-400 text-xs"></i>
+                }
+              </div>
+              <p class="text-sm text-slate-700 dark:text-slate-300 m-0 mt-1 leading-relaxed">{{ comment.text }}</p>
+              @if (comment.reason) {
+                <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-1 italic">Judge: {{ comment.reason }}</p>
+              }
+            </div>
+          </div>
+        }
+      </div>
+
+      <!-- Add your own -->
+      <div class="p-4 border-t border-slate-100 dark:border-zinc-700/50 flex gap-3">
+        <input type="text"
+               class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-4 py-2.5 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-indigo-500/40"
+               [(ngModel)]="newComment"
+               (keydown.enter)="submitComment()"
+               placeholder="Write a comment and see which stage catches it..." />
+        <button class="px-5 py-2 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white text-sm font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                [disabled]="!newComment.trim() || isProcessing || embedderStatus === 'unavailable'"
+                (click)="submitComment()">
+          Post
+        </button>
+      </div>
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/moderation-cascade-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/moderation-cascade-demo.component.ts
@@ -1,0 +1,269 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageModel: any;
+
+type Verdict = 'benign' | 'toxic' | 'spam';
+
+interface ModeratedComment {
+  id: number;
+  author: string;
+  text: string;
+  verdict: Verdict | null;
+  resolvedBy: 'embeddings' | 'llm' | null;
+  margin: number | null;
+  reason: string | null;
+  timeMs: number | null;
+  isProcessing: boolean;
+}
+
+const VERDICT_EXEMPLARS: Record<Verdict, string[]> = {
+  benign: [
+    'This tutorial saved my weekend, thank you so much!',
+    'Great write-up, I bookmarked it for later.',
+    'Could you do a follow-up post about performance?',
+    'I disagree with the methodology, but the data is useful.'
+  ],
+  toxic: [
+    'You are an idiot and everyone here knows it.',
+    'Only a complete moron would ship this garbage.',
+    'Nobody wants you here, just leave the forum.',
+    'Shut up, you have no idea what you are talking about.'
+  ],
+  spam: [
+    'BUY CHEAP WATCHES at best-deals-watch dot com',
+    'Make $5000 a week from home, DM me now!!!',
+    'FREE followers and likes at insta-boost dot net',
+    'Click here to claim your prize before it expires!!!'
+  ]
+};
+
+const COMMENTS: { author: string; text: string }[] = [
+  { author: 'maya_dev', text: 'This tutorial saved my weekend, thank you!' },
+  { author: 'watch4less', text: 'BUY CHEAP WATCHES >>> best-deals-watch dot com' },
+  { author: 'grumpy_gus', text: 'You\'re an idiot and everyone here knows it.' },
+  { author: 'sam_r', text: 'Great write-up, bookmarked for later reference.' },
+  { author: 'crypto_carl', text: 'Make $5000/week from home, DM me now!!!' },
+  { author: 'jjones', text: 'Could you do a follow-up on WebGPU support?' },
+  { author: 'anon4432', text: 'Only a complete moron would ship this garbage.' },
+  { author: 'lena_k', text: 'The dark mode on this site is gorgeous.' },
+  { author: 'insta_boost', text: '🔥🔥 FREE followers at insta-boost dot net 🔥🔥' },
+  { author: 'dr_stats', text: 'I disagree with the benchmark methodology, but the data itself is useful.' },
+  { author: 'sarcasmo', text: 'Wow, genius idea. Really groundbreaking stuff. Slow clap.' },
+  { author: 'self_promo_sue', text: 'I wrote a longer rebuttal on my blog if anyone is interested.' },
+  { author: 'quiet_quinn', text: 'First time commenting — this community seems really helpful.' }
+];
+
+const JUDGE_SCHEMA = {
+  type: 'object',
+  properties: {
+    verdict: { type: 'string', enum: ['benign', 'toxic', 'spam'] },
+    reason: { type: 'string' }
+  },
+  required: ['verdict', 'reason'],
+  additionalProperties: false
+};
+
+@Component({
+  selector: 'app-moderation-cascade-demo',
+  templateUrl: './moderation-cascade-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class ModerationCascadeDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'moderation-cascade')!;
+
+  comments: ModeratedComment[] = COMMENTS.map((c, i) => ({
+    id: i + 1,
+    ...c,
+    verdict: null,
+    resolvedBy: null,
+    margin: null,
+    reason: null,
+    timeMs: null,
+    isProcessing: false
+  }));
+
+  marginThreshold = 0.05;
+  newComment = '';
+
+  isProcessing = false;
+  processed = false;
+
+  embeddingResolved = 0;
+  llmResolved = 0;
+  totalEmbeddingMs = 0;
+  totalLlmMs = 0;
+
+  private centroids: Record<Verdict, Float32Array> | null = null;
+  private judgeSession: any = null;
+  private nextId = COMMENTS.length + 1;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability();
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Semantic Embedder', status: this.embedderStatus },
+      { name: 'Prompt API (judge)', status: this.languageModelAvailability }
+    ];
+  }
+
+  get resolvedPercentByEmbeddings(): number {
+    const total = this.embeddingResolved + this.llmResolved;
+    return total === 0 ? 0 : Math.round((this.embeddingResolved / total) * 100);
+  }
+
+  get averageEmbeddingMs(): number | null {
+    return this.embeddingResolved > 0 ? Math.round(this.totalEmbeddingMs / this.embeddingResolved) : null;
+  }
+
+  get averageLlmMs(): number | null {
+    return this.llmResolved > 0 ? Math.round(this.totalLlmMs / this.llmResolved) : null;
+  }
+
+  verdictChipClass(verdict: Verdict | null): string {
+    switch (verdict) {
+      case 'benign': return 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400';
+      case 'toxic': return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400';
+      case 'spam': return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400';
+      default: return 'bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-slate-400';
+    }
+  }
+
+  private async prepareCentroids() {
+    if (this.centroids) return;
+    const verdicts = Object.keys(VERDICT_EXEMPLARS) as Verdict[];
+    const allExemplars = verdicts.flatMap(v => VERDICT_EXEMPLARS[v]);
+    const vectors = await this.semanticEmbedder.embed(allExemplars, 'classification', this.onDownloadProgress);
+    const centroids = {} as Record<Verdict, Float32Array>;
+    let cursor = 0;
+    for (const verdict of verdicts) {
+      const count = VERDICT_EXEMPLARS[verdict].length;
+      centroids[verdict] = this.semanticEmbedder.meanVector(vectors.slice(cursor, cursor + count));
+      cursor += count;
+    }
+    this.centroids = centroids;
+  }
+
+  async processAll() {
+    if (this.isProcessing || this.embedderStatus === 'unavailable') return;
+
+    this.isProcessing = true;
+    this.errorMessage = '';
+    this.embeddingResolved = 0;
+    this.llmResolved = 0;
+    this.totalEmbeddingMs = 0;
+    this.totalLlmMs = 0;
+    this.comments.forEach(c => {
+      c.verdict = null;
+      c.resolvedBy = null;
+      c.margin = null;
+      c.reason = null;
+      c.timeMs = null;
+    });
+
+    try {
+      await this.prepareCentroids();
+      for (const comment of this.comments) {
+        await this.moderate(comment);
+      }
+      this.processed = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Moderation failed.';
+    } finally {
+      this.isProcessing = false;
+    }
+  }
+
+  private async moderate(comment: ModeratedComment) {
+    comment.isProcessing = true;
+    const start = performance.now();
+
+    try {
+      // Stage 1: embedding classifier — runs on every comment.
+      const vector = await this.semanticEmbedder.embedOne(comment.text, 'classification');
+      const scored = (Object.keys(this.centroids!) as Verdict[])
+        .map(verdict => ({ verdict, score: this.semanticEmbedder.cosineSimilarity(vector, this.centroids![verdict]) }))
+        .sort((a, b) => b.score - a.score);
+
+      const margin = scored[0].score - scored[1].score;
+      comment.margin = margin;
+      const embeddingMs = performance.now() - start;
+
+      if (margin >= this.marginThreshold || this.languageModelAvailability === 'unavailable') {
+        comment.verdict = scored[0].verdict;
+        comment.resolvedBy = 'embeddings';
+        comment.timeMs = Math.round(embeddingMs);
+        this.embeddingResolved++;
+        this.totalEmbeddingMs += embeddingMs;
+        return;
+      }
+
+      // Stage 2: the LLM judge — only for borderline comments.
+      const llmStart = performance.now();
+      if (!this.judgeSession) {
+        this.judgeSession = await LanguageModel.create({
+          systemPrompt: 'You moderate a technology forum. Classify comments as benign, toxic (insulting or hostile), or spam (unsolicited promotion or scams). Sarcasm and criticism of ideas are benign. Give a one-sentence reason.'
+        });
+      }
+      const response = await this.judgeSession.prompt(
+        `Comment: "${comment.text}"`,
+        { responseConstraint: JUDGE_SCHEMA }
+      );
+      const result = JSON.parse(response);
+      comment.verdict = result.verdict;
+      comment.reason = result.reason;
+      comment.resolvedBy = 'llm';
+      comment.timeMs = Math.round(performance.now() - start);
+      this.llmResolved++;
+      this.totalLlmMs += performance.now() - llmStart;
+    } catch (e: any) {
+      comment.reason = e.message;
+    } finally {
+      comment.isProcessing = false;
+    }
+  }
+
+  async submitComment() {
+    const text = this.newComment.trim();
+    if (!text || this.isProcessing || this.embedderStatus === 'unavailable') return;
+
+    const comment: ModeratedComment = {
+      id: this.nextId++,
+      author: 'you',
+      text,
+      verdict: null,
+      resolvedBy: null,
+      margin: null,
+      reason: null,
+      timeMs: null,
+      isProcessing: false
+    };
+    this.comments.push(comment);
+    this.newComment = '';
+
+    try {
+      await this.prepareCentroids();
+      await this.moderate(comment);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Could not moderate the comment.';
+    }
+  }
+
+  override ngOnDestroy() {
+    this.judgeSession?.destroy?.();
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/mystery-language-demo.component.html
+++ b/webapp/src/app/pages/demos/features/mystery-language-demo.component.html
@@ -1,0 +1,122 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      unavailableHint="<span class='font-semibold'>The Language Detector is not available in this browser.</span> You can still guess — but the detector can't play against you.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Scoreboard -->
+    <div class="flex items-center justify-center gap-6 mb-6">
+      <div class="text-center">
+        <div class="text-3xl font-extrabold text-indigo-600 dark:text-indigo-400">{{ playerScore }}</div>
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">You</div>
+      </div>
+      <div class="text-slate-300 dark:text-zinc-600 font-bold">vs</div>
+      <div class="text-center">
+        <div class="text-3xl font-extrabold text-emerald-600 dark:text-emerald-400">{{ detectorScore }}</div>
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Detector</div>
+      </div>
+      <div class="w-px h-10 bg-slate-200 dark:bg-zinc-700"></div>
+      <div class="text-center">
+        <div class="text-xl font-bold text-slate-600 dark:text-slate-300">{{ round }}/{{ totalRounds }}</div>
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider">Round</div>
+      </div>
+    </div>
+
+    @if (phase === 'finished') {
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border-2 p-8 text-center"
+           [ngClass]="playerScore >= detectorScore ? 'border-indigo-300 dark:border-indigo-700' : 'border-emerald-300 dark:border-emerald-700'">
+        <div class="text-4xl mb-2">{{ playerScore > detectorScore ? '🏆' : playerScore < detectorScore ? '🤖' : '🤝' }}</div>
+        <div class="text-xl font-bold text-slate-800 dark:text-slate-200">{{ verdictLine }}</div>
+        <div class="text-sm text-slate-500 dark:text-slate-400 mt-1">Final score: you {{ playerScore }} — detector {{ detectorScore }}</div>
+        <button class="mt-5 px-7 py-2.5 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-medium shadow-md transition-all active:scale-95 border-none"
+                (click)="startMatch()">
+          <i class="bi bi-arrow-repeat"></i> Rematch
+        </button>
+      </div>
+    } @else if (current) {
+      <!-- The snippet -->
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-8 text-center mb-5">
+        <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-3">What language is this?</div>
+        <p class="text-xl md:text-2xl font-serif text-slate-800 dark:text-slate-100 leading-relaxed m-0">
+          "{{ current.text }}"
+        </p>
+      </div>
+
+      @if (phase === 'guessing') {
+        <div class="grid grid-cols-2 md:grid-cols-4 gap-3">
+          @for (option of options; track option) {
+            <button class="px-4 py-4 rounded-2xl bg-[#ffffff] dark:bg-zinc-800/90 hover:bg-indigo-50 dark:hover:bg-indigo-900/20 border border-slate-200 dark:border-zinc-700 hover:border-indigo-300 dark:hover:border-indigo-700 text-sm font-bold text-slate-700 dark:text-slate-300 shadow-sm transition-all active:scale-95 disabled:opacity-50"
+                    [disabled]="isRevealing"
+                    (click)="guess(option)">
+              @if (isRevealing) {
+                <i class="bi bi-arrow-repeat animate-spin"></i>
+              } @else {
+                {{ languageName(option) }}
+              }
+            </button>
+          }
+        </div>
+      } @else if (phase === 'revealed' && lastResult) {
+        <div class="grid grid-cols-1 md:grid-cols-2 gap-4 mb-5">
+          <!-- Player -->
+          <div class="rounded-2xl border p-5"
+               [ngClass]="lastResult.playerCorrect
+                 ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/60 dark:bg-emerald-900/10'
+                 : 'border-red-200 dark:border-red-900/50 bg-red-50/50 dark:bg-red-900/10'">
+            <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Your guess</div>
+            <div class="flex items-center gap-2">
+              <i class="bi" [ngClass]="lastResult.playerCorrect ? 'bi-check-circle-fill text-emerald-500' : 'bi-x-circle-fill text-red-400'"></i>
+              <span class="text-lg font-bold text-slate-800 dark:text-slate-200">{{ languageName(lastResult.playerGuess) }}</span>
+            </div>
+          </div>
+          <!-- Detector -->
+          <div class="rounded-2xl border p-5"
+               [ngClass]="lastResult.detectorCorrect
+                 ? 'border-emerald-300 dark:border-emerald-700 bg-emerald-50/60 dark:bg-emerald-900/10'
+                 : 'border-slate-200 dark:border-zinc-700 bg-slate-50/50 dark:bg-[#161616]/50'">
+            <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1.5">Language Detector</div>
+            @if (lastResult.detectorTop) {
+              <div class="flex items-center gap-2">
+                <i class="bi" [ngClass]="lastResult.detectorCorrect ? 'bi-check-circle-fill text-emerald-500' : 'bi-x-circle-fill text-red-400'"></i>
+                <span class="text-lg font-bold text-slate-800 dark:text-slate-200">{{ languageName(lastResult.detectorTop.language) }}</span>
+                <span class="text-xs font-mono text-slate-400 dark:text-slate-500">{{ (lastResult.detectorTop.confidence * 100).toFixed(0) }}%</span>
+              </div>
+            } @else {
+              <span class="text-sm text-slate-400 dark:text-slate-500 font-light">The detector sat this round out.</span>
+            }
+          </div>
+        </div>
+
+        <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl border border-slate-200 dark:border-zinc-700 p-5 mb-5 text-center">
+          <div class="text-[10px] font-bold text-slate-400 dark:text-slate-500 uppercase tracking-wider mb-1">
+            It was {{ languageName(lastResult.snippet.language) }}
+          </div>
+          @if (lastResult.translation) {
+            <p class="text-sm text-slate-600 dark:text-slate-400 m-0 italic">"{{ lastResult.translation }}"</p>
+          }
+        </div>
+
+        <div class="text-center">
+          <button class="px-8 py-3 rounded-full bg-indigo-600 hover:bg-indigo-700 text-white font-semibold shadow-md transition-all active:scale-95 border-none"
+                  (click)="continueMatch()">
+            {{ round === totalRounds ? 'See Final Score' : 'Next Round' }} <i class="bi bi-arrow-right"></i>
+          </button>
+        </div>
+      }
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/mystery-language-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/mystery-language-demo.component.ts
@@ -1,0 +1,220 @@
+import { Component, Inject, OnInit, PLATFORM_ID } from '@angular/core';
+import { DOCUMENT, isPlatformServer } from '@angular/common';
+import { Title } from '@angular/platform-browser';
+import { BasePage } from '../../base-page';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageDetector: any;
+declare const Translator: any;
+
+interface Snippet {
+  text: string;
+  language: string;
+}
+
+interface RoundResult {
+  snippet: Snippet;
+  playerGuess: string;
+  playerCorrect: boolean;
+  detectorTop: { language: string; confidence: number } | null;
+  detectorCorrect: boolean;
+  translation: string | null;
+}
+
+const LANGUAGE_NAMES: Record<string, string> = {
+  fr: 'French', es: 'Spanish', de: 'German', it: 'Italian', pt: 'Portuguese',
+  nl: 'Dutch', sv: 'Swedish', pl: 'Polish', tr: 'Turkish', ja: 'Japanese',
+  fi: 'Finnish', da: 'Danish', ro: 'Romanian', no: 'Norwegian', cs: 'Czech'
+};
+
+const SNIPPETS: Snippet[] = [
+  { text: 'Qui vivra verra, dit-on souvent par ici.', language: 'fr' },
+  { text: 'No hay mal que por bien no venga, decía mi abuela.', language: 'es' },
+  { text: 'Übung macht den Meister, sagt man bei uns.', language: 'de' },
+  { text: 'Chi dorme non piglia pesci, ricordalo sempre.', language: 'it' },
+  { text: 'Quem não arrisca, não petisca — é o que dizem.', language: 'pt' },
+  { text: 'Wie het laatst lacht, lacht het best, zeggen wij.', language: 'nl' },
+  { text: 'Borta bra men hemma bäst, brukar vi säga.', language: 'sv' },
+  { text: 'Nie ma tego złego, co by na dobre nie wyszło.', language: 'pl' },
+  { text: 'Damlaya damlaya göl olur, derler bizde.', language: 'tr' },
+  { text: '猿も木から落ちると言いますからね。', language: 'ja' },
+  { text: 'Ei kukaan ole seppä syntyessään, sanotaan meillä.', language: 'fi' },
+  { text: 'Øvelse gør mester, plejer vi at sige.', language: 'da' },
+  { text: 'Cine se scoală de dimineață departe ajunge.', language: 'ro' }
+];
+
+const TOTAL_ROUNDS = 8;
+
+@Component({
+  selector: 'app-mystery-language-demo',
+  templateUrl: './mystery-language-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class MysteryLanguageDemoComponent extends BasePage implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'mystery-language')!;
+
+  detectorStatus = 'loading...';
+  errorMessage = '';
+
+  round = 0;
+  totalRounds = TOTAL_ROUNDS;
+  playerScore = 0;
+  detectorScore = 0;
+
+  current: Snippet | null = null;
+  options: string[] = [];
+  phase: 'guessing' | 'revealed' | 'finished' = 'guessing';
+  lastResult: RoundResult | null = null;
+  isRevealing = false;
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+  private remaining: Snippet[] = [];
+
+  constructor(
+    @Inject(DOCUMENT) document: Document,
+    title: Title,
+    @Inject(PLATFORM_ID) private readonly platformId: Object
+  ) {
+    super(document, title);
+  }
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    try {
+      this.detectorStatus = 'LanguageDetector' in self ? await LanguageDetector.availability() : 'unavailable';
+    } catch { this.detectorStatus = 'unavailable'; }
+
+    this.startMatch();
+  }
+
+  get statusPills() {
+    return [{ name: 'Language Detector', status: this.detectorStatus }];
+  }
+
+  languageName(code: string): string {
+    return LANGUAGE_NAMES[code] ?? code;
+  }
+
+  startMatch() {
+    this.remaining = [...SNIPPETS].sort(() => Math.random() - 0.5).slice(0, TOTAL_ROUNDS);
+    this.round = 0;
+    this.playerScore = 0;
+    this.detectorScore = 0;
+    this.lastResult = null;
+    this.nextRound();
+  }
+
+  private nextRound() {
+    if (this.remaining.length === 0) {
+      this.phase = 'finished';
+      this.current = null;
+      return;
+    }
+
+    this.current = this.remaining.pop()!;
+    this.round++;
+    this.phase = 'guessing';
+    this.lastResult = null;
+
+    // The correct answer plus three decoys, shuffled.
+    const decoys = Object.keys(LANGUAGE_NAMES)
+      .filter(code => code !== this.current!.language)
+      .sort(() => Math.random() - 0.5)
+      .slice(0, 3);
+    this.options = [this.current.language, ...decoys].sort(() => Math.random() - 0.5);
+  }
+
+  async guess(code: string) {
+    if (this.phase !== 'guessing' || !this.current || this.isRevealing) return;
+
+    this.isRevealing = true;
+    this.errorMessage = '';
+    const snippet = this.current;
+
+    const result: RoundResult = {
+      snippet,
+      playerGuess: code,
+      playerCorrect: code === snippet.language,
+      detectorTop: null,
+      detectorCorrect: false,
+      translation: null
+    };
+
+    try {
+      // The detector plays the same round.
+      if (this.detectorStatus !== 'unavailable') {
+        if (!this.detector) this.detector = await LanguageDetector.create();
+        const detections = await this.detector.detect(snippet.text);
+        const top = detections?.[0];
+        if (top && top.detectedLanguage !== 'und') {
+          result.detectorTop = { language: top.detectedLanguage, confidence: top.confidence };
+          result.detectorCorrect = top.detectedLanguage === snippet.language;
+        }
+      }
+
+      // Best effort: reveal what the snippet means.
+      if ('Translator' in self) {
+        try {
+          const key = `${snippet.language}->en`;
+          if (!this.translators.has(key)) {
+            this.translators.set(key, await Translator.create({
+              sourceLanguage: snippet.language,
+              targetLanguage: 'en'
+            }));
+          }
+          result.translation = await this.translators.get(key).translate(snippet.text);
+        } catch {
+          result.translation = null;
+        }
+      }
+
+      if (result.playerCorrect) this.playerScore++;
+      if (result.detectorCorrect) this.detectorScore++;
+      this.lastResult = result;
+      this.phase = 'revealed';
+    } catch (e: any) {
+      this.errorMessage = e.message || 'The reveal failed.';
+    } finally {
+      this.isRevealing = false;
+    }
+  }
+
+  continueMatch() {
+    if (this.phase !== 'revealed') return;
+    this.nextRound();
+  }
+
+  get verdictLine(): string {
+    if (this.playerScore > this.detectorScore) return 'You beat the Language Detector. Impressive.';
+    if (this.playerScore < this.detectorScore) return 'The Language Detector wins this one.';
+    return 'A tie — you and the detector are equally polyglot.';
+  }
+
+  get dynamicCodeSnippet(): string {
+    const snippet = this.lastResult?.snippet ?? SNIPPETS[0];
+    return `const detector = await LanguageDetector.create();
+
+// The player guesses first...
+const playerGuess = ${JSON.stringify(this.lastResult?.playerGuess ?? 'it')};
+
+// ...then the detector shows its ranked answer
+const results = await detector.detect(${JSON.stringify(snippet.text)});
+// [{ detectedLanguage: ${JSON.stringify(this.lastResult?.detectorTop?.language ?? snippet.language)}, confidence: ${this.lastResult?.detectorTop ? this.lastResult.detectorTop.confidence.toFixed(2) : '0.98'} }, ...]
+
+const [top] = results;
+if (playerGuess === top.detectedLanguage) score.player++;
+if (top.detectedLanguage === answer) score.detector++;
+
+// Reveal what it means with the Translator
+const translator = await Translator.create({
+  sourceLanguage: top.detectedLanguage,
+  targetLanguage: "en"
+});
+console.log(await translator.translate(${JSON.stringify(snippet.text)}));${this.lastResult?.translation ? `\n// "${this.lastResult.translation.replace(/"/g, '\\"')}"` : ''}`;
+  }
+}

--- a/webapp/src/app/pages/demos/features/omnibox-demo.component.html
+++ b/webapp/src/app/pages/demos/features/omnibox-demo.component.html
@@ -1,0 +1,133 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress"
+      unavailableHint="<span class='font-semibold'>The router needs the Semantic Embedder and Language Detector.</span> The destination APIs (Translator, Summarizer, Proofreader, Rewriter, Prompt) are created lazily when a route fires.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- The one box -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border-2 border-rose-200 dark:border-rose-900/50 p-5 mb-6">
+      <div class="flex flex-col sm:flex-row gap-3">
+        <textarea
+          class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-2xl px-5 py-3.5 text-base text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-rose-500/40 resize-none min-h-[76px]"
+          [(ngModel)]="input"
+          placeholder="Paste anything — a question, a draft, a foreign paragraph, a wall of text..."></textarea>
+        <button class="self-end flex items-center gap-2 px-7 py-3 rounded-full bg-rose-600 hover:bg-rose-700 text-white font-semibold shadow-md transition-all active:scale-95 disabled:opacity-50 border-none whitespace-nowrap"
+                [disabled]="!input.trim() || isRunning"
+                (click)="run()">
+          @if (isRunning) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Routing...
+          } @else {
+            <i class="bi bi-magic"></i> Route & Run
+          }
+        </button>
+      </div>
+      <div class="flex flex-wrap gap-2 mt-3">
+        @for (sample of sampleInputs; track sample.label) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                  [disabled]="isRunning"
+                  (click)="useSample(sample)">
+            {{ sample.label }}
+          </button>
+        }
+      </div>
+    </div>
+
+    <div class="flex flex-col lg:flex-row gap-6 items-start">
+
+      <!-- Routing decision -->
+      <div class="lg:flex-[2] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-signpost-split text-rose-500"></i> Routing Decision
+          </span>
+          @if (decision) {
+            <span class="text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+              routed in {{ decision.routingMs }}ms
+            </span>
+          }
+        </div>
+        <div class="p-5">
+          @if (!decision) {
+            <p class="text-sm text-slate-400 dark:text-slate-500 font-light m-0 text-center py-6">
+              Three rules pick the destination:<br />
+              <span class="text-xs">1. foreign language → Translate · 2. very long text → Summarize · 3. nearest intent embedding</span>
+            </p>
+          } @else {
+            <!-- Winner -->
+            <div class="rounded-2xl border border-rose-200 dark:border-rose-800 bg-rose-50/60 dark:bg-rose-900/10 p-4 mb-4">
+              <div class="flex items-center gap-2">
+                <i class="bi text-xl text-rose-600 dark:text-rose-400"
+                   [ngClass]="decision.route === 'translate' ? 'bi-translate' : routeById(decision.route)?.icon"></i>
+                <span class="text-lg font-bold text-rose-700 dark:text-rose-300 capitalize">{{ decision.route }}</span>
+              </div>
+              <p class="text-xs text-slate-500 dark:text-slate-400 m-0 mt-1.5">{{ decision.rule }}</p>
+            </div>
+
+            <!-- Intent scores -->
+            @if (routes[0].score !== null) {
+              <div class="flex flex-col gap-2">
+                @for (route of routes; track route.id) {
+                  <div class="flex items-center gap-3">
+                    <span class="text-xs font-semibold w-20 shrink-0"
+                          [ngClass]="decision.route === route.id ? 'text-rose-600 dark:text-rose-400' : 'text-slate-500 dark:text-slate-400'">
+                      {{ route.label }}
+                    </span>
+                    <div class="flex-grow h-1.5 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden">
+                      <div class="h-full rounded-full"
+                           [ngClass]="decision.route === route.id ? 'bg-rose-500' : 'bg-slate-400 dark:bg-zinc-500'"
+                           [style.width.%]="(route.score ?? 0) * 100"></div>
+                    </div>
+                    <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500 w-10 text-right">{{ route.score?.toFixed(3) }}</span>
+                  </div>
+                }
+              </div>
+            }
+          }
+        </div>
+      </div>
+
+      <!-- Output -->
+      <div class="lg:flex-[3] w-full bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 flex flex-col overflow-hidden min-h-[260px]">
+        <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+            <i class="bi bi-box-arrow-down text-rose-500"></i> {{ outputLabel || 'Output' }}
+          </span>
+          <div class="flex items-center gap-2">
+            @if (executionMs !== null) {
+              <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">ran in {{ executionMs }}ms</span>
+            }
+            @if (state === 'Inferencing') {
+              <app-latency-loader></app-latency-loader>
+            }
+          </div>
+        </div>
+        <div class="p-5 text-[15px] text-slate-800 dark:text-slate-200 leading-relaxed whitespace-pre-wrap flex-grow">
+          @if (output) {
+            {{ output }}
+          } @else if (isRunning) {
+            <span class="text-rose-500"><i class="bi bi-arrow-repeat animate-spin"></i> Running the chosen API...</span>
+          } @else {
+            <span class="text-slate-400 dark:text-slate-500 font-light select-none">The chosen API's result lands here, labeled with which tool ran.</span>
+          }
+        </div>
+      </div>
+
+    </div>
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/omnibox-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/omnibox-demo.component.ts
@@ -1,0 +1,277 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+declare const LanguageDetector: any;
+declare const Translator: any;
+declare const Summarizer: any;
+declare const Proofreader: any;
+declare const Rewriter: any;
+
+type RouteId = 'translate' | 'summarize' | 'proofread' | 'rewrite' | 'answer';
+
+interface IntentRoute {
+  id: RouteId;
+  label: string;
+  api: string;
+  icon: string;
+  exemplars: string[];
+  centroid: Float32Array | null;
+  score: number | null;
+}
+
+interface RoutingDecision {
+  route: RouteId;
+  rule: string;
+  detectedLanguage?: string;
+  routingMs: number;
+}
+
+const LONG_TEXT_THRESHOLD = 400;
+
+@Component({
+  selector: 'app-omnibox-demo',
+  templateUrl: './omnibox-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class OmniboxDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'omnibox')!;
+
+  input = '';
+  output = '';
+  outputLabel = '';
+  isRunning = false;
+  decision: RoutingDecision | null = null;
+  executionMs: number | null = null;
+
+  detectorStatus = 'loading...';
+
+  routes: IntentRoute[] = [
+    {
+      id: 'summarize', label: 'Summarize', api: 'Summarizer', icon: 'bi-card-text',
+      exemplars: ['Summarize this article for me', 'Give me the key points of this text', 'Condense this into a short overview'],
+      centroid: null, score: null
+    },
+    {
+      id: 'proofread', label: 'Proofread', api: 'Proofreader', icon: 'bi-patch-check',
+      exemplars: ['Fix the typos and grammar in this text', 'Correct my writing mistakes', 'Check this for spelling errors'],
+      centroid: null, score: null
+    },
+    {
+      id: 'rewrite', label: 'Rewrite', api: 'Rewriter', icon: 'bi-pencil-square',
+      exemplars: ['Make this sound more professional', 'Rephrase this more politely', 'Rewrite this in a formal tone'],
+      centroid: null, score: null
+    },
+    {
+      id: 'answer', label: 'Answer', api: 'Prompt API', icon: 'bi-chat-square-dots',
+      exemplars: ['What is the capital of France?', 'How does photosynthesis work?', 'Explain why the sky is blue'],
+      centroid: null, score: null
+    }
+  ];
+
+  sampleInputs: { label: string; text: string }[] = [
+    { label: 'A question', text: 'Why do cats purr, and does it always mean they are happy?' },
+    { label: 'Fix my typos', text: 'Can you fix the grammar in this: I has went to the libary but they was allready closed.' },
+    { label: 'Make it professional', text: 'Make this sound professional: hey boss, demo broke again, gonna be late with the fix, my bad.' },
+    { label: 'French text', text: 'Le navigateur devient une plateforme d\'intelligence artificielle : les modèles s\'exécutent désormais directement sur l\'appareil.' },
+    { label: 'A long article', text: 'Browsers are quietly becoming AI platforms. Over the past two years, Chrome has shipped a family of Built-In AI APIs that expose on-device models to any web page: a general-purpose language model, task-specific endpoints for summarizing, writing, rewriting, proofreading, and translating text, an embedding model for semantic search, and on-device speech recognition. The engineering bet is that many AI features do not need a frontier model in a data center. Summarizing an email thread, correcting grammar as someone types, or ranking help articles by meaning are tasks that small, specialized models handle well — and they are exactly the tasks where privacy, latency, and cost matter most. When the model runs on the user\'s own hardware, keystrokes never leave the device, responses begin in milliseconds, and developers pay nothing per call.' }
+  ];
+
+  private detector: any = null;
+  private translators = new Map<string, any>();
+  private centroidsReady = false;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    await this.checkEmbedderAvailability();
+    try {
+      this.detectorStatus = 'LanguageDetector' in self ? await LanguageDetector.availability() : 'unavailable';
+    } catch { this.detectorStatus = 'unavailable'; }
+
+    if (this.embedderStatus === 'available') {
+      await this.prepareCentroids();
+    }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Semantic Embedder', status: this.embedderStatus },
+      { name: 'Language Detector', status: this.detectorStatus }
+    ];
+  }
+
+  routeById(id: RouteId): IntentRoute | undefined {
+    return this.routes.find(r => r.id === id);
+  }
+
+  private async prepareCentroids() {
+    const allExemplars = this.routes.flatMap(r => r.exemplars);
+    const vectors = await this.semanticEmbedder.embed(allExemplars, 'classification', this.onDownloadProgress);
+    let cursor = 0;
+    for (const route of this.routes) {
+      route.centroid = this.semanticEmbedder.meanVector(vectors.slice(cursor, cursor + route.exemplars.length));
+      cursor += route.exemplars.length;
+    }
+    this.centroidsReady = true;
+  }
+
+  useSample(sample: { label: string; text: string }) {
+    this.input = sample.text;
+    this.run();
+  }
+
+  async run() {
+    const input = this.input.trim();
+    if (!input || this.isRunning) return;
+
+    this.isRunning = true;
+    this.errorMessage = '';
+    this.output = '';
+    this.outputLabel = '';
+    this.decision = null;
+    this.executionMs = null;
+    this.routes.forEach(r => (r.score = null));
+
+    const routingStart = performance.now();
+
+    try {
+      // Rule 1: a confidently foreign input always routes to translation.
+      let detectedLanguage: string | null = null;
+      if (this.detectorStatus !== 'unavailable') {
+        if (!this.detector) this.detector = await LanguageDetector.create();
+        const results = await this.detector.detect(input);
+        const top = results?.[0];
+        if (top && top.detectedLanguage !== 'und' && top.detectedLanguage !== 'en' && top.confidence > 0.6) {
+          detectedLanguage = top.detectedLanguage;
+        }
+      }
+
+      if (detectedLanguage) {
+        this.decision = {
+          route: 'translate',
+          rule: `Language Detector: not English (${detectedLanguage})`,
+          detectedLanguage,
+          routingMs: Math.round(performance.now() - routingStart)
+        };
+        await this.execute(input, this.decision);
+        return;
+      }
+
+      // Rule 2: very long input is content to summarize, not an instruction.
+      if (input.length > LONG_TEXT_THRESHOLD) {
+        this.decision = {
+          route: 'summarize',
+          rule: `Length heuristic: ${input.length} chars > ${LONG_TEXT_THRESHOLD}`,
+          routingMs: Math.round(performance.now() - routingStart)
+        };
+        await this.execute(input, this.decision);
+        return;
+      }
+
+      // Rule 3: nearest intent centroid decides.
+      if (!this.centroidsReady) {
+        if (this.embedderStatus === 'unavailable') {
+          this.decision = { route: 'answer', rule: 'Embedder unavailable — defaulting to the Prompt API', routingMs: 0 };
+          await this.execute(input, this.decision);
+          return;
+        }
+        await this.prepareCentroids();
+      }
+
+      const vector = await this.semanticEmbedder.embedOne(input, 'classification');
+      let best: IntentRoute | null = null;
+      for (const route of this.routes) {
+        route.score = this.semanticEmbedder.cosineSimilarity(vector, route.centroid!);
+        if (!best || route.score > (best.score ?? -1)) best = route;
+      }
+
+      this.decision = {
+        route: best!.id,
+        rule: `Embedding similarity: nearest to "${best!.label}" exemplars`,
+        routingMs: Math.round(performance.now() - routingStart)
+      };
+      await this.execute(input, this.decision);
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Routing failed.';
+    } finally {
+      this.isRunning = false;
+    }
+  }
+
+  /** For "instruction: content" inputs, run the tool on the content only. */
+  private extractPayload(input: string): string {
+    const match = input.match(/^[^:\n]{0,80}:\s*([\s\S]+)$/);
+    return match ? match[1].trim() : input;
+  }
+
+  private async execute(input: string, decision: RoutingDecision) {
+    const start = performance.now();
+    try {
+      switch (decision.route) {
+        case 'translate': {
+          const key = `${decision.detectedLanguage}->en`;
+          if (!this.translators.has(key)) {
+            this.translators.set(key, await Translator.create({
+              sourceLanguage: decision.detectedLanguage,
+              targetLanguage: 'en'
+            }));
+          }
+          this.output = await this.translators.get(key).translate(input);
+          this.outputLabel = `Translated from ${decision.detectedLanguage} — Translator API`;
+          break;
+        }
+        case 'summarize': {
+          const summarizer = await Summarizer.create({ type: 'key-points', length: 'short', format: 'plain-text' });
+          this.output = await summarizer.summarize(input);
+          this.outputLabel = 'Key points — Summarizer API';
+          summarizer.destroy?.();
+          break;
+        }
+        case 'proofread': {
+          const proofreader = await Proofreader.create({ expectedInputLanguages: ['en'] });
+          const payload = this.extractPayload(input);
+          const result = await proofreader.proofread(payload);
+          const corrections = result.corrections?.length ?? 0;
+          this.output = result.correctedInput ?? result.correction ?? payload;
+          this.outputLabel = `${corrections} ${corrections === 1 ? 'correction' : 'corrections'} — Proofreader API`;
+          proofreader.destroy?.();
+          break;
+        }
+        case 'rewrite': {
+          const rewriter = await Rewriter.create({ tone: 'more-formal', format: 'plain-text' });
+          this.output = await rewriter.rewrite(this.extractPayload(input));
+          this.outputLabel = 'More formal — Rewriter API';
+          rewriter.destroy?.();
+          break;
+        }
+        case 'answer': {
+          const session = await LanguageModel.create();
+          this.state = PromptInputStateEnum.Inferencing;
+          const stream = session.promptStreaming(input);
+          for await (const chunk of stream) {
+            this.output += chunk;
+          }
+          this.state = PromptInputStateEnum.Ready;
+          this.outputLabel = 'Answer — Prompt API';
+          session.destroy?.();
+          break;
+        }
+      }
+      this.executionMs = Math.round(performance.now() - start);
+    } catch (e: any) {
+      this.state = PromptInputStateEnum.Ready;
+      this.errorMessage = `${this.routeById(decision.route)?.api ?? decision.route} failed: ${e.message}`;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/photo-search-demo.component.html
+++ b/webapp/src/app/pages/demos/features/photo-search-demo.component.html
@@ -1,0 +1,113 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress"
+      unavailableHint="<span class='font-semibold'>Indexing needs the multimodal Prompt API and the Semantic Embedder.</span> Photos never leave the device — captions and vectors are computed locally.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Controls -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="flex flex-col sm:flex-row gap-3">
+        <label class="flex items-center justify-center gap-2 px-5 py-3 rounded-full bg-violet-600 hover:bg-violet-700 text-white text-sm font-medium shadow-md cursor-pointer transition-all active:scale-95 whitespace-nowrap">
+          <i class="bi bi-images"></i> Add Photos
+          <input type="file" accept="image/*" multiple class="hidden" (change)="onFilesSelected($event)" />
+        </label>
+        <div class="relative flex-grow">
+          <i class="bi bi-search absolute left-5 top-1/2 -translate-y-1/2 text-slate-400"></i>
+          <input type="text"
+                 class="w-full bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full pl-12 pr-32 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-violet-500/40"
+                 [(ngModel)]="query"
+                 (ngModelChange)="onQueryChanged($event)"
+                 [disabled]="readyPhotos.length === 0"
+                 placeholder="{{ readyPhotos.length > 0 ? 'Search your photos by meaning...' : 'Add photos first — they are indexed locally...' }}" />
+          @if (searchLatencyMs !== null && hasSearched) {
+            <span class="absolute right-4 top-1/2 -translate-y-1/2 text-[10px] font-semibold px-2 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+              {{ searchLatencyMs }}ms
+            </span>
+          }
+        </div>
+      </div>
+      <div class="flex flex-wrap items-center gap-2 mt-3">
+        @for (sample of sampleQueries; track sample) {
+          <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                  [disabled]="readyPhotos.length === 0"
+                  (click)="useSample(sample)">
+            "{{ sample }}"
+          </button>
+        }
+        <div class="flex-grow"></div>
+        @if (isIndexing) {
+          <span class="text-xs font-semibold text-violet-600 dark:text-violet-400"><i class="bi bi-arrow-repeat animate-spin"></i> Captioning & embedding...</span>
+        } @else if (photos.length > 0) {
+          <span class="text-xs font-semibold text-slate-400 dark:text-slate-500">{{ indexedCount }}/{{ photos.length }} indexed</span>
+        }
+      </div>
+    </div>
+
+    <!-- Photo grid -->
+    @if (photos.length === 0) {
+      <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border-2 border-dashed border-slate-300 dark:border-zinc-600 p-12 text-center">
+        <i class="bi bi-images text-5xl text-slate-200 dark:text-zinc-700"></i>
+        <p class="text-sm text-slate-400 dark:text-slate-500 mt-4 font-light max-w-md mx-auto m-0">
+          Add a handful of photos. Each one is captioned by the on-device vision model and embedded for search — nothing is uploaded, which is the whole point.
+        </p>
+      </div>
+    } @else {
+      <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 gap-4">
+        @for (photo of sortedPhotos; track photo.id; let i = $index) {
+          <div class="relative rounded-2xl overflow-hidden border shadow-sm group transition-all"
+               [ngClass]="hasSearched && i === 0 && photo.score !== null
+                 ? 'border-violet-400 dark:border-violet-600 ring-2 ring-violet-200 dark:ring-violet-900/60'
+                 : 'border-slate-200 dark:border-zinc-700'"
+               [style.opacity]="hasSearched && photo.score !== null && photo.score < 0.3 ? 0.45 : 1">
+            <img [src]="photo.url" alt="{{ photo.caption || 'Uploaded photo' }}" class="w-full h-36 object-cover block" />
+
+            <!-- Status / score -->
+            <div class="absolute top-2 right-2 flex gap-1.5">
+              @if (photo.status === 'captioning') {
+                <span class="px-2 py-0.5 rounded-full bg-black/60 text-white text-[10px] font-semibold backdrop-blur"><i class="bi bi-arrow-repeat animate-spin"></i></span>
+              } @else if (photo.status === 'error') {
+                <span class="px-2 py-0.5 rounded-full bg-red-600/90 text-white text-[10px] font-semibold">error</span>
+              } @else if (hasSearched && photo.score !== null) {
+                <span class="px-2 py-0.5 rounded-full text-[10px] font-mono font-bold backdrop-blur"
+                      [ngClass]="i === 0 ? 'bg-violet-600/95 text-white' : 'bg-black/60 text-white'">
+                  {{ photo.score.toFixed(3) }}
+                </span>
+              }
+            </div>
+
+            <button class="absolute top-2 left-2 w-6 h-6 rounded-full bg-black/50 hover:bg-black/80 text-white text-xs border-none opacity-0 group-hover:opacity-100 transition-opacity flex items-center justify-center"
+                    title="Remove"
+                    (click)="removePhoto(photo)">
+              <i class="bi bi-x"></i>
+            </button>
+
+            @if (photo.caption) {
+              <div class="px-3 py-2 bg-[#ffffff] dark:bg-zinc-800/95 text-[10px] text-slate-500 dark:text-slate-400 leading-snug line-clamp-2" title="{{ photo.caption }}">
+                {{ photo.caption }}
+              </div>
+            }
+          </div>
+        }
+      </div>
+      <p class="text-[11px] text-slate-400 dark:text-slate-500 mt-3">
+        Captions shown under each photo are what the search actually matches against. Low-scoring photos fade when a query is active.
+      </p>
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/photo-search-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/photo-search-demo.component.ts
@@ -1,0 +1,189 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { Subject, debounceTime } from 'rxjs';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+
+declare const LanguageModel: any;
+
+interface IndexedPhoto {
+  id: number;
+  url: string;
+  caption: string | null;
+  vector: Float32Array | null;
+  score: number | null;
+  status: 'pending' | 'captioning' | 'ready' | 'error';
+}
+
+@Component({
+  selector: 'app-photo-search-demo',
+  templateUrl: './photo-search-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class PhotoSearchDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'photo-search')!;
+
+  photos: IndexedPhoto[] = [];
+  query = '';
+  isIndexing = false;
+  indexedCount = 0;
+  searchLatencyMs: number | null = null;
+  hasSearched = false;
+
+  sampleQueries = ['food on a table', 'someone smiling', 'outdoors in nature', 'a screen or device', 'an animal'];
+
+  private query$ = new Subject<string>();
+  private searchToken = 0;
+  private nextId = 1;
+  private captionSession: any = null;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+
+    this.subscriptions.push(
+      this.query$.pipe(debounceTime(250)).subscribe(q => this.search(q))
+    );
+
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability([{ type: 'image' }]);
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Prompt API (image)', status: this.languageModelAvailability },
+      { name: 'Semantic Embedder', status: this.embedderStatus }
+    ];
+  }
+
+  get readyPhotos(): IndexedPhoto[] {
+    return this.photos.filter(p => p.status === 'ready');
+  }
+
+  get sortedPhotos(): IndexedPhoto[] {
+    if (!this.hasSearched) return this.photos;
+    return [...this.photos].sort((a, b) => (b.score ?? -1) - (a.score ?? -1));
+  }
+
+  async onFilesSelected(event: Event) {
+    const files = Array.from((event.target as HTMLInputElement).files ?? []);
+    if (files.length === 0) return;
+
+    const added: IndexedPhoto[] = [];
+    for (const file of files.slice(0, 12)) {
+      added.push({
+        id: this.nextId++,
+        url: URL.createObjectURL(file),
+        caption: null,
+        vector: null,
+        score: null,
+        status: 'pending'
+      });
+    }
+    this.photos.push(...added);
+    (event.target as HTMLInputElement).value = '';
+
+    await this.indexPhotos(added, files.slice(0, 12));
+  }
+
+  private async indexPhotos(photos: IndexedPhoto[], files: File[]) {
+    if (this.languageModelAvailability === 'unavailable' || this.embedderStatus === 'unavailable') {
+      this.errorMessage = 'Indexing needs the multimodal Prompt API and the Semantic Embedder.';
+      photos.forEach(p => (p.status = 'error'));
+      return;
+    }
+
+    this.isIndexing = true;
+    this.errorMessage = '';
+
+    try {
+      if (!this.captionSession) {
+        this.captionSession = await LanguageModel.create({
+          expectedInputs: [{ type: 'image' }],
+          systemPrompt: 'You caption photos for a search index. Reply with ONE factual sentence describing the main subjects, setting, and any visible text. No preamble.'
+        });
+      }
+
+      for (let i = 0; i < photos.length; i++) {
+        const photo = photos[i];
+        photo.status = 'captioning';
+        try {
+          const bitmap = await createImageBitmap(files[i]);
+          // A clone keeps each caption independent — the session's context stays clean.
+          const session = await this.captionSession.clone();
+          photo.caption = (await session.prompt([{
+            role: 'user',
+            content: [
+              { type: 'text', value: 'Caption this photo for search.' },
+              { type: 'image', value: bitmap }
+            ]
+          }])).trim();
+          session.destroy?.();
+
+          photo.vector = await this.semanticEmbedder.embedOne(photo.caption!, 'retrieval-document');
+          photo.status = 'ready';
+          this.indexedCount++;
+        } catch (e: any) {
+          photo.status = 'error';
+          this.errorMessage = e.message || 'Failed to index a photo.';
+        }
+      }
+
+      if (this.query.trim()) this.search(this.query);
+    } finally {
+      this.isIndexing = false;
+    }
+  }
+
+  removePhoto(photo: IndexedPhoto) {
+    URL.revokeObjectURL(photo.url);
+    this.photos = this.photos.filter(p => p.id !== photo.id);
+    if (photo.status === 'ready') this.indexedCount--;
+  }
+
+  onQueryChanged(value: string) {
+    this.query$.next(value);
+  }
+
+  useSample(sample: string) {
+    this.query = sample;
+    this.search(sample);
+  }
+
+  async search(rawQuery: string) {
+    const query = rawQuery.trim();
+    const token = ++this.searchToken;
+
+    if (!query || this.readyPhotos.length === 0) {
+      this.hasSearched = false;
+      this.photos.forEach(p => (p.score = null));
+      return;
+    }
+
+    try {
+      const start = performance.now();
+      const queryVector = await this.semanticEmbedder.embedOne(query, 'retrieval-query');
+      if (token !== this.searchToken) return;
+
+      this.searchLatencyMs = Math.round(performance.now() - start);
+      for (const photo of this.photos) {
+        photo.score = photo.vector ? this.semanticEmbedder.cosineSimilarity(queryVector, photo.vector) : null;
+      }
+      this.hasSearched = true;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Search failed.';
+    }
+  }
+
+  override ngOnDestroy() {
+    this.photos.forEach(photo => URL.revokeObjectURL(photo.url));
+    this.captionSession?.destroy?.();
+    super.ngOnDestroy();
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/study-kit-demo.component.html
+++ b/webapp/src/app/pages/demos/features/study-kit-demo.component.html
@@ -1,0 +1,178 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="statusPills"
+      [isDownloading]="isDownloading"
+      [downloadProgress]="downloadProgress"
+      unavailableHint="<span class='font-semibold'>Part of the kit is unavailable.</span> Audio transcription needs the multimodal Prompt API — without it, paste a transcript instead. Notes and flashcards degrade gracefully.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Input + pipeline -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-5 mb-6">
+      <div class="flex flex-wrap items-center gap-3">
+        <label class="flex items-center gap-2 px-5 py-2.5 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-700 dark:text-slate-300 text-sm font-medium border border-slate-200 dark:border-zinc-700 cursor-pointer transition-colors">
+          <i class="bi bi-file-earmark-music"></i> {{ audioFile ? audioFile.name : 'Upload Lecture Audio' }}
+          <input type="file" accept="audio/*" class="hidden" (change)="onFileSelected($event)" />
+        </label>
+        <span class="text-xs text-slate-400 dark:text-slate-500">or</span>
+        <button class="px-5 py-2.5 rounded-full bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-700 dark:text-slate-300 text-sm font-medium border border-slate-200 dark:border-zinc-700 transition-colors"
+                (click)="useSampleTranscript()">
+          <i class="bi bi-journal-text"></i> Use Sample Transcript
+        </button>
+        <div class="flex-grow"></div>
+        <button class="flex items-center gap-2 px-6 py-2.5 rounded-full bg-amber-600 hover:bg-amber-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                [disabled]="!canBuild"
+                (click)="build()">
+          @if (isBuilding) {
+            <i class="bi bi-arrow-repeat animate-spin"></i> Building...
+          } @else {
+            <i class="bi bi-mortarboard"></i> Build Study Kit
+          }
+        </button>
+      </div>
+
+      @if (pastedTranscript && !audioFile) {
+        <textarea
+          class="w-full mt-3 bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-2xl px-4 py-3 text-xs text-slate-600 dark:text-slate-400 outline-none focus:ring-2 focus:ring-amber-500/40 resize-none leading-relaxed"
+          rows="4"
+          [(ngModel)]="pastedTranscript"></textarea>
+      }
+
+      <!-- Pipeline stages -->
+      <div class="flex items-center gap-2 mt-4 flex-wrap">
+        @for (stageDef of [{ id: 'transcribe', label: 'Transcribe', api: 'Prompt' }, { id: 'notes', label: 'Notes', api: 'Summarizer' }, { id: 'index', label: 'Index', api: 'Embedder' }, { id: 'flashcards', label: 'Flashcards', api: 'Prompt' }]; track stageDef.id; let last = $last) {
+          @let state = stageState(stageDef.id === 'transcribe' ? 'transcribe' : stageDef.id === 'notes' ? 'notes' : stageDef.id === 'index' ? 'index' : 'flashcards');
+          <div class="flex items-center gap-1.5 px-3 py-1.5 rounded-full border text-xs font-semibold transition-colors"
+               [ngClass]="{
+                 'border-slate-200 dark:border-zinc-700 text-slate-400 dark:text-slate-500': state === 'idle',
+                 'border-amber-300 dark:border-amber-700 bg-amber-50 dark:bg-amber-900/20 text-amber-700 dark:text-amber-400': state === 'active',
+                 'border-emerald-300 dark:border-emerald-700 bg-emerald-50 dark:bg-emerald-900/15 text-emerald-700 dark:text-emerald-400': state === 'done'
+               }">
+            @if (state === 'active') {
+              <i class="bi bi-arrow-repeat animate-spin"></i>
+            } @else if (state === 'done') {
+              <i class="bi bi-check-circle-fill"></i>
+            }
+            {{ stageDef.label }}
+            <span class="text-[9px] opacity-60 font-mono">{{ stageDef.api }}</span>
+          </div>
+          @if (!last) {
+            <i class="bi bi-arrow-right text-slate-300 dark:text-zinc-600 text-xs"></i>
+          }
+        }
+        @if (buildMs !== null && built) {
+          <span class="ml-auto text-[11px] font-semibold px-2.5 py-1 rounded-full bg-emerald-50 dark:bg-emerald-900/20 text-emerald-700 dark:text-emerald-400 border border-emerald-200 dark:border-emerald-900/40">
+            kit built in {{ buildMs }}ms
+          </span>
+        }
+      </div>
+    </div>
+
+    @if (built) {
+      <div class="flex flex-col xl:flex-row gap-6 items-start">
+
+        <!-- Notes + Q&A -->
+        <div class="xl:flex-[3] w-full flex flex-col gap-5">
+          @if (notes) {
+            <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+              <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50">
+                <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                  <i class="bi bi-journal-check text-amber-500"></i> Key-Point Notes
+                </span>
+              </div>
+              <div class="p-5 text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap">{{ notes }}</div>
+            </div>
+          }
+
+          <!-- Q&A -->
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 overflow-hidden">
+            <div class="px-5 py-3.5 border-b border-slate-100 dark:border-zinc-700/50 bg-slate-50/50 dark:bg-[#161616]/50 flex justify-between items-center">
+              <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2">
+                <i class="bi bi-chat-square-quote text-amber-500"></i> Ask the Lecture
+              </span>
+              @if (isAnswering) {
+                <app-latency-loader></app-latency-loader>
+              }
+            </div>
+            <div class="p-5">
+              <div class="flex gap-3">
+                <input type="text"
+                       class="flex-grow bg-slate-50 dark:bg-[#161616] border border-slate-200 dark:border-zinc-700 rounded-full px-5 py-3 text-sm text-slate-800 dark:text-slate-200 placeholder-slate-400 outline-none focus:ring-2 focus:ring-amber-500/40"
+                       [(ngModel)]="question"
+                       (keydown.enter)="ask()"
+                       placeholder="Ask anything covered in the lecture..." />
+                <button class="px-6 py-2.5 rounded-full bg-amber-600 hover:bg-amber-700 text-white font-medium shadow-md transition-all active:scale-95 disabled:opacity-50 border-none"
+                        [disabled]="!question.trim() || isAnswering"
+                        (click)="ask()">
+                  Ask
+                </button>
+              </div>
+              <div class="flex flex-wrap gap-2 mt-3">
+                @for (sample of sampleQuestions; track sample) {
+                  <button class="px-3 py-1.5 rounded-full text-xs font-medium bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border border-slate-200 dark:border-zinc-700 transition-colors disabled:opacity-40"
+                          [disabled]="isAnswering"
+                          (click)="useSampleQuestion(sample)">
+                    {{ sample }}
+                  </button>
+                }
+              </div>
+
+              @if (answer) {
+                <div class="mt-4 rounded-2xl border border-slate-200 dark:border-zinc-700 bg-slate-50/60 dark:bg-[#161616]/60 p-4 text-sm text-slate-700 dark:text-slate-300 leading-relaxed whitespace-pre-wrap">
+                  {{ answer }}
+                </div>
+                @if (retrieved.length > 0) {
+                  <p class="text-[11px] text-slate-400 dark:text-slate-500 m-0 mt-2">
+                    Grounded in {{ retrieved.length }} retrieved passages (top similarity {{ retrieved[0].score.toFixed(3) }}).
+                  </p>
+                }
+              }
+            </div>
+          </div>
+        </div>
+
+        <!-- Flashcards -->
+        <div class="xl:flex-[2] w-full">
+          <span class="text-xs font-bold text-slate-500 dark:text-slate-400 uppercase tracking-wider flex items-center gap-2 mb-3">
+            <i class="bi bi-collection text-amber-500"></i> Flashcards — click to flip
+          </span>
+          <div class="flex flex-col gap-3">
+            @for (card of flashcards; track $index) {
+              <button class="text-left rounded-2xl border p-5 min-h-[100px] transition-all active:scale-[0.99] bg-transparent"
+                      [ngClass]="card.flipped
+                        ? 'border-amber-300 dark:border-amber-700 bg-amber-50/70 dark:bg-amber-900/15'
+                        : 'border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800/90 hover:border-amber-300 dark:hover:border-amber-800 shadow-sm'"
+                      (click)="card.flipped = !card.flipped">
+                <div class="text-[9px] font-bold uppercase tracking-wider mb-1.5"
+                     [ngClass]="card.flipped ? 'text-amber-600 dark:text-amber-400' : 'text-slate-400 dark:text-slate-500'">
+                  {{ card.flipped ? 'Answer' : 'Question ' + ($index + 1) }}
+                </div>
+                <div class="text-sm leading-relaxed"
+                     [ngClass]="card.flipped ? 'text-amber-900 dark:text-amber-100' : 'text-slate-800 dark:text-slate-200 font-medium'">
+                  {{ card.flipped ? card.answer : card.question }}
+                </div>
+              </button>
+            }
+            @if (flashcards.length === 0) {
+              <p class="text-sm text-slate-400 dark:text-slate-500 font-light">Flashcards need the Prompt API — they were skipped.</p>
+            }
+          </div>
+        </div>
+
+      </div>
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/study-kit-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/study-kit-demo.component.ts
@@ -1,0 +1,256 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseEmbedderDemoComponent } from '../components/base-demo/base-embedder-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { PromptInputStateEnum } from '../../../core/enums/prompt-input-state.enum';
+
+declare const LanguageModel: any;
+declare const Summarizer: any;
+
+interface Flashcard {
+  question: string;
+  answer: string;
+  flipped: boolean;
+}
+
+interface TranscriptChunk {
+  text: string;
+  vector: Float32Array;
+}
+
+type KitStage = 'transcribe' | 'notes' | 'index' | 'flashcards';
+
+const FLASHCARDS_SCHEMA = {
+  type: 'object',
+  properties: {
+    cards: {
+      type: 'array',
+      minItems: 3,
+      maxItems: 5,
+      items: {
+        type: 'object',
+        properties: {
+          question: { type: 'string' },
+          answer: { type: 'string' }
+        },
+        required: ['question', 'answer'],
+        additionalProperties: false
+      }
+    }
+  },
+  required: ['cards'],
+  additionalProperties: false
+};
+
+const SAMPLE_TRANSCRIPT = `Today we are going to talk about photosynthesis, which is how plants convert light energy into chemical energy. The process happens in the chloroplasts, specifically using a green pigment called chlorophyll, which absorbs mostly red and blue light and reflects green — which is why leaves look green to us.
+
+Photosynthesis has two main stages. The light-dependent reactions happen in the thylakoid membranes. Water molecules are split, releasing oxygen as a byproduct, and the energy is captured in two carrier molecules, ATP and NADPH. Remember that the oxygen we breathe is essentially a waste product of this stage.
+
+The second stage is the Calvin cycle, which takes place in the stroma and does not require light directly. Here the plant uses the ATP and NADPH from the first stage to fix carbon dioxide from the air into glucose. The key enzyme is RuBisCO, which is widely considered the most abundant protein on Earth.
+
+For the exam, know the overall equation: six CO2 plus six H2O, with light energy, yields one glucose molecule and six O2. And be ready to explain why photosynthesis rates change with light intensity, CO2 concentration, and temperature — those three are the classic limiting factors.`;
+
+@Component({
+  selector: 'app-study-kit-demo',
+  templateUrl: './study-kit-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class StudyKitDemoComponent extends BaseEmbedderDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'study-kit')!;
+
+  audioFile: File | null = null;
+  transcript = '';
+  pastedTranscript = '';
+  notes = '';
+  flashcards: Flashcard[] = [];
+  chunks: TranscriptChunk[] = [];
+
+  stage: KitStage | null = null;
+  isBuilding = false;
+  built = false;
+  buildMs: number | null = null;
+
+  question = '';
+  answer = '';
+  retrieved: { text: string; score: number }[] = [];
+  isAnswering = false;
+
+  summarizerStatus = 'loading...';
+
+  sampleQuestions = [
+    'What does RuBisCO do?',
+    'Why do leaves look green?',
+    'Where does the oxygen we breathe come from?',
+    'What are the three limiting factors?'
+  ];
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+
+    await this.checkEmbedderAvailability();
+    await this.checkAvailability([{ type: 'audio' }]);
+    try {
+      this.summarizerStatus = 'Summarizer' in self ? await Summarizer.availability() : 'unavailable';
+    } catch { this.summarizerStatus = 'unavailable'; }
+  }
+
+  get statusPills() {
+    return [
+      { name: 'Prompt API (audio)', status: this.languageModelAvailability },
+      { name: 'Summarizer', status: this.summarizerStatus },
+      { name: 'Semantic Embedder', status: this.embedderStatus }
+    ];
+  }
+
+  stageState(stage: KitStage): 'idle' | 'active' | 'done' {
+    const order: KitStage[] = ['transcribe', 'notes', 'index', 'flashcards'];
+    if (this.built) return 'done';
+    if (this.stage === null) return 'idle';
+    const currentIdx = order.indexOf(this.stage);
+    const stageIdx = order.indexOf(stage);
+    if (stageIdx < currentIdx) return 'done';
+    if (stageIdx === currentIdx) return 'active';
+    return 'idle';
+  }
+
+  onFileSelected(event: Event) {
+    const file = (event.target as HTMLInputElement).files?.[0];
+    if (file) {
+      this.audioFile = file;
+      this.pastedTranscript = '';
+    }
+  }
+
+  useSampleTranscript() {
+    this.pastedTranscript = SAMPLE_TRANSCRIPT;
+    this.audioFile = null;
+  }
+
+  get canBuild(): boolean {
+    return !this.isBuilding
+      && (!!this.audioFile || !!this.pastedTranscript.trim())
+      && this.embedderStatus !== 'unavailable';
+  }
+
+  async build() {
+    if (!this.canBuild) return;
+
+    this.isBuilding = true;
+    this.built = false;
+    this.errorMessage = '';
+    this.notes = '';
+    this.flashcards = [];
+    this.chunks = [];
+    this.answer = '';
+    this.retrieved = [];
+    const start = performance.now();
+
+    try {
+      // Stage 1: transcript — from audio via the multimodal Prompt API, or pasted.
+      this.stage = 'transcribe';
+      if (this.audioFile) {
+        if (this.languageModelAvailability === 'unavailable') {
+          throw new Error('The Prompt API is unavailable — paste a transcript instead.');
+        }
+        const session = await LanguageModel.create({ expectedInputs: [{ type: 'audio' }] });
+        this.transcript = await session.prompt([{
+          role: 'user',
+          content: [
+            { type: 'text', value: 'Transcribe this lecture recording exactly as spoken.' },
+            { type: 'audio', value: this.audioFile }
+          ]
+        }]);
+        session.destroy?.();
+      } else {
+        this.transcript = this.pastedTranscript.trim();
+      }
+
+      // Stage 2: key-point notes with the Summarizer.
+      this.stage = 'notes';
+      if (this.summarizerStatus !== 'unavailable') {
+        const summarizer = await Summarizer.create({ type: 'key-points', length: 'medium', format: 'plain-text' });
+        this.notes = await summarizer.summarize(this.transcript, { context: 'This is a lecture transcript a student wants to revise from.' });
+        summarizer.destroy?.();
+      } else {
+        this.notes = '';
+      }
+
+      // Stage 3: index the transcript for Q&A.
+      this.stage = 'index';
+      const parts = this.transcript.split(/\n\s*\n/).map(p => p.trim()).filter(p => p.length > 0);
+      const vectors = await this.semanticEmbedder.embed(parts, 'retrieval-document', this.onDownloadProgress);
+      this.chunks = parts.map((text, i) => ({ text, vector: vectors[i] }));
+
+      // Stage 4: flashcards via structured output.
+      this.stage = 'flashcards';
+      if (this.languageModelAvailability !== 'unavailable') {
+        const session = await LanguageModel.create({
+          systemPrompt: 'You create study flashcards from lecture transcripts. Questions should test understanding, answers should be one or two sentences.'
+        });
+        const response = await session.prompt(
+          `Create flashcards from this lecture:\n\n${this.transcript}`,
+          { responseConstraint: FLASHCARDS_SCHEMA }
+        );
+        session.destroy?.();
+        this.flashcards = JSON.parse(response).cards.map((card: any) => ({ ...card, flipped: false }));
+      }
+
+      this.buildMs = Math.round(performance.now() - start);
+      this.built = true;
+      this.stage = null;
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Building the study kit failed.';
+      this.stage = null;
+    } finally {
+      this.isBuilding = false;
+    }
+  }
+
+  useSampleQuestion(sample: string) {
+    this.question = sample;
+    this.ask();
+  }
+
+  async ask() {
+    const q = this.question.trim();
+    if (!q || !this.built || this.isAnswering || this.chunks.length === 0) return;
+    if (this.languageModelAvailability === 'unavailable') {
+      this.errorMessage = 'The Prompt API is unavailable — Q&A is disabled.';
+      return;
+    }
+
+    this.isAnswering = true;
+    this.answer = '';
+    this.retrieved = [];
+    this.errorMessage = '';
+    this.state = PromptInputStateEnum.Inferencing;
+
+    try {
+      const queryVector = await this.semanticEmbedder.embedOne(q, 'retrieval-query');
+      const top = this.semanticEmbedder.topK(queryVector, this.chunks.map(c => c.vector), 2);
+      this.retrieved = top.map(r => ({ text: this.chunks[r.index].text, score: r.score }));
+
+      const context = this.retrieved.map((c, i) => `[${i + 1}] ${c.text}`).join('\n\n');
+      const session = await LanguageModel.create({
+        systemPrompt: 'Answer the student\'s question using ONLY the provided lecture passages. Be concise and cite passage numbers like [1].'
+      });
+      const stream = session.promptStreaming(`Lecture passages:\n${context}\n\nQuestion: ${q}`);
+      for await (const chunk of stream) {
+        this.answer += chunk;
+      }
+      session.destroy?.();
+    } catch (e: any) {
+      this.errorMessage = e.message || 'Could not answer the question.';
+    } finally {
+      this.isAnswering = false;
+      this.state = PromptInputStateEnum.Ready;
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return this.demo.codeSnippet;
+  }
+}

--- a/webapp/src/app/pages/demos/features/tongue-twister-demo.component.html
+++ b/webapp/src/app/pages/demos/features/tongue-twister-demo.component.html
@@ -1,0 +1,111 @@
+<app-demo-layout
+  [title]="demo.title"
+  [description]="demo.description"
+  [icon]="demo.icon"
+  [category]="demo.category"
+  [onDeviceReason]="demo.onDeviceReason"
+  [codeSnippet]="dynamicCodeSnippet">
+  <div demo-ui>
+
+    <app-api-status
+      [apis]="[{ name: 'Web Speech (on-device)', status: speechStatus }]"
+      [showInstall]="true"
+      [isInstalling]="isInstalling"
+      (install)="installSpeechModel({ quality: 'dictation' })"
+      unavailableHint="<span class='font-semibold'>On-device speech recognition is not available in this browser.</span> Use a recent Chrome build with on-device Web Speech support.">
+    </app-api-status>
+
+    @if (errorMessage) {
+      <div class="mb-4 bg-red-50 border border-red-200 dark:bg-red-900/10 dark:border-red-900/30 rounded-2xl p-4 text-sm text-red-700 dark:text-red-300">
+        {{ errorMessage }}
+      </div>
+    }
+
+    <!-- Twister picker -->
+    <div class="flex flex-wrap gap-2 mb-6">
+      @for (option of twisters; track option) {
+        <button class="px-3.5 py-2 rounded-full text-xs font-medium transition-all border disabled:opacity-40"
+                [ngClass]="twister === option
+                  ? 'bg-cyan-600 text-white border-cyan-600 shadow-md'
+                  : 'bg-slate-100 hover:bg-slate-200 dark:bg-zinc-800 dark:hover:bg-zinc-700 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-zinc-700'"
+                [disabled]="isListening"
+                (click)="selectTwister(option)">
+          {{ option.length > 44 ? option.slice(0, 44) + '…' : option }}
+        </button>
+      }
+    </div>
+
+    <!-- The stage -->
+    <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-3xl shadow-sm border border-slate-200 dark:border-zinc-700 p-8 text-center mb-6">
+      <p class="text-2xl md:text-3xl font-serif font-bold text-slate-800 dark:text-slate-100 leading-snug m-0 max-w-2xl mx-auto">
+        "{{ twister }}"
+      </p>
+
+      <div class="mt-6 flex flex-col items-center gap-3">
+        @if (isListening) {
+          <button class="w-20 h-20 rounded-full bg-red-600 hover:bg-red-700 text-white text-3xl shadow-lg transition-all active:scale-95 border-none relative"
+                  (click)="stop()">
+            <span class="absolute inset-0 rounded-full bg-red-500/40 animate-ping"></span>
+            <i class="bi bi-stop-fill relative"></i>
+          </button>
+          <p class="text-sm text-slate-500 dark:text-slate-400 m-0 min-h-[24px]">
+            @if (interim || liveTranscript) {
+              <span class="italic">"{{ liveTranscript }} {{ interim }}"</span>
+            } @else {
+              Go — as fast as you can!
+            }
+          </p>
+        } @else {
+          <button class="w-20 h-20 rounded-full bg-cyan-600 hover:bg-cyan-700 text-white text-3xl shadow-lg transition-all active:scale-95 disabled:opacity-40 border-none"
+                  [disabled]="speechStatus !== 'available'"
+                  (click)="record()">
+            <i class="bi bi-mic-fill"></i>
+          </button>
+          <p class="text-sm text-slate-400 dark:text-slate-500 m-0">
+            Tap and say it as fast as you dare. Scored on-device, judged mercilessly.
+          </p>
+        }
+        @if (bestAccuracy !== null) {
+          <span class="text-xs font-bold px-3 py-1.5 rounded-full bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400">
+            <i class="bi bi-trophy"></i> Best: {{ bestAccuracy }}%
+          </span>
+        }
+      </div>
+    </div>
+
+    <!-- Attempts -->
+    @if (attempts.length > 0) {
+      <div class="flex flex-col gap-3">
+        @for (attempt of attempts; track $index) {
+          <div class="bg-[#ffffff] dark:bg-zinc-800/90 rounded-2xl shadow-sm border p-4"
+               [ngClass]="$first ? 'border-cyan-200 dark:border-cyan-900/50' : 'border-slate-200 dark:border-zinc-700'">
+            <div class="flex items-center gap-3 flex-wrap">
+              <span class="text-2xl">{{ attempt.rank.emoji }}</span>
+              <span class="text-sm font-bold {{ attempt.rank.textClass }}">{{ attempt.rank.label }}</span>
+              <div class="flex-grow h-2 bg-slate-200 dark:bg-zinc-700 rounded-full overflow-hidden min-w-[100px]">
+                <div class="h-full rounded-full transition-all duration-500"
+                     [ngClass]="attempt.accuracy >= 85 ? 'bg-emerald-500' : attempt.accuracy >= 70 ? 'bg-amber-500' : 'bg-rose-500'"
+                     [style.width.%]="attempt.accuracy"></div>
+              </div>
+              <span class="text-lg font-extrabold"
+                    [ngClass]="attempt.accuracy >= 85 ? 'text-emerald-600 dark:text-emerald-400' : attempt.accuracy >= 70 ? 'text-amber-600 dark:text-amber-400' : 'text-rose-600 dark:text-rose-400'">
+                {{ attempt.accuracy }}%
+              </span>
+              <span class="text-[10px] font-mono text-slate-400 dark:text-slate-500">{{ (attempt.durationMs / 1000).toFixed(1) }}s</span>
+            </div>
+            <p class="text-sm m-0 mt-2 leading-relaxed">
+              @for (token of attempt.diff; track $index) {
+                <span [ngClass]="diffTokenClass(token.kind)">{{ token.text }}</span>{{ ' ' }}
+              }
+            </p>
+          </div>
+        }
+      </div>
+      <div class="mt-3 flex flex-wrap gap-x-5 gap-y-1 text-[11px] text-slate-400 dark:text-slate-500">
+        <span><span class="inline-block w-3 h-3 rounded bg-red-100 dark:bg-red-900/30 align-middle mr-1"></span> wrong word</span>
+        <span><span class="inline-block w-3 h-3 rounded bg-amber-100 dark:bg-amber-900/30 align-middle mr-1"></span> extra word</span>
+        <span><span class="line-through mr-1">word</span> missed word</span>
+      </div>
+    }
+  </div>
+</app-demo-layout>

--- a/webapp/src/app/pages/demos/features/tongue-twister-demo.component.ts
+++ b/webapp/src/app/pages/demos/features/tongue-twister-demo.component.ts
@@ -1,0 +1,176 @@
+import { Component, OnInit } from '@angular/core';
+import { isPlatformServer } from '@angular/common';
+import { BaseSpeechDemoComponent } from '../components/base-demo/base-speech-demo.component';
+import { DEMOS_DATA } from '../../../core/services/demos.data';
+import { diffWords, tokenizeWords, WordDiffToken } from '../../../core/utils/word-diff.util';
+
+interface Attempt {
+  transcript: string;
+  accuracy: number;
+  diff: WordDiffToken[];
+  durationMs: number;
+  rank: Rank;
+}
+
+interface Rank {
+  label: string;
+  emoji: string;
+  textClass: string;
+}
+
+const TWISTERS = [
+  'She sells seashells by the seashore.',
+  'Peter Piper picked a peck of pickled peppers.',
+  'How much wood would a woodchuck chuck if a woodchuck could chuck wood?',
+  'Red lorry, yellow lorry, red lorry, yellow lorry.',
+  'The sixth sick sheikh\'s sixth sheep is sick.',
+  'Unique New York, unique New York, you know you need unique New York.'
+];
+
+@Component({
+  selector: 'app-tongue-twister-demo',
+  templateUrl: './tongue-twister-demo.component.html',
+  standalone: false,
+  host: { class: 'block h-full' }
+})
+export class TongueTwisterDemoComponent extends BaseSpeechDemoComponent implements OnInit {
+  demo = DEMOS_DATA.find(d => d.id === 'tongue-twister')!;
+
+  twisters = TWISTERS;
+  twister = TWISTERS[0];
+
+  attempts: Attempt[] = [];
+  interim = '';
+  liveTranscript = '';
+  bestAccuracy: number | null = null;
+
+  private recordingStart = 0;
+
+  override async ngOnInit() {
+    super.ngOnInit();
+    this.setTitle(`Demo: ${this.demo.title}`);
+    if (isPlatformServer(this.platformId)) return;
+    await this.checkSpeechAvailability({ quality: 'dictation' });
+  }
+
+  selectTwister(twister: string) {
+    if (this.isListening) return;
+    this.twister = twister;
+    this.attempts = [];
+    this.bestAccuracy = null;
+  }
+
+  rankFor(accuracy: number): Rank {
+    if (accuracy >= 95) return { label: 'Tongue Master', emoji: '🏆', textClass: 'text-amber-500' };
+    if (accuracy >= 85) return { label: 'Silver Tongue', emoji: '🥈', textClass: 'text-slate-400' };
+    if (accuracy >= 70) return { label: 'Getting There', emoji: '💪', textClass: 'text-sky-500' };
+    return { label: 'Tongue Tied', emoji: '🙃', textClass: 'text-rose-500' };
+  }
+
+  record() {
+    if (this.isListening || this.speechStatus !== 'available') return;
+
+    this.errorMessage = '';
+    this.liveTranscript = '';
+    this.interim = '';
+
+    try {
+      this.recognition = this.webSpeech.createRecognizer({
+        quality: 'dictation',
+        continuous: false,
+        interimResults: true
+      });
+    } catch (e: any) {
+      this.errorMessage = e.message;
+      return;
+    }
+
+    const r = this.recognition;
+    this.isListening = true;
+    this.recordingStart = performance.now();
+
+    r.onresult = (event: any) => this.ngZone.run(() => {
+      let finalText = '';
+      let interim = '';
+      for (let i = 0; i < event.results.length; i++) {
+        const transcript = event.results[i][0].transcript;
+        if (event.results[i].isFinal) finalText += transcript + ' ';
+        else interim += transcript;
+      }
+      this.liveTranscript = finalText.trim();
+      this.interim = interim;
+    });
+
+    r.onerror = (event: any) => this.ngZone.run(() => {
+      this.errorMessage = event.error === 'not-allowed'
+        ? 'Microphone access was denied. Allow the mic to play.'
+        : event.error === 'no-speech'
+          ? 'No speech detected — try again, and faster!'
+          : `Recognition error: ${event.error}`;
+    });
+
+    r.onend = () => this.ngZone.run(() => {
+      this.isListening = false;
+      this.interim = '';
+      this.recognition = null;
+      if (this.liveTranscript) this.scoreAttempt();
+    });
+
+    r.start();
+  }
+
+  stop() {
+    this.stopRecognition();
+  }
+
+  private scoreAttempt() {
+    const reference = tokenizeWords(this.twister);
+    const hypothesis = tokenizeWords(this.liveTranscript);
+    const result = diffWords(reference, hypothesis);
+    const accuracy = Math.max(0, Math.round((1 - result.wer) * 100));
+
+    const attempt: Attempt = {
+      transcript: this.liveTranscript,
+      accuracy,
+      diff: result.tokens,
+      durationMs: Math.round(performance.now() - this.recordingStart),
+      rank: this.rankFor(accuracy)
+    };
+    this.attempts.unshift(attempt);
+    if (this.attempts.length > 6) this.attempts.pop();
+    this.bestAccuracy = Math.max(this.bestAccuracy ?? 0, accuracy);
+    this.liveTranscript = '';
+  }
+
+  diffTokenClass(kind: WordDiffToken['kind']): string {
+    switch (kind) {
+      case 'sub': return 'bg-red-100 dark:bg-red-900/30 text-red-700 dark:text-red-400 rounded px-0.5';
+      case 'ins': return 'bg-amber-100 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400 rounded px-0.5';
+      case 'del': return 'text-slate-400 dark:text-slate-500 line-through';
+      default: return '';
+    }
+  }
+
+  get dynamicCodeSnippet(): string {
+    return `const twister = ${JSON.stringify(this.twister)};
+
+const recognition = new SpeechRecognition();
+recognition.options = { langs: ["en-US"], processLocally: true, quality: "dictation" };
+recognition.interimResults = true;
+
+recognition.onresult = (event) => {
+  const transcript = [...event.results].map(r => r[0].transcript).join("");
+
+  // Score with word error rate against the target sentence
+  const accuracy = 1 - wordErrorRate(twister, transcript);
+
+  if (accuracy >= 0.95) rank = "🏆 Tongue Master";
+  else if (accuracy >= 0.85) rank = "🥈 Silver Tongue";
+  else if (accuracy >= 0.70) rank = "💪 Getting There";
+  else rank = "🙃 Tongue Tied";
+};
+
+recognition.start(); // now say it FAST
+${this.bestAccuracy !== null ? `\n// Your best so far: ${this.bestAccuracy}%` : ''}`;
+  }
+}


### PR DESCRIPTION
## Summary

Tranche 4: the two remaining flagship patterns from the brainstorm (intent routing, cascade moderation), two practical multimodal pipelines, and two games. Six new demos — 55 total on the index.

| Demo | Route | APIs |
|---|---|---|
| The Omnibox | `/demos/omnibox` | Semantic Embedder + Language Detector, dispatching to Translator / Summarizer / Proofreader / Rewriter / Prompt |
| Moderation Cascade | `/demos/moderation-cascade` | Semantic Embedder + Prompt API |
| Lecture Study Kit | `/demos/study-kit` | Prompt API (audio) + Summarizer + Semantic Embedder |
| Photo Semantic Search | `/demos/photo-search` | Prompt API (image) + Semantic Embedder |
| Tongue Twister Trial | `/demos/tongue-twister` | Web Speech |
| Mystery Language | `/demos/mystery-language` | Language Detector + Translator |

## Highlights

- **The Omnibox** makes routing explainable: three visible rules (foreign → translate, long → summarize, else nearest intent centroid) with per-route similarity bars, routing-vs-execution timings, and the output labeled with which API ran. "Instruction: content" inputs strip the instruction before running Proofreader/Rewriter.
- **Moderation Cascade** shows the production cost pattern live: a 13-comment queue where confident margins resolve in microseconds by embeddings and only borderline cases (sarcasm, self-promo) escalate to a structured-output LLM judge — with an adjustable escalation margin, per-comment margins, and resolved-by-embeddings percentage. Post your own comment to test the stages.
- **Lecture Study Kit** chains four stages with progress chips and degrades per API: no audio model → paste a transcript; no Summarizer → skip notes; flashcards flip on click; Q&A retrieves passages with `retrieval-query`/`retrieval-document` task types.
- **Photo Semantic Search** clones a shared caption session per photo to keep contexts independent, revokes object URLs on removal/destroy, and fades non-matching photos during a query so ranking is visible at a glance.
- **Tongue Twister Trial** extracts the word-diff/WER logic into a shared `core/utils/word-diff.util.ts` (the ASR Quality Tier Lab's private copy can migrate later).
- `app-api-status` gained `isDownloading`/`downloadProgress` inputs for the embedder-backed demos.

## Testing

- `ng build` passes; all 6 routes prerender through SSR (55 demo cards on the index).
- Mic, camera-roll uploads, and audio files only process locally; photo object URLs are revoked on cleanup.
- Model-dependent behaviors worth validating on a flagged build: Omnibox intent separation, cascade margin distribution (default 0.05), caption quality for photo search, and Mystery Language detector accuracy on short snippets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)