### PR TITLE
Show a visual preview of each demo on the demos listing

### DIFF
--- a/webapp/src/app/app-module.ts
+++ b/webapp/src/app/app-module.ts
@@ -98,6 +98,7 @@ import {CameraModalComponent} from './components/prompt-input/camera-modal/camer
 import {AudioRecordingModalComponent} from './components/prompt-input/audio-recording-modal/audio-recording-modal.component';
 import {DemosPage} from './pages/demos/demos.page';
 import {DemoLayoutComponent} from './pages/demos/components/demo-layout/demo-layout.component';
+import {DemoPreviewComponent} from './pages/demos/components/demo-preview/demo-preview.component';
 import { TranslationDemoComponent } from './pages/demos/features/translation-demo.component';
 import { SummarizationDemoComponent } from './pages/demos/features/summarization-demo.component';
 import { ProofreadingDemoComponent } from './pages/demos/features/proofreading-demo.component';
@@ -223,6 +224,7 @@ import { WebSpeechPlaygroundPage } from './pages/playgrounds/web-speech/web-spee
     SemanticEmbedderPlaygroundPage,
     WebSpeechPlaygroundPage,
     DemoLayoutComponent,
+    DemoPreviewComponent,
     SafeHtmlPipe,
     TranslationDemoComponent,
     SummarizationDemoComponent,

--- a/webapp/src/app/core/models/demo-preview.interface.ts
+++ b/webapp/src/app/core/models/demo-preview.interface.ts
@@ -1,0 +1,96 @@
+/**
+ * Hand-authored, illustrative previews shown on the demo cards.
+ *
+ * Nothing here runs a model: the content is fake sample data whose only job is to let
+ * someone scanning /demos see the *shape* of what a demo produces before opening it.
+ */
+
+export type DemoPreviewKind =
+  | 'io'        // input block -> output block
+  | 'diff'      // before / after, with the changed spans marked
+  | 'chat'      // alternating conversation bubbles
+  | 'captions'  // stacked transcript tracks
+  | 'list'      // ranked rows with a score bar
+  | 'chips'     // labelled tags, clusters or categories
+  | 'json'      // pretty-printed structured output
+  | 'code';     // generated code
+
+/** The small tile shown on the left of the preview when a demo consumes a media input. */
+export interface DemoPreviewSource {
+  icon: string;   // bi-* class, e.g. bi-mic, bi-camera, bi-image
+  label: string;  // e.g. "receipt.jpg", "standup.wav"
+}
+
+export interface DemoPreviewIoRow {
+  /** `in` renders muted (the user's input), `out` renders as the model's answer. */
+  role: 'in' | 'out';
+  text: string;
+}
+
+export interface DemoPreviewDiffRow {
+  text: string;
+  /** Marks the span as corrected / rewritten. */
+  changed?: boolean;
+}
+
+export interface DemoPreviewListRow {
+  text: string;
+  /** 0..1 — drawn as a bar plus a percentage. */
+  score: number;
+  /** Optional trailing label, e.g. a matched category. */
+  meta?: string;
+}
+
+export interface DemoPreviewChipRow {
+  label: string;
+  /** Optional grouping header rendered above the chip row. */
+  group?: string;
+}
+
+export type DemoPreviewRow =
+  | DemoPreviewIoRow
+  | DemoPreviewDiffRow
+  | DemoPreviewListRow
+  | DemoPreviewChipRow;
+
+interface DemoPreviewBase {
+  source?: DemoPreviewSource;
+}
+
+export interface DemoIoPreview extends DemoPreviewBase {
+  kind: 'io' | 'chat' | 'captions';
+  rows: DemoPreviewIoRow[];
+}
+
+export interface DemoDiffPreview extends DemoPreviewBase {
+  kind: 'diff';
+  before: DemoPreviewDiffRow[];
+  after: DemoPreviewDiffRow[];
+}
+
+export interface DemoListPreview extends DemoPreviewBase {
+  kind: 'list';
+  query?: string;
+  rows: DemoPreviewListRow[];
+}
+
+export interface DemoChipsPreview extends DemoPreviewBase {
+  kind: 'chips';
+  caption?: string;
+  rows: DemoPreviewChipRow[];
+}
+
+export interface DemoCodePreview extends DemoPreviewBase {
+  kind: 'json' | 'code';
+  /** Rendered verbatim in a monospace block; keep it to ~6 short lines. */
+  code: string;
+  /** Optional single-line prompt shown above the block. */
+  caption?: string;
+}
+
+export type DemoPreview =
+  | DemoIoPreview
+  | DemoDiffPreview
+  | DemoListPreview
+  | DemoChipsPreview
+  | DemoCodePreview;

--- a/webapp/src/app/core/models/demo.interface.ts
+++ b/webapp/src/app/core/models/demo.interface.ts
@@ -1,5 +1,6 @@
 import {PromptRunOptions} from './prompt-run.options';
 import {AttachmentTypeEnum} from '../enums/attachment-type.enum';
+import {DemoPreview} from './demo-preview.interface';
 
 export type DemoCategory = 'Text Input' | 'Image Input' | 'Audio Input' | 'Tools Calling' | 'Mix-and-Match' | 'Embeddings' | 'Speech';
 
@@ -23,6 +24,9 @@ export interface DemoExample {
   icon: string;
   onDeviceReason: string;
   codeSnippet: string;
+
+  /** Hand-authored sample of what the demo produces, shown on the listing card. */
+  preview?: DemoPreview;
   
   // To power the execution
   promptRunOptions: Partial<PromptRunOptions>;

--- a/webapp/src/app/core/services/demo-previews.data.ts
+++ b/webapp/src/app/core/services/demo-previews.data.ts
@@ -1,0 +1,528 @@
+import { DemoPreview } from '../models/demo-preview.interface';
+
+/**
+ * Illustrative card previews, keyed by demo id.
+ *
+ * Every value here is hand-authored sample data — it is never produced by a model. The
+ * goal is that someone scanning /demos can tell what a demo outputs before opening it,
+ * so keep each preview short (3-4 lines) and representative of the real demo.
+ */
+export const DEMO_PREVIEWS: Record<string, DemoPreview> = {
+  // ---------------------------------------------------------------- Speech
+  'live-translated-captions': {
+    kind: 'captions',
+    source: { icon: 'bi-mic-fill', label: 'live microphone' },
+    rows: [
+      { role: 'in', text: '"Let\'s meet at the café at seven."' },
+      { role: 'out', text: '« Retrouvons-nous au café à sept heures. »' },
+      { role: 'in', text: '"I\'ll bring the tickets."' },
+      { role: 'out', text: '« J\'apporterai les billets. »' },
+    ],
+  },
+
+  'speak-to-fill': {
+    kind: 'json',
+    source: { icon: 'bi-mic-fill', label: '"table for four next Friday at seven, outside"' },
+    code: `{
+  "partySize": 4,
+  "date": "2026-08-07",
+  "time": "19:00",
+  "seating": "outside"
+}`,
+  },
+
+  'asr-quality-tiers': {
+    kind: 'list',
+    source: { icon: 'bi-mic-fill', label: 'same passage, three models' },
+    rows: [
+      { text: 'command', score: 0.71, meta: '180 ms' },
+      { text: 'dictation', score: 0.94, meta: '420 ms' },
+      { text: 'conversation', score: 0.97, meta: '910 ms' },
+    ],
+  },
+
+  'contextual-biasing': {
+    kind: 'diff',
+    source: { icon: 'bi-mic-fill', label: 'without → with biasing' },
+    before: [
+      { text: 'add ' },
+      { text: 'tiny gemma', changed: true },
+      { text: ' and ' },
+      { text: 'web and then', changed: true },
+      { text: ' benchmarks to the ' },
+      { text: 'axon sweet', changed: true },
+    ],
+    after: [
+      { text: 'Add ' },
+      { text: 'TinyGemma', changed: true },
+      { text: ' and ' },
+      { text: 'WebNN', changed: true },
+      { text: ' benchmarks to the ' },
+      { text: 'Axon suite', changed: true },
+    ],
+  },
+
+  'dictate-and-polish': {
+    kind: 'diff',
+    source: { icon: 'bi-mic-fill', label: 'spoken draft' },
+    before: [
+      { text: 'so basically i think we ' },
+      { text: 'should of', changed: true },
+      { text: ' shipped it last week and ' },
+      { text: 'its', changed: true },
+      { text: ' fine' },
+    ],
+    after: [
+      { text: 'We ' },
+      { text: 'should have', changed: true },
+      { text: ' shipped it last week, and ' },
+      { text: 'it is', changed: true },
+      { text: ' fine.' },
+    ],
+  },
+
+  'story-time': {
+    kind: 'io',
+    source: { icon: 'bi-volume-up-fill', label: 'read aloud, word by word' },
+    rows: [
+      { role: 'in', text: 'a shy dragon · a lost umbrella · the moon' },
+      { role: 'out', text: 'Once upon a time, a very shy dragon found a red umbrella on the road to the moon…' },
+    ],
+  },
+
+  // --------------------------------------------------------- Text / writing
+  'polyglot-chat': {
+    kind: 'chat',
+    rows: [
+      { role: 'in', text: 'Peux-tu m\'envoyer le devis ?' },
+      { role: 'out', text: 'Can you send me the quote?' },
+      { role: 'in', text: 'Sure — sending it over now.' },
+      { role: 'out', text: 'Bien sûr — je l\'envoie tout de suite.' },
+    ],
+  },
+
+  'proofreader-inline': {
+    kind: 'diff',
+    before: [
+      { text: 'I ' },
+      { text: 'has went', changed: true },
+      { text: ' to the store yesterday, but they ' },
+      { text: 'was', changed: true },
+      { text: ' all out.' },
+    ],
+    after: [
+      { text: 'I ' },
+      { text: 'went', changed: true },
+      { text: ' to the store yesterday, but they ' },
+      { text: 'were', changed: true },
+      { text: ' all out.' },
+    ],
+  },
+
+  'tone-pad': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: '"Can you send the report?" · more-formal · longer' },
+      { role: 'out', text: 'Would you mind forwarding the report when you have a moment? I would be grateful.' },
+    ],
+  },
+
+  'summarizer-matrix': {
+    kind: 'chips',
+    caption: 'One 900-word article, every option combination:',
+    rows: [
+      { group: 'type', label: 'tldr' },
+      { label: 'key-points' },
+      { label: 'teaser' },
+      { label: 'headline' },
+      { group: 'length', label: 'short' },
+      { label: 'medium' },
+      { label: 'long' },
+    ],
+  },
+
+  'reply-composer': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Re: Contract renewal — can we meet Thursday? · intent: decline' },
+      { role: 'out', text: 'Thanks for reaching out. Thursday does not work on my end, but I am free Friday morning…' },
+    ],
+  },
+
+  'translation': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Hello world! How are you doing today?' },
+      { role: 'out', text: 'Bonjour le monde ! Comment allez-vous aujourd\'hui ?' },
+    ],
+  },
+
+  'summarization': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Artificial intelligence (AI) is intelligence demonstrated by machines, as opposed to…' },
+      { role: 'out', text: 'AI is machine-demonstrated intelligence; the field studies agents that act to maximise their goals.' },
+    ],
+  },
+
+  'proofreading': {
+    kind: 'diff',
+    before: [
+      { text: 'I ' },
+      { text: 'has went', changed: true },
+      { text: ' to the store yesterday to buy some apples, but they ' },
+      { text: 'was', changed: true },
+      { text: ' all out.' },
+    ],
+    after: [
+      { text: 'I ' },
+      { text: 'went', changed: true },
+      { text: ' to the store yesterday to buy some apples, but they ' },
+      { text: 'were', changed: true },
+      { text: ' all out.' },
+    ],
+  },
+
+  'tone-changer': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Hey boss, I can\'t come in today, I feel super sick. Talk tomorrow.' },
+      { role: 'out', text: 'Good morning — I am unwell today and will not be able to come in. I will follow up tomorrow.' },
+    ],
+  },
+
+  'brainstorming': {
+    kind: 'chips',
+    caption: 'A mobile app that helps people learn gardening',
+    rows: [
+      { label: 'Plant-a-day streaks' },
+      { label: 'Photo plant doctor' },
+      { label: 'Balcony sun mapper' },
+      { label: 'Seed swap map' },
+      { label: 'Watering reminders' },
+    ],
+  },
+
+  'eli5': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Quantum entanglement' },
+      { role: 'out', text: 'Imagine two magic coins. Flip one and it lands heads — the other instantly lands tails, however far away it is.' },
+    ],
+  },
+
+  'write-email': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Ask my client John if he is available next Tuesday at 2pm.' },
+      { role: 'out', text: 'Hi John, would Tuesday at 2:00 pm work for a quick call? Happy to shift if another time suits you.' },
+    ],
+  },
+
+  'write-javascript': {
+    kind: 'code',
+    caption: 'Write a debounce function, default delay 300ms.',
+    code: `function debounce(fn, delay = 300) {
+  let timer;
+  return (...args) => {
+    clearTimeout(timer);
+    timer = setTimeout(() => fn(...args), delay);
+  };
+}`,
+  },
+
+  'write-html-css': {
+    kind: 'code',
+    caption: 'A responsive pricing card',
+    code: `<div class="rounded-2xl border p-6 shadow-sm">
+  <h3 class="text-lg font-bold">Pro</h3>
+  <p class="text-4xl font-extrabold">$29<span>/mo</span></p>
+  <ul class="mt-4 space-y-1 text-sm">…</ul>
+  <button class="mt-6 w-full rounded-xl">Buy</button>
+</div>`,
+  },
+
+  'sql-generator': {
+    kind: 'code',
+    caption: 'Find the average age of users living in New York.',
+    code: `SELECT AVG(age) AS average_age
+FROM users
+WHERE city = 'New York';`,
+  },
+
+  'regex-lab': {
+    kind: 'code',
+    caption: 'Match a semver tag like v1.2.3',
+    code: `/^v(\\d+)\\.(\\d+)\\.(\\d+)$/
+✓ v1.2.3    ✓ v10.0.1
+✗ 1.2.3     ✗ v1.2`,
+  },
+
+  'session-branching': {
+    kind: 'io',
+    rows: [
+      { role: 'in', text: 'Plan a 3-day trip to Kyoto' },
+      { role: 'out', text: 'Branch A — temples & gardens: Fushimi Inari at dawn, then Arashiyama…' },
+      { role: 'out', text: 'Branch B — food & nightlife: Nishiki market, then Pontocho alley…' },
+    ],
+  },
+
+  // ------------------------------------------------------------ Mix & match
+  'localization-qa': {
+    kind: 'list',
+    source: { icon: 'bi-translate', label: 'fr.json · 3 stragglers' },
+    rows: [
+      { text: '"checkout.button": "Buy now"', score: 0.98, meta: 'en' },
+      { text: '"cart.empty": "Your cart is empty"', score: 0.96, meta: 'en' },
+      { text: '"nav.home": "Accueil"', score: 0.99, meta: 'fr ✓' },
+    ],
+  },
+
+  'universal-inbox': {
+    kind: 'chips',
+    caption: 'Fwd: Facture en retard — pouvez-vous vérifier ?',
+    rows: [
+      { group: 'detected', label: 'fr' },
+      { group: 'translated', label: 'en' },
+      { group: 'folder', label: 'Billing' },
+      { group: 'reply', label: 'drafted in fr' },
+    ],
+  },
+
+  'image-audio-query': {
+    kind: 'chat',
+    source: { icon: 'bi-image', label: 'chart.png + spoken question' },
+    rows: [
+      { role: 'in', text: '"Which bar is the tallest here?"' },
+      { role: 'out', text: 'March, at roughly 4.2k — about double February.' },
+    ],
+  },
+
+  'receipt-to-json': {
+    kind: 'json',
+    source: { icon: 'bi-receipt', label: 'receipt.jpg' },
+    code: `{
+  "merchant": "Blue Bottle Coffee",
+  "total": 18.72,
+  "items": [
+    { "name": "Latte", "price": 5.50 }
+  ]
+}`,
+  },
+
+  // ------------------------------------------------------------- Embeddings
+  'document-chat': {
+    kind: 'chat',
+    source: { icon: 'bi-file-earmark-text', label: 'employee-handbook.pdf' },
+    rows: [
+      { role: 'in', text: 'How many vacation days do I get?' },
+      { role: 'out', text: '20 days per year, accruing monthly. [p. 14]' },
+    ],
+  },
+
+  'semantic-search': {
+    kind: 'list',
+    query: 'my card was declined',
+    rows: [
+      { text: 'Why did my payment fail?', score: 0.91, meta: 'semantic' },
+      { text: 'Update your billing details', score: 0.78, meta: 'semantic' },
+      { text: 'Card security FAQ', score: 0.34, meta: 'keyword' },
+    ],
+  },
+
+  'smart-triage': {
+    kind: 'list',
+    query: 'The app crashes when I upload a PDF',
+    rows: [
+      { text: 'Bug report', score: 0.93 },
+      { text: 'Feature request', score: 0.21 },
+      { text: 'Billing question', score: 0.06 },
+    ],
+  },
+
+  'duplicate-detector': {
+    kind: 'list',
+    query: 'App freezes on file upload',
+    rows: [
+      { text: '#412 Crash when attaching PDFs', score: 0.88, meta: 'duplicate' },
+      { text: '#309 Upload spinner never ends', score: 0.74, meta: 'related' },
+      { text: '#118 Dark mode contrast', score: 0.11 },
+    ],
+  },
+
+  'cluster-and-label': {
+    kind: 'chips',
+    caption: '128 feedback notes → 4 named themes',
+    rows: [
+      { label: 'Onboarding friction' },
+      { label: 'Pricing confusion' },
+      { label: 'Mobile bugs' },
+      { label: 'Export requests' },
+    ],
+  },
+
+  'semantic-cache': {
+    kind: 'list',
+    query: 'how do I reset my password?',
+    rows: [
+      { text: 'cached: "steps to reset a password"', score: 0.94, meta: 'hit · 0 ms' },
+      { text: 'cached: "change my email address"', score: 0.41, meta: 'miss' },
+    ],
+  },
+
+  'command-palette': {
+    kind: 'list',
+    query: 'make the page easier on my eyes',
+    rows: [
+      { text: 'Toggle dark theme', score: 0.95 },
+      { text: 'Increase font size', score: 0.62 },
+      { text: 'Print this page', score: 0.12 },
+    ],
+  },
+
+  'semantic-word-game': {
+    kind: 'list',
+    query: 'secret word · guess #7',
+    rows: [
+      { text: 'stream', score: 0.86, meta: 'hot' },
+      { text: 'ocean', score: 0.72, meta: 'warm' },
+      { text: 'bicycle', score: 0.08, meta: 'cold' },
+    ],
+  },
+
+  // ------------------------------------------------------------ Image input
+  'camera-qa': {
+    kind: 'chat',
+    source: { icon: 'bi-camera-fill', label: 'frozen webcam frame' },
+    rows: [
+      { role: 'in', text: 'What model is this router?' },
+      { role: 'out', text: 'A TP-Link Archer — the label on the side reads AX55.' },
+    ],
+  },
+
+  'draw-and-guess': {
+    kind: 'io',
+    source: { icon: 'bi-pencil-fill', label: 'your sketch · 12 strokes' },
+    rows: [
+      { role: 'out', text: 'Looks like a fox — the pointed ears and bushy tail give it away.' },
+    ],
+  },
+
+  'ocr': {
+    kind: 'io',
+    source: { icon: 'bi-image', label: 'receipt.jpg' },
+    rows: [
+      { role: 'out', text: 'WHOLE FOODS MARKET · 4th St · Oat milk 5.49 · Bananas 2.10 · TOTAL 18.72' },
+    ],
+  },
+
+  'image-description': {
+    kind: 'io',
+    source: { icon: 'bi-image', label: 'beach-dog.jpg' },
+    rows: [
+      { role: 'out', text: 'A golden retriever mid-leap over wet sand at sunset, the spray backlit by low orange light.' },
+    ],
+  },
+
+  'explain-meme': {
+    kind: 'io',
+    source: { icon: 'bi-image', label: 'meme.png' },
+    rows: [
+      { role: 'out', text: 'It is the "distracted boyfriend" format — the joke is abandoning a stable stack for whatever is new.' },
+    ],
+  },
+
+  'fridge-recipe': {
+    kind: 'chips',
+    source: { icon: 'bi-camera-fill', label: 'fridge.jpg' },
+    caption: 'Spotted: eggs, spinach, feta, tortillas',
+    rows: [
+      { label: 'Spinach & feta frittata' },
+      { label: 'Breakfast quesadilla' },
+      { label: 'Greek scramble wrap' },
+    ],
+  },
+
+  'image-categorization': {
+    kind: 'list',
+    source: { icon: 'bi-image', label: 'IMG_2043.jpg' },
+    rows: [
+      { text: 'Travel', score: 0.92 },
+      { text: 'Landscape', score: 0.81 },
+      { text: 'Food', score: 0.04 },
+    ],
+  },
+
+  'screenshot-to-code': {
+    kind: 'code',
+    source: { icon: 'bi-image', label: 'dashboard.png' },
+    code: `<header class="flex items-center justify-between">
+  <h1 class="text-xl font-semibold">Dashboard</h1>
+  <button class="rounded-lg bg-indigo-600 px-3 py-1.5">New</button>
+</header>`,
+  },
+
+  // ------------------------------------------------------------ Audio input
+  'audio-transcription': {
+    kind: 'io',
+    source: { icon: 'bi-soundwave', label: 'voice-note.m4a · 0:38' },
+    rows: [
+      { role: 'out', text: '"Reminder: send the deck to Priya before Thursday and book the meeting room."' },
+    ],
+  },
+
+  'meeting-notes': {
+    kind: 'io',
+    source: { icon: 'bi-soundwave', label: 'standup.wav · 11:42' },
+    rows: [
+      { role: 'out', text: '☐ Priya — ship the migration script by Friday' },
+      { role: 'out', text: '☐ Sam — reply to the security questionnaire' },
+    ],
+  },
+
+  'audio-summarization': {
+    kind: 'io',
+    source: { icon: 'bi-soundwave', label: 'client-call.m4a · 4:12' },
+    rows: [
+      { role: 'out', text: 'Client wants launch pushed a week, budget is approved, and new mockups are due Monday.' },
+    ],
+  },
+
+  // ----------------------------------------------------------- Tool calling
+  'tool-calling': {
+    kind: 'code',
+    caption: 'Dim the living room to 40% and set an evening scene.',
+    code: `setBrightness({ room: "living", level: 40 })
+  → { ok: true, level: 40 }
+setScene({ room: "living", scene: "evening" })
+  → { ok: true }`,
+  },
+
+  'csv-qa': {
+    kind: 'chat',
+    source: { icon: 'bi-filetype-csv', label: 'sales-q2.csv · 1,204 rows' },
+    rows: [
+      { role: 'in', text: 'Which region grew the most last quarter?' },
+      { role: 'out', text: 'EMEA — up 34% ($412k → $552k).' },
+    ],
+  },
+
+  'structured-json': {
+    kind: 'json',
+    caption: 'My name is John Doe and I just turned 30 years old yesterday.',
+    code: `{
+  "name": "John Doe",
+  "age": 30
+}`,
+  },
+
+  'extract-entities': {
+    kind: 'json',
+    caption: 'Yesterday, Alice and Bob traveled from Seattle to Tokyo.',
+    code: `{
+  "people": ["Alice", "Bob"],
+  "locations": ["Seattle", "Tokyo"],
+  "organizations": []
+}`,
+  },
+};

--- a/webapp/src/app/core/services/demos.data.ts
+++ b/webapp/src/app/core/services/demos.data.ts
@@ -1,7 +1,8 @@
 import { DemoExample } from '../models/demo.interface';
 import { AttachmentTypeEnum } from '../enums/attachment-type.enum';
+import { DEMO_PREVIEWS } from './demo-previews.data';
 
-export const DEMOS_DATA: DemoExample[] = [
+const DEMOS: DemoExample[] = [
   // SPEECH
   {
     id: 'live-translated-captions',
@@ -1444,3 +1445,9 @@ const result = await session.prompt([
     requiredAttachmentTypes: [AttachmentTypeEnum.Image]
   }
 ];
+
+// Card previews live in their own file to keep this one readable; they are attached by id.
+export const DEMOS_DATA: DemoExample[] = DEMOS.map(demo => ({
+  ...demo,
+  preview: DEMO_PREVIEWS[demo.id],
+}));

--- a/webapp/src/app/pages/demos/components/demo-preview/demo-preview.component.html
+++ b/webapp/src/app/pages/demos/components/demo-preview/demo-preview.component.html
@@ -1,0 +1,142 @@
+<!--
+  Illustrative only — the card's title and description carry the accessible name,
+  so the whole block is hidden from assistive tech.
+-->
+<div aria-hidden="true"
+     class="relative max-h-32 rounded-xl border border-slate-200/80 dark:border-zinc-700/60 bg-slate-50 dark:bg-zinc-900/60 px-3 py-2.5 overflow-hidden select-none">
+
+  @if (preview.source; as source) {
+    <div class="flex items-center gap-1.5 mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-400 dark:text-zinc-500">
+      <i class="bi {{ source.icon }} {{ accent }} text-xs"></i>
+      <span class="truncate">{{ source.label }}</span>
+    </div>
+  }
+
+  @switch (preview.kind) {
+
+    <!-- Input -> output, as two stacked blocks -->
+    @case ('io') {
+      <div class="flex flex-col gap-1.5">
+        @for (row of io.rows; track $index) {
+          @if (row.role === 'in') {
+            <div class="text-[11px] leading-snug text-slate-400 dark:text-zinc-500 line-clamp-2">{{ row.text }}</div>
+          } @else {
+            <div class="flex gap-1.5">
+              <i class="bi bi-arrow-return-right {{ accent }} text-[11px] shrink-0 mt-px"></i>
+              <div class="text-[11px] leading-snug font-medium text-slate-700 dark:text-slate-300 line-clamp-3">{{ row.text }}</div>
+            </div>
+          }
+        }
+      </div>
+    }
+
+    <!-- Conversation bubbles -->
+    @case ('chat') {
+      <div class="flex flex-col gap-1.5">
+        @for (row of io.rows; track $index) {
+          <div class="flex" [class.justify-end]="row.role === 'in'">
+            <div class="max-w-[85%] rounded-lg px-2 py-1 text-[11px] leading-snug line-clamp-2"
+                 [ngClass]="row.role === 'in'
+                   ? 'bg-slate-200/70 dark:bg-zinc-700/70 text-slate-600 dark:text-slate-300'
+                   : 'bg-[#ffffff] dark:bg-zinc-800 border border-slate-200 dark:border-zinc-700 text-slate-700 dark:text-slate-200 font-medium'">
+              {{ row.text }}
+            </div>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Stacked transcript tracks -->
+    @case ('captions') {
+      <div class="flex flex-col gap-1.5">
+        @for (row of io.rows; track $index) {
+          <div class="flex items-start gap-1.5">
+            <span class="w-1 self-stretch rounded-full shrink-0"
+                  [ngClass]="row.role === 'in' ? 'bg-slate-300 dark:bg-zinc-600' : 'bg-current ' + accent"></span>
+            <span class="text-[11px] leading-snug line-clamp-2"
+                  [ngClass]="row.role === 'in'
+                    ? 'text-slate-400 dark:text-zinc-500'
+                    : 'text-slate-700 dark:text-slate-300 font-medium'">{{ row.text }}</span>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Before / after with the changed spans marked -->
+    @case ('diff') {
+      <div class="flex flex-col gap-2">
+        <p class="m-0 text-[11px] leading-snug text-slate-400 dark:text-zinc-500 line-clamp-2">
+          @for (span of diff.before; track $index) {
+            <span [class]="span.changed ? 'line-through decoration-rose-400/70 text-rose-500/80 dark:text-rose-400/80' : ''">{{ span.text }}</span>
+          }
+        </p>
+        <p class="m-0 text-[11px] leading-snug font-medium text-slate-700 dark:text-slate-300 line-clamp-3">
+          @for (span of diff.after; track $index) {
+            <span [class]="span.changed ? 'rounded bg-emerald-100 dark:bg-emerald-500/15 text-emerald-700 dark:text-emerald-400 px-0.5' : ''">{{ span.text }}</span>
+          }
+        </p>
+      </div>
+    }
+
+    <!-- Ranked rows with score bars -->
+    @case ('list') {
+      <div class="flex flex-col gap-1.5">
+        @if (list.query) {
+          <div class="flex items-center gap-1.5 text-[11px] text-slate-400 dark:text-zinc-500">
+            <i class="bi bi-search text-[10px]"></i>
+            <span class="truncate italic">{{ list.query }}</span>
+          </div>
+        }
+        @for (row of list.rows; track $index) {
+          <div class="flex items-center gap-2">
+            <span class="flex-1 min-w-0 truncate text-[11px] leading-snug text-slate-700 dark:text-slate-300">
+              {{ row.text }}
+              @if (row.meta) {
+                <span class="text-slate-400 dark:text-zinc-500">· {{ row.meta }}</span>
+              }
+            </span>
+            <span class="h-1 w-10 shrink-0 rounded-full bg-slate-200 dark:bg-zinc-700 overflow-hidden">
+              <span class="block h-full rounded-full bg-current {{ accent }}" [style.width.%]="row.score * 100"></span>
+            </span>
+            <span class="w-7 shrink-0 text-right text-[10px] font-semibold tabular-nums text-slate-400 dark:text-zinc-500">{{ row.score * 100 | number: '1.0-0' }}%</span>
+          </div>
+        }
+      </div>
+    }
+
+    <!-- Labels, clusters, categories -->
+    @case ('chips') {
+      <div class="flex flex-col gap-2">
+        @if (chips.caption) {
+          <div class="text-[11px] leading-snug text-slate-400 dark:text-zinc-500 line-clamp-2">{{ chips.caption }}</div>
+        }
+        <div class="flex flex-wrap gap-1">
+          @for (row of chips.rows; track $index) {
+            <span class="inline-flex items-center gap-1 rounded-md border border-slate-200 dark:border-zinc-700 bg-[#ffffff] dark:bg-zinc-800 px-1.5 py-0.5 text-[10px] font-semibold text-slate-600 dark:text-slate-300">
+              @if (row.group) {
+                <span class="{{ accent }} font-bold uppercase tracking-wider text-[9px]">{{ row.group }}</span>
+              }
+              {{ row.label }}
+            </span>
+          }
+        </div>
+      </div>
+    }
+
+    <!-- Structured output / generated code -->
+    @case ('json') { <ng-container *ngTemplateOutlet="codeTemplate"></ng-container> }
+    @case ('code') { <ng-container *ngTemplateOutlet="codeTemplate"></ng-container> }
+  }
+
+  <!-- Fade the overflow out instead of clipping mid-line -->
+  <div class="pointer-events-none absolute inset-x-0 bottom-0 h-6 bg-gradient-to-t from-slate-50 dark:from-[#18181b] to-transparent"></div>
+</div>
+
+<ng-template #codeTemplate>
+  <div class="flex flex-col gap-1.5">
+    @if (codeBlock.caption) {
+      <div class="text-[11px] leading-snug text-slate-400 dark:text-zinc-500 line-clamp-1">{{ codeBlock.caption }}</div>
+    }
+    <pre class="m-0 overflow-hidden font-mono text-[10px] leading-[1.45] text-slate-600 dark:text-slate-300"><code>@for (line of codeLines; track $index) {<span class="block overflow-hidden text-ellipsis whitespace-pre">{{ line }}</span>}</code></pre>
+  </div>
+</ng-template>

--- a/webapp/src/app/pages/demos/components/demo-preview/demo-preview.component.ts
+++ b/webapp/src/app/pages/demos/components/demo-preview/demo-preview.component.ts
@@ -1,0 +1,52 @@
+import { Component, Input } from '@angular/core';
+import {
+  DemoChipsPreview,
+  DemoCodePreview,
+  DemoDiffPreview,
+  DemoIoPreview,
+  DemoListPreview,
+  DemoPreview,
+} from '../../../../core/models/demo-preview.interface';
+
+/**
+ * Renders the illustrative preview of a demo on its card.
+ *
+ * Purely presentational: no lifecycle, no API calls, no browser-only code, so it
+ * prerenders with the rest of the /demos page.
+ */
+@Component({
+  selector: 'app-demo-preview',
+  templateUrl: './demo-preview.component.html',
+  standalone: false,
+})
+export class DemoPreviewComponent {
+  @Input({ required: true }) preview!: DemoPreview;
+
+  /** Category accent, e.g. "text-cyan-600 dark:text-cyan-400". */
+  @Input() accent = 'text-slate-600 dark:text-slate-400';
+
+  // Narrowing helpers: @switch on `kind` does not narrow the union inside the template.
+  get io(): DemoIoPreview {
+    return this.preview as DemoIoPreview;
+  }
+
+  get diff(): DemoDiffPreview {
+    return this.preview as DemoDiffPreview;
+  }
+
+  get list(): DemoListPreview {
+    return this.preview as DemoListPreview;
+  }
+
+  get chips(): DemoChipsPreview {
+    return this.preview as DemoChipsPreview;
+  }
+
+  get codeBlock(): DemoCodePreview {
+    return this.preview as DemoCodePreview;
+  }
+
+  get codeLines(): string[] {
+    return this.codeBlock.code.split('\n');
+  }
+}

--- a/webapp/src/app/pages/demos/demos.page.html
+++ b/webapp/src/app/pages/demos/demos.page.html
@@ -146,7 +146,14 @@
 
                   <h3 class="text-xl font-bold text-slate-900 dark:text-white mb-3 tracking-tight group-hover/card:text-slate-700 dark:group-hover/card:text-slate-300 transition-colors break-words">{{ demo.title }}</h3>
 
-                  <p class="text-sm text-slate-500 dark:text-slate-400 line-clamp-3 leading-relaxed mb-6 flex-grow font-medium">{{ demo.description }}</p>
+                  <!-- No flex-grow here: stretching the box lets a clipped extra line show past the clamp. -->
+                  <p class="text-sm text-slate-500 dark:text-slate-400 leading-relaxed mb-6 font-medium"
+                     [ngClass]="demo.preview ? 'line-clamp-2' : 'line-clamp-3'">{{ demo.description }}</p>
+
+                  <!-- Illustrative preview of the demo's output -->
+                  @if (demo.preview; as preview) {
+                    <app-demo-preview class="block mb-6" [preview]="preview" [accent]="style.icon"></app-demo-preview>
+                  }
 
                   <!-- API chips -->
                   <div class="flex flex-wrap gap-1.5 mb-6">


### PR DESCRIPTION
## Why

Every card on `/demos` was text only — icon, title, description, API chips. You could not tell what a demo actually *produces* without opening it, and most demos need input (a mic, a file, a photo) before they show anything at all.

## What

All 50 demos now carry a hand-authored preview, rendered inline on the card between the description and the API chips.

The content is **fake sample data** chosen to match what the demo really outputs — never model output. So the previews cost nothing at runtime, need no image assets, work with no model downloaded, and prerender into the static `/demos` HTML.

- **`core/models/demo-preview.interface.ts`** — a `DemoPreview` union over eight shapes (`io`, `diff`, `chat`, `captions`, `list`, `chips`, `json`, `code`) plus an optional media source tile (mic, camera, image, audio, CSV). Most demos reuse a handful of renderers.
- **`core/services/demo-previews.data.ts`** — the 50 payloads, keyed by demo id and kept out of the already-1400-line `demos.data.ts`, which now attaches them when building `DEMOS_DATA`. The field is optional, so a demo without a preview renders exactly as before.
- **`pages/demos/components/demo-preview/`** — one presentational component switching on `kind`. No lifecycle, no API calls, no browser-only code, so it is SSR-safe. The block is `aria-hidden`: it is illustrative, and the card's title and description already carry the accessible name.

The description drops to `line-clamp-2` when a preview is present, and loses `flex-grow` — stretching a clamped box let a clipped extra line show below the ellipsis (a pre-existing glitch, just more visible next to a preview).

## Verification

- `ng build` clean, verified in an isolated worktree at this commit (only the pre-existing `ace-builds` CommonJS warnings).
- All 50 demo ids have a preview; no orphaned preview keys.
- Confirmed the previews land in the prerendered `dist/.../demos/index.html`, then reviewed the rendered page in headless Chrome in **both light and dark mode**. Three issues found and fixed that way: `truncate` collapsed code indentation via `white-space: nowrap`; a fixed preview height left dead space on short previews; and the description clamp leak above.

## Scope note

The working tree also had unrelated in-progress work (demo-of-the-day, `demo-discovery.service.ts`, demo-layout changes). This branch deliberately excludes it — only my single hunk in `demos.page.html` is included, so the diff there is +9/-2.