### PR TITLE
Add icons to all sidebar sub-navigation items

### DIFF
--- a/webapp/src/app/components/sidebar/sidebar.component.html
+++ b/webapp/src/app/components/sidebar/sidebar.component.html
@@ -68,7 +68,10 @@
               @if (routeEnum === RouteEnum.GetStarted) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Getting Started</span>
+              <div class="flex items-center">
+                <i class="bi bi-rocket-takeoff text-sm w-6 flex justify-start"></i>
+                <span>Getting Started</span>
+              </div>
             </a>
 
             <!-- Check Availability -->
@@ -78,7 +81,10 @@
               @if (routeEnum === RouteEnum.CheckAvailability) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Check Availability</span>
+              <div class="flex items-center">
+                <i class="bi bi-check-circle text-sm w-6 flex justify-start"></i>
+                <span>Check Availability</span>
+              </div>
             </a>
 
             <!-- Tracking Download -->
@@ -88,7 +94,10 @@
               @if (routeEnum === RouteEnum.TrackingDownload) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Tracking Download</span>
+              <div class="flex items-center">
+                <i class="bi bi-cloud-arrow-down text-sm w-6 flex justify-start"></i>
+                <span>Tracking Download</span>
+              </div>
             </a>
 
             <!-- Aborting Operations -->
@@ -98,7 +107,10 @@
               @if (routeEnum === RouteEnum.AbortingOperations) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Aborting Operations</span>
+              <div class="flex items-center">
+                <i class="bi bi-x-octagon text-sm w-6 flex justify-start"></i>
+                <span>Aborting Operations</span>
+              </div>
             </a>
 
             <!-- Errors -->
@@ -108,7 +120,10 @@
               @if (routeEnum === RouteEnum.Errors) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Error Handling</span>
+              <div class="flex items-center">
+                <i class="bi bi-exclamation-triangle text-sm w-6 flex justify-start"></i>
+                <span>Error Handling</span>
+              </div>
             </a>
 
             <div class="mt-3 mb-1.5 text-[10px] font-bold tracking-widest text-slate-400 dark:text-slate-500 uppercase">
@@ -123,7 +138,10 @@
                 @if (routeEnum === RouteEnum.PromptApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Prompt API</span>
+                <div class="flex items-center">
+                  <i class="bi bi-chat-left-text text-sm w-6 flex justify-start"></i>
+                  <span>Prompt API</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.PromptApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -147,7 +165,10 @@
                 @if (routeEnum === RouteEnum.SummarizerApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Summarizer</span>
+                <div class="flex items-center">
+                  <i class="bi bi-file-earmark-text text-sm w-6 flex justify-start"></i>
+                  <span>Summarizer</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.SummarizerApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -170,7 +191,10 @@
                 @if (routeEnum === RouteEnum.WriterApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Writer</span>
+                <div class="flex items-center">
+                  <i class="bi bi-pencil text-sm w-6 flex justify-start"></i>
+                  <span>Writer</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.WriterApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -193,7 +217,10 @@
                 @if (routeEnum === RouteEnum.RewriterApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Rewriter</span>
+                <div class="flex items-center">
+                  <i class="bi bi-arrow-repeat text-sm w-6 flex justify-start"></i>
+                  <span>Rewriter</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.RewriterApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -216,7 +243,10 @@
                 @if (routeEnum === RouteEnum.TranslatorApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Translator</span>
+                <div class="flex items-center">
+                  <i class="bi bi-translate text-sm w-6 flex justify-start"></i>
+                  <span>Translator</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.TranslatorApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -239,7 +269,10 @@
                 @if (routeEnum === RouteEnum.LanguageDetectorApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Language Detector</span>
+                <div class="flex items-center">
+                  <i class="bi bi-globe2 text-sm w-6 flex justify-start"></i>
+                  <span>Language Detector</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.LanguageDetectorApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -261,7 +294,10 @@
                 @if (routeEnum === RouteEnum.ProofreaderApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Proofreader</span>
+                <div class="flex items-center">
+                  <i class="bi bi-spellcheck text-sm w-6 flex justify-start"></i>
+                  <span>Proofreader</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.ProofreaderApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -282,7 +318,10 @@
                 @if (routeEnum === RouteEnum.SemanticEmbedderApi) {
                   <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
                 }
-                <span>Semantic Embedder</span>
+                <div class="flex items-center">
+                  <i class="bi bi-diagram-3 text-sm w-6 flex justify-start"></i>
+                  <span>Semantic Embedder</span>
+                </div>
               </a>
               @if (routeEnum === RouteEnum.SemanticEmbedderApi) {
                 <div class="flex flex-col gap-1 pl-6 mt-1 mb-2 relative before:content-[''] before:absolute before:left-[14px] before:top-1 before:bottom-1 before:w-px before:bg-slate-200 dark:before:bg-zinc-800">
@@ -329,7 +368,10 @@
               @if (routeEnum === RouteEnum.BestPracticesSessionManagement) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Session Management</span>
+              <div class="flex items-center">
+                <i class="bi bi-hourglass-split text-sm w-6 flex justify-start"></i>
+                <span>Session Management</span>
+              </div>
             </a>
 
             <!-- Performance -->
@@ -339,7 +381,10 @@
               @if (routeEnum === RouteEnum.BestPracticesPerformance) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Performance</span>
+              <div class="flex items-center">
+                <i class="bi bi-speedometer2 text-sm w-6 flex justify-start"></i>
+                <span>Performance</span>
+              </div>
             </a>
 
             <!-- Streaming & Rendering -->
@@ -349,7 +394,10 @@
               @if (routeEnum === RouteEnum.BestPracticesStreaming) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Streaming &amp; Rendering</span>
+              <div class="flex items-center">
+                <i class="bi bi-broadcast text-sm w-6 flex justify-start"></i>
+                <span>Streaming &amp; Rendering</span>
+              </div>
             </a>
 
             <!-- Structured Output -->
@@ -359,7 +407,10 @@
               @if (routeEnum === RouteEnum.BestPracticesStructuredOutput) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Structured Output</span>
+              <div class="flex items-center">
+                <i class="bi bi-braces text-sm w-6 flex justify-start"></i>
+                <span>Structured Output</span>
+              </div>
             </a>
 
             <!-- UX Patterns -->
@@ -369,7 +420,10 @@
               @if (routeEnum === RouteEnum.BestPracticesUserExperience) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>UX Patterns</span>
+              <div class="flex items-center">
+                <i class="bi bi-stars text-sm w-6 flex justify-start"></i>
+                <span>UX Patterns</span>
+              </div>
             </a>
 
           </div>
@@ -400,7 +454,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsPrompt) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Prompt API</span>
+              <div class="flex items-center">
+                <i class="bi bi-chat-left-text text-sm w-6 flex justify-start"></i>
+                <span>Prompt API</span>
+              </div>
             </a>
 
             <!-- Summarizer API -->
@@ -410,7 +467,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsSummarizer) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Summarizer API</span>
+              <div class="flex items-center">
+                <i class="bi bi-file-earmark-text text-sm w-6 flex justify-start"></i>
+                <span>Summarizer API</span>
+              </div>
             </a>
 
             <!-- Writer API -->
@@ -420,7 +480,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsWriter) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Writer API</span>
+              <div class="flex items-center">
+                <i class="bi bi-pencil text-sm w-6 flex justify-start"></i>
+                <span>Writer API</span>
+              </div>
             </a>
 
             <!-- Rewriter API -->
@@ -430,7 +493,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsRewriter) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Rewriter API</span>
+              <div class="flex items-center">
+                <i class="bi bi-arrow-repeat text-sm w-6 flex justify-start"></i>
+                <span>Rewriter API</span>
+              </div>
             </a>
 
             <!-- Translator API -->
@@ -440,7 +506,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsTranslator) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Translator API</span>
+              <div class="flex items-center">
+                <i class="bi bi-translate text-sm w-6 flex justify-start"></i>
+                <span>Translator API</span>
+              </div>
             </a>
 
             <!-- Language Detector API -->
@@ -450,7 +519,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsLanguageDetector) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Language Detector API</span>
+              <div class="flex items-center">
+                <i class="bi bi-globe2 text-sm w-6 flex justify-start"></i>
+                <span>Language Detector API</span>
+              </div>
             </a>
 
             <!-- Proofreader API -->
@@ -460,7 +532,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsProofreader) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Proofreader API</span>
+              <div class="flex items-center">
+                <i class="bi bi-spellcheck text-sm w-6 flex justify-start"></i>
+                <span>Proofreader API</span>
+              </div>
             </a>
 
             <!-- Semantic Embedder API -->
@@ -470,7 +545,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsSemanticEmbedder) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Semantic Embedder API</span>
+              <div class="flex items-center">
+                <i class="bi bi-diagram-3 text-sm w-6 flex justify-start"></i>
+                <span>Semantic Embedder API</span>
+              </div>
             </a>
 
             <!-- Web Speech API -->
@@ -480,7 +558,10 @@
               @if (routeEnum === RouteEnum.PlaygroundsWebSpeech) {
                 <div class="absolute -left-[10px] top-1/2 -translate-y-1/2 w-[3px] h-4 bg-indigo-500 rounded-full"></div>
               }
-              <span>Web Speech API</span>
+              <div class="flex items-center">
+                <i class="bi bi-mic text-sm w-6 flex justify-start"></i>
+                <span>Web Speech API</span>
+              </div>
             </a>
           </div>
         }


### PR DESCRIPTION
Every top-level sidebar entry already had a Bootstrap icon, but the nested items under **Documentation**, **Best Practices** and **Playgrounds** were text-only. This adds an icon to all 27 of them.

### Icons

| Section | Items |
| --- | --- |
| Documentation → guides | Getting Started `bi-rocket-takeoff`, Check Availability `bi-check-circle`, Tracking Download `bi-cloud-arrow-down`, Aborting Operations `bi-x-octagon`, Error Handling `bi-exclamation-triangle` |
| Documentation → API references | Prompt `bi-chat-left-text`, Summarizer `bi-file-earmark-text`, Writer `bi-pencil`, Rewriter `bi-arrow-repeat`, Translator `bi-translate`, Language Detector `bi-globe2`, Proofreader `bi-spellcheck`, Semantic Embedder `bi-diagram-3` |
| Best Practices | Session Management `bi-hourglass-split`, Performance `bi-speedometer2`, Streaming & Rendering `bi-broadcast`, Structured Output `bi-braces`, UX Patterns `bi-stars` |
| Playgrounds | same icons as the matching Documentation API entries, plus Web Speech `bi-mic` |

### Notes

- Sub-items use `text-sm w-6` against the top-level `text-lg w-7`, so the visual hierarchy stays legible.
- The API entries under Documentation reuse the icons of their Playgrounds counterparts, so the same API reads consistently in both places.
- Each label is wrapped in a `flex items-center` div because the anchors use `justify-between` — without the wrapper the icon and label would be pushed to opposite edges.
- The active-route indicator bars and all top-level entries are untouched.

### Testing

`ng build` passes (only the pre-existing ACE CommonJS bailout warnings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)