### PR TITLE
Add card previews for the six newest demos

### DIFF
--- a/webapp/src/app/core/services/demo-previews.data.ts
+++ b/webapp/src/app/core/services/demo-previews.data.ts
@@ -90,6 +90,16 @@ export const DEMO_PREVIEWS: Record<string, DemoPreview> = {
     ],
   },
 
+  'tongue-twister': {
+    kind: 'list',
+    source: { icon: 'bi-mic-fill', label: '"she sells seashells by the seashore"' },
+    rows: [
+      { text: 'attempt 1', score: 0.62, meta: '4.8 s' },
+      { text: 'attempt 2', score: 0.81, meta: '3.4 s' },
+      { text: 'attempt 3', score: 0.94, meta: '3.1 s' },
+    ],
+  },
+
   // --------------------------------------------------------- Text / writing
   'polyglot-chat': {
     kind: 'chat',
@@ -267,6 +277,16 @@ WHERE city = 'New York';`,
     ],
   },
 
+  'mystery-language': {
+    kind: 'list',
+    query: '"Ik heb honger, maar de winkel is gesloten."',
+    rows: [
+      { text: 'Dutch', score: 0.94, meta: 'your guess ✓' },
+      { text: 'Afrikaans', score: 0.05 },
+      { text: 'German', score: 0.01 },
+    ],
+  },
+
   // ------------------------------------------------------------ Mix & match
   'localization-qa': {
     kind: 'list',
@@ -308,6 +328,16 @@ WHERE city = 'New York';`,
     { "name": "Latte", "price": 5.50 }
   ]
 }`,
+  },
+
+  'omnibox': {
+    kind: 'list',
+    query: '"pourriez-vous m\'aider avec ma commande ?"',
+    rows: [
+      { text: '→ Translator', score: 0.93, meta: 'fr detected' },
+      { text: '→ Prompt API', score: 0.31 },
+      { text: '→ Proofreader', score: 0.11 },
+    ],
   },
 
   // ------------------------------------------------------------- Embeddings
@@ -390,6 +420,16 @@ WHERE city = 'New York';`,
     ],
   },
 
+  'moderation-cascade': {
+    kind: 'list',
+    query: '2,044 comments through the cascade',
+    rows: [
+      { text: 'cleared instantly', score: 0.9 },
+      { text: 'escalated to the LLM', score: 0.06 },
+      { text: 'blocked instantly', score: 0.04 },
+    ],
+  },
+
   // ------------------------------------------------------------ Image input
   'camera-qa': {
     kind: 'chat',
@@ -462,6 +502,17 @@ WHERE city = 'New York';`,
 </header>`,
   },
 
+  'photo-search': {
+    kind: 'list',
+    source: { icon: 'bi-images', label: '128 local photos' },
+    query: 'food on a table',
+    rows: [
+      { text: 'brunch spread', score: 0.89 },
+      { text: 'birthday cake', score: 0.71 },
+      { text: 'dog on the beach', score: 0.09 },
+    ],
+  },
+
   // ------------------------------------------------------------ Audio input
   'audio-transcription': {
     kind: 'io',
@@ -485,6 +536,18 @@ WHERE city = 'New York';`,
     source: { icon: 'bi-soundwave', label: 'client-call.m4a · 4:12' },
     rows: [
       { role: 'out', text: 'Client wants launch pushed a week, budget is approved, and new mockups are due Monday.' },
+    ],
+  },
+
+  'study-kit': {
+    kind: 'chips',
+    source: { icon: 'bi-mortarboard-fill', label: 'lecture-week-4.m4a · 52:10' },
+    caption: 'Built from the recording:',
+    rows: [
+      { label: 'Transcript · 8,410 words' },
+      { label: '12 key points' },
+      { label: 'Q&A chat' },
+      { label: '34 flashcards' },
     ],
   },
 


### PR DESCRIPTION
## Why

The demos merged after #102 (#100 agentic/devtool, #101 omnibox/games) had no entry in `DEMO_PREVIEWS`, so their cards fell back to text only while every other card showed a preview. Coverage is now 56/56 demos, no orphaned keys.

## The six

| Demo | Kind | What it shows |
|---|---|---|
| Tongue Twister Trial | `list` | three attempts, score climbing 62% → 94%, with times |
| Moderation Cascade | `list` | 2,044 comments split 90% cleared / 6% escalated to the LLM / 4% blocked — the cascade's whole point in one glance |
| Mystery Language | `list` | ranked detections (Dutch 94%, Afrikaans 5%, German 1%) with `your guess ✓` on the winner |
| The Omnibox | `list` | the router's own ranking: `→ Translator · fr detected` 93%, `→ Prompt API` 31%, `→ Proofreader` 11% |
| Photo Semantic Search | `list` | "food on a table" ranking three captioned photos |
| Lecture Study Kit | `chips` | the four artifacts built from one recording: transcript, key points, Q&A chat, flashcards |

Five are `list` because each is fundamentally a *ranking* — that is what the demo puts on screen. No new preview kinds or renderer changes were needed; this is data only, one file.

## Verification

- `ng build` clean.
- 56 demos / 56 previews, no missing and no orphans.
- Screenshotted all six in the built page. Two needed a fix: **Moderation Cascade** and **Photo Semantic Search** had labels long enough to truncate (`cleared · embeddings o…`, `IMG_0412 · brunch spre…`), losing their counts. Shortened both — row text shares a truncating line with its meta, so labels want to stay under roughly 20 characters at card width.

## Note

Authored from a clean worktree on `master`, because the main checkout has unrelated uncommitted work (demo-of-the-day, `demo-discovery.service.ts`) that blocks switching branches. Nothing in that tree was touched.