### PR TITLE
Surface new and unexplored demos from every demos page

### DIFF
--- a/webapp/src/app/core/services/demo-discovery.service.ts
+++ b/webapp/src/app/core/services/demo-discovery.service.ts
@@ -1,0 +1,257 @@
+import { Inject, Injectable, PLATFORM_ID } from '@angular/core';
+import { isPlatformBrowser } from '@angular/common';
+import { BehaviorSubject } from 'rxjs';
+import { DEMOS_DATA } from './demos.data';
+import { DemoExample } from '../models/demo.interface';
+
+interface DemoDiscoveryState {
+  version: number;
+  /** Every demo id this browser has already been shown at least once. */
+  knownIds: string[];
+  /** Demo detail pages this browser has actually opened. */
+  visitedIds: string[];
+  /** Ids that appeared since the previous visit and have not been opened yet. */
+  newIds: string[];
+}
+
+const STORAGE_KEY = 'web-ai-studio.demo-discovery';
+const STATE_VERSION = 1;
+
+/**
+ * Tracks what the visitor has already seen so the demos surfaces can highlight what they
+ * have not. All state is per-browser (localStorage) and browser-only: on the server every
+ * getter resolves to the "nothing seen yet, nothing new" baseline so SSR output stays stable.
+ */
+@Injectable({
+  providedIn: 'root'
+})
+export class DemoDiscoveryService {
+  private readonly isBrowser: boolean;
+
+  private state: DemoDiscoveryState = {
+    version: STATE_VERSION,
+    knownIds: [],
+    visitedIds: [],
+    newIds: [],
+  };
+
+  private readonly stateSubject = new BehaviorSubject<DemoDiscoveryState>(this.state);
+  public readonly state$ = this.stateSubject.asObservable();
+
+  constructor(@Inject(PLATFORM_ID) platformId: Object) {
+    this.isBrowser = isPlatformBrowser(platformId);
+
+    if (this.isBrowser) {
+      this.reconcile();
+    }
+  }
+
+  /**
+   * Loads the stored state and diffs it against the demos currently shipped.
+   *
+   * On a first-ever visit every demo is marked known but none are marked new — a wall of 50
+   * "New" badges tells the visitor nothing. From the second visit on, anything added since
+   * counts as new until they open it.
+   */
+  private reconcile(): void {
+    const stored = this.read();
+    const currentIds = DEMOS_DATA.map(demo => demo.id);
+
+    if (stored === null) {
+      this.commit({
+        version: STATE_VERSION,
+        knownIds: currentIds,
+        visitedIds: [],
+        newIds: [],
+      });
+      return;
+    }
+
+    const known = new Set(stored.knownIds);
+    const visited = new Set(stored.visitedIds.filter(id => currentIds.includes(id)));
+    const addedSinceLastVisit = currentIds.filter(id => !known.has(id));
+
+    // New stays new until it is opened, so a same-day second visit does not lose the badge.
+    const newIds = [...new Set([...stored.newIds, ...addedSinceLastVisit])]
+      .filter(id => currentIds.includes(id) && !visited.has(id));
+
+    this.commit({
+      version: STATE_VERSION,
+      knownIds: currentIds,
+      visitedIds: [...visited],
+      newIds,
+    });
+  }
+
+  private read(): DemoDiscoveryState | null {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) {
+        return null;
+      }
+
+      const parsed = JSON.parse(raw) as Partial<DemoDiscoveryState>;
+      if (parsed?.version !== STATE_VERSION || !Array.isArray(parsed.knownIds)) {
+        return null;
+      }
+
+      return {
+        version: STATE_VERSION,
+        knownIds: parsed.knownIds ?? [],
+        visitedIds: parsed.visitedIds ?? [],
+        newIds: parsed.newIds ?? [],
+      };
+    } catch {
+      // Private mode, quota errors, hand-edited storage — degrade to "first visit".
+      return null;
+    }
+  }
+
+  private commit(state: DemoDiscoveryState): void {
+    this.state = state;
+    this.stateSubject.next(state);
+
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // Storage unavailable: keep the in-memory state so the session still behaves.
+    }
+  }
+
+  /** Records that the visitor opened a demo, which also clears its "new" flag. */
+  markVisited(demoId: string): void {
+    if (!this.isBrowser || this.state.visitedIds.includes(demoId)) {
+      // Still clear the new flag if the id somehow lingers there.
+      if (this.isBrowser && this.state.newIds.includes(demoId)) {
+        this.commit({ ...this.state, newIds: this.state.newIds.filter(id => id !== demoId) });
+      }
+      return;
+    }
+
+    this.commit({
+      ...this.state,
+      visitedIds: [...this.state.visitedIds, demoId],
+      newIds: this.state.newIds.filter(id => id !== demoId),
+    });
+  }
+
+  isVisited(demoId: string): boolean {
+    return this.state.visitedIds.includes(demoId);
+  }
+
+  isNew(demoId: string): boolean {
+    return this.state.newIds.includes(demoId);
+  }
+
+  get visitedCount(): number {
+    return this.state.visitedIds.length;
+  }
+
+  get totalCount(): number {
+    return DEMOS_DATA.length;
+  }
+
+  get newDemos(): DemoExample[] {
+    return DEMOS_DATA.filter(demo => this.state.newIds.includes(demo.id));
+  }
+
+  get unvisitedDemos(): DemoExample[] {
+    return DEMOS_DATA.filter(demo => !this.state.visitedIds.includes(demo.id));
+  }
+
+  resetProgress(): void {
+    if (!this.isBrowser) {
+      return;
+    }
+
+    this.commit({
+      version: STATE_VERSION,
+      knownIds: DEMOS_DATA.map(demo => demo.id),
+      visitedIds: [],
+      newIds: [],
+    });
+  }
+
+  /**
+   * Ranks the other demos by how much they share with the given one: overlapping APIs first,
+   * same category as a tie-break, then a nudge toward demos the visitor has not opened yet.
+   *
+   * Pass `personalized: false` for the render that has to match the server output — the
+   * visited/new nudges are browser-only state and would otherwise break hydration.
+   */
+  getRelatedDemos(demo: DemoExample, limit = 3, personalized = true, excludeIds: string[] = []): DemoExample[] {
+    return DEMOS_DATA
+      .filter(candidate => candidate.id !== demo.id && !excludeIds.includes(candidate.id))
+      .map(candidate => ({ candidate, score: this.relatednessScore(demo, candidate, personalized) }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit)
+      .map(entry => entry.candidate);
+  }
+
+  private relatednessScore(demo: DemoExample, candidate: DemoExample, personalized: boolean): number {
+    const sharedApis = candidate.apis.filter(api => demo.apis.includes(api)).length;
+
+    let score = sharedApis * 10;
+
+    if (candidate.category === demo.category) {
+      score += 4;
+    }
+
+    // Uses every API the source demo uses: a natural "next step up" from this one.
+    if (sharedApis > 0 && sharedApis === demo.apis.length) {
+      score += 2;
+    }
+
+    if (personalized && !this.isVisited(candidate.id)) {
+      score += 3;
+    }
+
+    if (personalized && this.isNew(candidate.id)) {
+      score += 2;
+    }
+
+    return score;
+  }
+
+  /** The demos before and after this one within its own category, for linear browsing. */
+  getCategoryNeighbours(demo: DemoExample): { previous: DemoExample | null; next: DemoExample | null } {
+    const siblings = DEMOS_DATA.filter(candidate => candidate.category === demo.category);
+    const index = siblings.findIndex(candidate => candidate.id === demo.id);
+
+    if (index === -1) {
+      return { previous: null, next: null };
+    }
+
+    return {
+      previous: siblings[index - 1] ?? null,
+      next: siblings[index + 1] ?? null,
+    };
+  }
+
+  /** A random demo, preferring ones the visitor has not opened yet. */
+  getSurpriseDemo(excludeId?: string): DemoExample | null {
+    const unvisited = this.unvisitedDemos.filter(demo => demo.id !== excludeId);
+    const pool = unvisited.length > 0
+      ? unvisited
+      : DEMOS_DATA.filter(demo => demo.id !== excludeId);
+
+    if (pool.length === 0) {
+      return null;
+    }
+
+    return pool[Math.floor(Math.random() * pool.length)];
+  }
+
+  /**
+   * The same demo for everybody on a given day, so it is worth coming back for and worth
+   * sharing. Derived from the day number rather than randomness.
+   */
+  getDemoOfTheDay(now: Date = new Date()): DemoExample {
+    const dayNumber = Math.floor(
+      Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()) / 86_400_000
+    );
+
+    // A stride coprime with most list lengths keeps consecutive days far apart in the list.
+    return DEMOS_DATA[(dayNumber * 7) % DEMOS_DATA.length];
+  }
+}

--- a/webapp/src/app/pages/demos/components/demo-layout/demo-layout.component.html
+++ b/webapp/src/app/pages/demos/components/demo-layout/demo-layout.component.html
@@ -81,5 +81,91 @@
 
     </div>
 
+    <!-- Keep Exploring -->
+    @if (demo) {
+      <div class="mt-16 pt-10 border-t border-slate-200 dark:border-zinc-800">
+        <div class="flex flex-wrap items-end justify-between gap-4 mb-8">
+          <div>
+            <h3 class="text-xl font-bold text-slate-800 dark:text-slate-200 m-0">Keep exploring</h3>
+            <p class="text-sm text-slate-500 dark:text-slate-400 mt-1 m-0">
+              @if (personalized && exploredCount > 0) {
+                You've explored {{ exploredCount }} of {{ totalCount }} demos.
+              } @else {
+                {{ totalCount }} demos, all running on-device.
+              }
+            </p>
+          </div>
+
+          <button
+            type="button"
+            (click)="surpriseMe()"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#ffffff] hover:bg-slate-100 dark:bg-zinc-800/80 dark:hover:bg-zinc-700 text-sm font-semibold text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white transition-all border border-slate-200 dark:border-zinc-700 shadow-sm group">
+            <i class="bi bi-shuffle transition-transform group-hover:rotate-12"></i>
+            <span>Surprise me</span>
+          </button>
+        </div>
+
+        <div class="grid grid-cols-1 md:grid-cols-3 gap-5">
+          @for (related of relatedDemos; track related.id) {
+            <a [routerLink]="['/demos', related.id]" class="!no-underline group/related block h-full focus:outline-none focus-visible:ring-4 focus-visible:ring-slate-500/50 rounded-2xl">
+              <div class="relative h-full bg-[#ffffff] dark:bg-[#18181b] rounded-2xl p-5 border border-slate-200 dark:border-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 flex flex-col">
+                <div class="flex items-start justify-between gap-3 mb-3">
+                  <div class="w-10 h-10 rounded-xl bg-slate-100 dark:bg-zinc-800 text-slate-600 dark:text-slate-300 flex items-center justify-center text-lg shrink-0 group-hover/related:scale-110 transition-transform duration-300">
+                    <i class="bi {{ related.icon }}"></i>
+                  </div>
+
+                  @if (isNew(related)) {
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-50 dark:bg-indigo-500/10 text-indigo-700 dark:text-indigo-400 text-[10px] font-bold uppercase tracking-wider">
+                      <span class="w-1.5 h-1.5 rounded-full bg-indigo-500"></span> New
+                    </span>
+                  } @else if (isUnvisited(related)) {
+                    <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-zinc-400 text-[10px] font-bold uppercase tracking-wider">
+                      <span class="w-1.5 h-1.5 rounded-full bg-slate-400"></span> Not explored
+                    </span>
+                  }
+                </div>
+
+                <h4 class="text-base font-bold text-slate-900 dark:text-white mb-2 tracking-tight break-words">{{ related.title }}</h4>
+                <p class="text-sm text-slate-500 dark:text-slate-400 line-clamp-2 leading-relaxed m-0 flex-grow">{{ related.description }}</p>
+
+                <div class="flex flex-wrap gap-1.5 mt-4">
+                  @for (api of related.apis; track api) {
+                    <span class="px-2 py-0.5 rounded-md text-[10px] font-semibold bg-slate-100 dark:bg-zinc-800 text-slate-500 dark:text-zinc-400 border border-slate-200/60 dark:border-zinc-700/60">
+                      {{ api }}
+                    </span>
+                  }
+                </div>
+              </div>
+            </a>
+          }
+        </div>
+
+        <!-- Linear browsing within the category -->
+        @if (previousDemo || nextDemo) {
+          <div class="flex flex-col sm:flex-row items-stretch gap-4 mt-8">
+            @if (previousDemo) {
+              <a [routerLink]="['/demos', previousDemo.id]" class="!no-underline flex-1 group/nav flex items-center gap-3 px-5 py-4 rounded-2xl bg-[#ffffff] dark:bg-[#18181b] border border-slate-200 dark:border-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 shadow-sm hover:shadow-md transition-all">
+                <i class="bi bi-arrow-left text-slate-400 dark:text-zinc-500 transition-transform group-hover/nav:-translate-x-1"></i>
+                <div class="min-w-0">
+                  <div class="text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500">Previous in {{ category }}</div>
+                  <div class="text-sm font-semibold text-slate-800 dark:text-slate-200 truncate">{{ previousDemo.title }}</div>
+                </div>
+              </a>
+            }
+
+            @if (nextDemo) {
+              <a [routerLink]="['/demos', nextDemo.id]" class="!no-underline flex-1 group/nav flex items-center justify-end gap-3 px-5 py-4 rounded-2xl bg-[#ffffff] dark:bg-[#18181b] border border-slate-200 dark:border-zinc-800 hover:border-slate-300 dark:hover:border-zinc-700 shadow-sm hover:shadow-md transition-all text-right">
+                <div class="min-w-0">
+                  <div class="text-[10px] font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500">Next in {{ category }}</div>
+                  <div class="text-sm font-semibold text-slate-800 dark:text-slate-200 truncate">{{ nextDemo.title }}</div>
+                </div>
+                <i class="bi bi-arrow-right text-slate-400 dark:text-zinc-500 transition-transform group-hover/nav:translate-x-1"></i>
+              </a>
+            }
+          </div>
+        }
+      </div>
+    }
+
   </div>
 </div>

--- a/webapp/src/app/pages/demos/components/demo-layout/demo-layout.component.ts
+++ b/webapp/src/app/pages/demos/components/demo-layout/demo-layout.component.ts
@@ -1,4 +1,10 @@
-import { Component, Input } from '@angular/core';
+import { afterNextRender, Component, Input, OnDestroy, OnInit } from '@angular/core';
+import { NavigationEnd, Router } from '@angular/router';
+import { Subscription } from 'rxjs';
+import { filter, startWith } from 'rxjs/operators';
+import { DEMOS_DATA } from '../../../../core/services/demos.data';
+import { DemoExample } from '../../../../core/models/demo.interface';
+import { DemoDiscoveryService } from '../../../../core/services/demo-discovery.service';
 
 @Component({
   selector: 'app-demo-layout',
@@ -6,7 +12,7 @@ import { Component, Input } from '@angular/core';
   styleUrls: ['./demo-layout.component.scss'],
   standalone: false
 })
-export class DemoLayoutComponent {
+export class DemoLayoutComponent implements OnInit, OnDestroy {
   @Input() title: string = '';
   @Input() description: string = '';
   @Input() icon: string = '';
@@ -15,6 +21,104 @@ export class DemoLayoutComponent {
   @Input() codeSnippet: string = '';
   @Input() ttft: number | null = null;
   @Input() totalTime: number | null = null;
-  
 
+  /**
+   * The demo being shown. Resolved from the URL rather than taken as an input so that the
+   * "keep exploring" footer works on every demo page without touching all 50 components —
+   * each demo id is also its route segment.
+   */
+  demo: DemoExample | null = null;
+
+  relatedDemos: DemoExample[] = [];
+  previousDemo: DemoExample | null = null;
+  nextDemo: DemoExample | null = null;
+
+  /** Flipped after hydration, so localStorage-derived state never renders on the server. */
+  personalized = false;
+
+  private readonly subscriptions: Subscription[] = [];
+
+  constructor(
+    private readonly router: Router,
+    private readonly discoveryService: DemoDiscoveryService,
+  ) {
+    // Deferred one macrotask so zone.js schedules a change detection pass for the
+    // personalized state — afterNextRender itself runs after CD has already finished.
+    afterNextRender(() => setTimeout(() => {
+      this.personalized = true;
+
+      if (this.demo) {
+        this.discoveryService.markVisited(this.demo.id);
+        this.refreshRecommendations();
+      }
+    }));
+  }
+
+  ngOnInit(): void {
+    this.subscriptions.push(
+      this.router.events
+        .pipe(filter(event => event instanceof NavigationEnd), startWith(null))
+        .subscribe(() => this.resolveDemo())
+    );
+  }
+
+  ngOnDestroy(): void {
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+
+  private resolveDemo(): void {
+    const id = this.router.url.split('?')[0].split('#')[0].split('/').filter(Boolean).pop();
+    this.demo = DEMOS_DATA.find(demo => demo.id === id) ?? null;
+
+    if (!this.demo) {
+      this.relatedDemos = [];
+      this.previousDemo = null;
+      this.nextDemo = null;
+      return;
+    }
+
+    if (this.personalized) {
+      this.discoveryService.markVisited(this.demo.id);
+    }
+
+    this.refreshRecommendations();
+  }
+
+  private refreshRecommendations(): void {
+    if (!this.demo) {
+      return;
+    }
+
+    const neighbours = this.discoveryService.getCategoryNeighbours(this.demo);
+    this.previousDemo = neighbours.previous;
+    this.nextDemo = neighbours.next;
+
+    // The prev/next links already surface the neighbours — don't spend a card on them too.
+    const neighbourIds = [neighbours.previous?.id, neighbours.next?.id].filter((id): id is string => !!id);
+    this.relatedDemos = this.discoveryService.getRelatedDemos(this.demo, 3, this.personalized, neighbourIds);
+  }
+
+  isNew(demo: DemoExample): boolean {
+    return this.personalized && this.discoveryService.isNew(demo.id);
+  }
+
+  isUnvisited(demo: DemoExample): boolean {
+    return this.personalized && !this.discoveryService.isVisited(demo.id);
+  }
+
+  get exploredCount(): number {
+    return this.personalized ? this.discoveryService.visitedCount : 0;
+  }
+
+  get totalCount(): number {
+    return this.discoveryService.totalCount;
+  }
+
+  surpriseMe(): void {
+    const demo = this.discoveryService.getSurpriseDemo(this.demo?.id);
+
+    if (demo) {
+      this.router.navigate(['/demos', demo.id]);
+    }
+  }
 }

--- a/webapp/src/app/pages/demos/demos.page.html
+++ b/webapp/src/app/pages/demos/demos.page.html
@@ -14,8 +14,66 @@
         Explore what's possible with On-Device AI directly in the browser.
         No API keys, no server costs, full privacy.
       </p>
+
+      <!-- Demo of the day: same pick for everybody, rotates daily -->
+      @if (demoOfTheDay) {
+        <div class="mt-10 flex flex-col sm:flex-row items-center justify-center gap-3">
+          <a [routerLink]="['/demos', demoOfTheDay.id]"
+             class="!no-underline group/dotd inline-flex items-center gap-4 pl-5 pr-6 py-4 rounded-2xl bg-[#ffffff] dark:bg-[#18181b] border border-slate-200 dark:border-zinc-800 hover:border-amber-300 dark:hover:border-amber-500/40 shadow-sm hover:shadow-xl transition-all duration-300 hover:-translate-y-0.5 text-left max-w-xl">
+            <div class="w-12 h-12 rounded-xl bg-amber-50 dark:bg-amber-500/10 text-amber-600 dark:text-amber-400 flex items-center justify-center text-xl shrink-0 group-hover/dotd:scale-110 transition-transform duration-300">
+              <i class="bi {{ demoOfTheDay.icon }}"></i>
+            </div>
+            <div class="min-w-0">
+              <div class="text-[10px] font-bold uppercase tracking-wider text-amber-600 dark:text-amber-400 flex items-center gap-1.5">
+                <i class="bi bi-stars"></i> Demo of the day
+              </div>
+              <div class="text-base font-bold text-slate-900 dark:text-white truncate">{{ demoOfTheDay.title }}</div>
+              <div class="text-xs text-slate-500 dark:text-slate-400 line-clamp-1">{{ demoOfTheDay.description }}</div>
+            </div>
+            <i class="bi bi-arrow-right text-slate-400 dark:text-zinc-500 shrink-0 transition-transform group-hover/dotd:translate-x-1"></i>
+          </a>
+
+          <button
+            type="button"
+            (click)="surpriseMe()"
+            class="inline-flex items-center gap-2 px-4 py-2 rounded-full bg-[#ffffff] hover:bg-slate-100 dark:bg-zinc-800/80 dark:hover:bg-zinc-700 text-sm font-semibold text-slate-600 hover:text-slate-900 dark:text-slate-300 dark:hover:text-white transition-all border border-slate-200 dark:border-zinc-700 shadow-sm group/shuffle">
+            <i class="bi bi-shuffle transition-transform group-hover/shuffle:rotate-12"></i>
+            <span>Surprise me</span>
+          </button>
+        </div>
+      }
     </div>
   </div>
+
+  <!-- New since your last visit -->
+  @if (personalized && newDemos.length > 0) {
+    <div class="px-6 md:px-10 max-w-7xl mx-auto w-full relative z-20 mb-8">
+      <div class="rounded-3xl border border-indigo-200 dark:border-indigo-500/30 bg-indigo-50/60 dark:bg-indigo-500/[0.07] p-5 md:p-6">
+        <div class="flex items-center gap-2 mb-4">
+          <i class="bi bi-sparkles text-indigo-600 dark:text-indigo-400"></i>
+          <h2 class="text-sm font-bold uppercase tracking-wider text-indigo-700 dark:text-indigo-300 m-0">
+            New since your last visit
+          </h2>
+          <span class="px-2 py-0.5 rounded-full bg-indigo-600 text-white text-[10px] font-bold">{{ newDemos.length }}</span>
+        </div>
+
+        <div class="flex gap-4 overflow-x-auto pb-2 -mb-2 snap-x">
+          @for (demo of newDemos; track demo.id) {
+            <a [routerLink]="['/demos', demo.id]"
+               class="!no-underline group/new shrink-0 w-72 snap-start focus:outline-none focus-visible:ring-4 focus-visible:ring-indigo-500/40 rounded-2xl">
+              <div class="h-full bg-[#ffffff] dark:bg-[#18181b] rounded-2xl p-5 border border-indigo-200/70 dark:border-indigo-500/20 hover:border-indigo-300 dark:hover:border-indigo-500/50 shadow-sm hover:shadow-lg transition-all duration-300 hover:-translate-y-0.5 flex flex-col">
+                <div class="w-10 h-10 rounded-xl bg-indigo-50 dark:bg-indigo-500/10 text-indigo-600 dark:text-indigo-400 flex items-center justify-center text-lg mb-3 group-hover/new:scale-110 transition-transform duration-300">
+                  <i class="bi {{ demo.icon }}"></i>
+                </div>
+                <h3 class="text-base font-bold text-slate-900 dark:text-white mb-1.5 tracking-tight break-words">{{ demo.title }}</h3>
+                <p class="text-xs text-slate-500 dark:text-slate-400 line-clamp-2 leading-relaxed m-0">{{ demo.description }}</p>
+              </div>
+            </a>
+          }
+        </div>
+      </div>
+    </div>
+  }
 
   <!-- Search & Filters -->
   <div class="px-6 md:px-10 max-w-7xl mx-auto w-full relative z-20">
@@ -70,14 +128,55 @@
           </button>
         }
       </div>
+
+      <!-- Exploration progress -->
+      @if (personalized) {
+        <div class="flex flex-wrap items-center gap-x-4 gap-y-3 pt-4 border-t border-slate-200 dark:border-zinc-800">
+          <button
+            type="button"
+            (click)="toggleOnlyUnexplored()"
+            class="px-3 py-1.5 rounded-full text-xs font-semibold border transition-colors inline-flex items-center gap-1.5"
+            [ngClass]="onlyUnexplored
+              ? 'bg-emerald-600 text-white border-emerald-600'
+              : 'bg-slate-50 dark:bg-zinc-900 text-slate-600 dark:text-slate-400 border-slate-200 dark:border-zinc-700 hover:border-emerald-400 dark:hover:border-emerald-500'">
+            <i class="bi bi-compass"></i> Not yet explored
+            <span class="opacity-70">{{ unexploredCount }}</span>
+          </button>
+
+          <div class="flex items-center gap-3 flex-1 min-w-[200px]">
+            <div class="h-1.5 flex-1 rounded-full bg-slate-100 dark:bg-zinc-800 overflow-hidden">
+              <div class="h-full rounded-full bg-emerald-500 transition-all duration-700" [style.width.%]="exploredPercent"></div>
+            </div>
+            <span class="text-xs font-semibold text-slate-500 dark:text-zinc-400 whitespace-nowrap">
+              {{ exploredCount }} of {{ totalCount }} explored
+            </span>
+          </div>
+
+          @if (exploredCount > 0) {
+            <button
+              type="button"
+              (click)="resetProgress()"
+              class="text-xs font-semibold text-slate-400 dark:text-zinc-500 hover:text-slate-700 dark:hover:text-slate-300 transition-colors inline-flex items-center gap-1.5">
+              <i class="bi bi-arrow-counterclockwise"></i> Reset
+            </button>
+          }
+        </div>
+      }
     </div>
   </div>
 
   <div class="p-6 md:px-10 pb-20 max-w-7xl mx-auto w-full relative z-20 mt-8">
     @if (filteredDemos.length === 0) {
       <div class="text-center py-24">
-        <i class="bi bi-binoculars text-5xl text-slate-300 dark:text-zinc-700"></i>
-        <p class="mt-4 text-lg font-semibold text-slate-600 dark:text-slate-400">No demos match your filters.</p>
+        @if (onlyUnexplored && unexploredCount === 0) {
+          <i class="bi bi-trophy text-5xl text-amber-400"></i>
+          <p class="mt-4 text-lg font-semibold text-slate-600 dark:text-slate-400">
+            You've explored all {{ totalCount }} demos. Nicely done.
+          </p>
+        } @else {
+          <i class="bi bi-binoculars text-5xl text-slate-300 dark:text-zinc-700"></i>
+          <p class="mt-4 text-lg font-semibold text-slate-600 dark:text-slate-400">No demos match your filters.</p>
+        }
         <button type="button" (click)="clearFilters()" class="mt-2 text-sm font-semibold text-indigo-600 dark:text-indigo-400 hover:underline">
           Clear filters
         </button>
@@ -114,6 +213,13 @@
                       <i class="bi {{ demo.icon }}"></i>
                     </div>
 
+                    <div class="flex flex-col items-end gap-2">
+                    @if (isNew(demo)) {
+                      <span class="inline-flex items-center gap-1.5 px-2.5 py-1 rounded-full bg-indigo-600 text-white text-[10px] font-bold uppercase tracking-wider shadow-sm">
+                        <i class="bi bi-sparkles"></i> New
+                      </span>
+                    }
+
                     <!-- Availability badge -->
                     @switch (demoAvailability) {
                       @case ('available') {
@@ -142,6 +248,7 @@
                         </span>
                       }
                     }
+                    </div>
                   </div>
 
                   <h3 class="text-xl font-bold text-slate-900 dark:text-white mb-3 tracking-tight group-hover/card:text-slate-700 dark:group-hover/card:text-slate-300 transition-colors break-words">{{ demo.title }}</h3>
@@ -168,7 +275,12 @@
                     <div class="flex items-center justify-center w-8 h-8 rounded-full bg-slate-50 dark:bg-zinc-800/80 group-hover/card:bg-slate-900 group-hover/card:text-white dark:group-hover/card:bg-[#ffffff] dark:group-hover/card:text-slate-900 transition-colors duration-300 shadow-sm border border-slate-200 dark:border-zinc-700/50 group-hover/card:border-transparent">
                       <i class="bi bi-arrow-right -rotate-45 group-hover/card:rotate-0 transition-transform duration-300"></i>
                     </div>
-                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500 group-hover/card:text-slate-900 dark:group-hover/card:text-white transition-colors duration-300">Explore</span>
+                    <span class="text-xs font-bold uppercase tracking-wider text-slate-400 dark:text-zinc-500 group-hover/card:text-slate-900 dark:group-hover/card:text-white transition-colors duration-300 inline-flex items-center gap-2">
+                      @if (isUnvisited(demo)) {
+                        <span class="w-1.5 h-1.5 rounded-full bg-emerald-500" title="You haven't opened this one yet"></span>
+                      }
+                      Explore
+                    </span>
                   </div>
                 </div>
               </div>

--- a/webapp/src/app/pages/demos/demos.page.ts
+++ b/webapp/src/app/pages/demos/demos.page.ts
@@ -1,4 +1,4 @@
-import { Component, Inject, OnInit } from '@angular/core';
+import { afterNextRender, Component, Inject, OnInit } from '@angular/core';
 import { BasePage } from '../base-page';
 import { Title } from '@angular/platform-browser';
 import { DOCUMENT } from '@angular/common';
@@ -6,6 +6,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { DEMOS_DATA } from '../../core/services/demos.data';
 import { DemoApi, DemoCategory, DemoExample } from '../../core/models/demo.interface';
 import { DemoApiAvailability, DemoAvailabilityService } from '../../core/services/demo-availability.service';
+import { DemoDiscoveryService } from '../../core/services/demo-discovery.service';
 
 interface CategoryStyle {
   icon: string;
@@ -26,6 +27,14 @@ export class DemosPage extends BasePage implements OnInit {
   searchQuery = '';
   selectedCategory: DemoCategory | null = null;
   selectedApi: DemoApi | null = null;
+  onlyUnexplored = false;
+
+  /** Flipped after hydration: everything below is derived from localStorage. */
+  personalized = false;
+
+  newDemos: DemoExample[] = [];
+  demoOfTheDay: DemoExample | null = null;
+  exploredCount = 0;
 
   availability: Record<DemoApi, DemoApiAvailability> = {
     'Prompt API': 'checking',
@@ -76,9 +85,21 @@ export class DemosPage extends BasePage implements OnInit {
     private readonly route: ActivatedRoute,
     private readonly router: Router,
     private readonly demoAvailabilityService: DemoAvailabilityService,
+    private readonly discoveryService: DemoDiscoveryService,
   ) {
     super(document, title);
     this.setTitle("Demos");
+
+    // Deferred one macrotask so zone.js schedules a change detection pass for the
+    // personalized state — afterNextRender itself runs after CD has already finished.
+    afterNextRender(() => setTimeout(() => this.refreshDiscovery()));
+  }
+
+  private refreshDiscovery(): void {
+    this.personalized = true;
+    this.newDemos = this.discoveryService.newDemos;
+    this.demoOfTheDay = this.discoveryService.getDemoOfTheDay();
+    this.exploredCount = this.discoveryService.visitedCount;
   }
 
   override ngOnInit(): void {
@@ -92,6 +113,8 @@ export class DemosPage extends BasePage implements OnInit {
 
       const api = params.get('api');
       this.selectedApi = this.apis.find(a => a === api) ?? null;
+
+      this.onlyUnexplored = params.get('unexplored') === '1';
     }));
 
     this.subscriptions.push(this.demoAvailabilityService.availability$.subscribe(availability => {
@@ -104,6 +127,11 @@ export class DemosPage extends BasePage implements OnInit {
 
     return this.demos.filter(demo => {
       if (this.selectedCategory && demo.category !== this.selectedCategory) {
+        return false;
+      }
+
+      // Gated on `personalized` so the pre-hydration render matches the server's.
+      if (this.onlyUnexplored && this.personalized && this.discoveryService.isVisited(demo.id)) {
         return false;
       }
 
@@ -146,15 +174,57 @@ export class DemosPage extends BasePage implements OnInit {
     this.syncQueryParams();
   }
 
+  toggleOnlyUnexplored(): void {
+    this.onlyUnexplored = !this.onlyUnexplored;
+    this.syncQueryParams();
+  }
+
   clearFilters(): void {
     this.searchQuery = '';
     this.selectedCategory = null;
     this.selectedApi = null;
+    this.onlyUnexplored = false;
     this.syncQueryParams();
   }
 
   get hasActiveFilters(): boolean {
-    return this.searchQuery.trim() !== '' || this.selectedCategory !== null || this.selectedApi !== null;
+    return this.searchQuery.trim() !== ''
+      || this.selectedCategory !== null
+      || this.selectedApi !== null
+      || this.onlyUnexplored;
+  }
+
+  isNew(demo: DemoExample): boolean {
+    return this.personalized && this.discoveryService.isNew(demo.id);
+  }
+
+  isUnvisited(demo: DemoExample): boolean {
+    return this.personalized && !this.discoveryService.isVisited(demo.id);
+  }
+
+  get totalCount(): number {
+    return this.discoveryService.totalCount;
+  }
+
+  get unexploredCount(): number {
+    return this.totalCount - this.exploredCount;
+  }
+
+  get exploredPercent(): number {
+    return this.totalCount === 0 ? 0 : Math.round((this.exploredCount / this.totalCount) * 100);
+  }
+
+  surpriseMe(): void {
+    const demo = this.discoveryService.getSurpriseDemo();
+
+    if (demo) {
+      this.router.navigate(['/demos', demo.id]);
+    }
+  }
+
+  resetProgress(): void {
+    this.discoveryService.resetProgress();
+    this.refreshDiscovery();
   }
 
   getCategoryStyle(category: DemoCategory): CategoryStyle {
@@ -175,6 +245,7 @@ export class DemosPage extends BasePage implements OnInit {
         q: this.searchQuery.trim() || null,
         category: this.selectedCategory,
         api: this.selectedApi,
+        unexplored: this.onlyUnexplored ? '1' : null,
       },
       queryParamsHandling: 'merge',
       replaceUrl: true,


### PR DESCRIPTION
## Problem

The demos listing has grown past 50 cards behind a search box, so discovery only works if you already know the word to type. Worse, every demo page is a dead end — the sole navigation affordance is "Back to Demos", which drops you at the top of the same wall. Nothing tells a returning visitor which demos appeared since their last visit.

## Approach

A new `DemoDiscoveryService` tracks, per browser, which demos have been *shown*, which have been *opened*, and which arrived *since the last visit*. State is a single localStorage key and is browser-only: on the server every getter reports the "nothing seen yet" baseline, so SSR output stays stable and hydration is clean.

**Demo pages — "Keep exploring" footer.** Three related demos ranked by shared APIs (×10), same category (+4), being a superset of the current demo's APIs (+2), then nudged toward unopened (+3) and new (+2). Plus prev/next within the category and a "Surprise me" shortcut biased to unvisited demos.

The layout resolves its own demo from `router.url` — each demo id is also its route segment — rather than taking it as an `@Input`. That's why this reaches **every** demo page without touching any of the 50+ feature components.

**Listing page.** A "New since your last visit" rail, `New` badges and unvisited dots on cards, a "Not yet explored" filter chip with progress and reset (URL-synced as `?unexplored=1`), an all-explored trophy state, and a demo of the day derived from the day number so the pick is identical for everyone and worth sharing.

## Two deliberate behaviours

- **New stays new until you open it**, not until your next visit — a second visit the same day shouldn't silently burn the badge.
- **A first-ever visit marks everything known but nothing new.** Fifty `New` badges communicate nothing.

## Verification

Driven with headless Chrome over CDP against the SSR build:

- Seeded a returning visitor missing 6 demos → rail showed exactly those 6, 6 `New` badges, `5 of 56 explored`, chip read 51, 51 unvisited dots.
- "Not yet explored" filter hid the 5 visited demos and set `?unexplored=1`.
- Opening `/demos/ocr` recorded the visit; related cards were all vision demos; prev/next resolved within Image Input; neighbours are excluded from the related cards so nothing appears twice.
- **No hydration errors.** localStorage-derived UI is gated behind a flag flipped in `afterNextRender`, deferred one macrotask because this app is zone-based and `afterNextRender` runs after CD has already finished.
- The footer still *prerenders* with an unpersonalized ranking, so crawlers get the internal links — confirmed present in `dist/.../demos/ocr/index.html`.
- `ng build` clean, 91 routes prerendered. The two `NG8102` warnings are pre-existing in `cortex-insights`.

Unrelated pre-existing issue noticed while testing: the SSR server 404s ACE's `worker-javascript.js`, which throws on every demo page console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Gv1raQVhYDDih7QttQheBJ