### PR TITLE
Make the site navigable on mobile

### DIFF
--- a/webapp/src/app/components/header/header.component.html
+++ b/webapp/src/app/components/header/header.component.html
@@ -1,9 +1,6 @@
 <div class="w-full px-4 sm:px-6 lg:px-8">
   <div class="flex items-center mt-4 mb-3 gap-3">
-    <button class="lg:hidden p-2 rounded-md text-slate-500 hover:text-slate-700 hover:bg-slate-100 dark:text-slate-400 dark:hover:text-slate-200 dark:hover:bg-zinc-800 transition-colors" (click)="openSidebar()">
-      <i class="bi bi-list text-xl"></i>
-    </button>
-    <div class="flex-grow">
+    <div class="flex-grow min-w-0">
       <ng-content select="[header-title-row]"></ng-content>
     </div>
   </div>

--- a/webapp/src/app/components/header/header.component.ts
+++ b/webapp/src/app/components/header/header.component.ts
@@ -1,7 +1,4 @@
-import {Component, Inject, Input, OnInit, PLATFORM_ID} from '@angular/core';
-import {isPlatformServer} from '@angular/common';
-import {Dialog} from '@angular/cdk/dialog';
-import {SidebarComponent} from '../sidebar/sidebar.component';
+import {Component, OnInit} from '@angular/core';
 
 @Component({
   selector: 'webai-studio-header',
@@ -11,22 +8,8 @@ import {SidebarComponent} from '../sidebar/sidebar.component';
 })
 export class HeaderComponent implements OnInit {
 
-  constructor(
-    @Inject(PLATFORM_ID) private platformId: Object,
-    protected readonly dialog: Dialog
-  ) {
-  }
-
   async ngOnInit() {
 
-  }
-
-  openSidebar() {
-    this.dialog.open(SidebarComponent, { 
-      panelClass: ['w-64', 'h-full', 'fixed', 'left-0', 'top-0', 'bg-white', 'shadow-2xl', 'dark:bg-[#121212]'],
-      hasBackdrop: true,
-      backdropClass: 'bg-black/50'
-    });
   }
 
 }

--- a/webapp/src/app/components/layout/layout.component.html
+++ b/webapp/src/app/components/layout/layout.component.html
@@ -1,6 +1,32 @@
-<div class="flex h-screen w-full transition-colors duration-200">
-  <webai-studio-sidebar class="offcanvas offcanvas-start lg:block flex-shrink-0 border-r border-slate-200 dark:border-zinc-800"></webai-studio-sidebar>
-  <div class="flex-grow h-full overflow-hidden flex flex-col">
-    <router-outlet></router-outlet>
+<div class="flex h-dvh w-full transition-colors duration-200">
+  <!-- Backdrop, small screens only -->
+  @if (isSidebarOpen) {
+    <div class="lg:hidden fixed inset-0 z-40 bg-black/50" (click)="closeSidebar()" aria-hidden="true"></div>
+  }
+
+  <webai-studio-sidebar
+    class="fixed inset-y-0 left-0 z-50 transition-transform duration-200 ease-out
+           lg:static lg:z-auto
+           flex-shrink-0 border-r border-slate-200 dark:border-zinc-800"
+    [class.translate-x-0]="isSidebarOpen"
+    [class.-translate-x-full]="!isSidebarOpen"></webai-studio-sidebar>
+
+  <div class="flex-grow min-w-0 h-full overflow-hidden flex flex-col">
+    <!-- Mobile navigation bar -->
+    <div class="lg:hidden flex-shrink-0 flex items-center gap-3 px-3 h-14 bg-slate-50 dark:bg-[#121212] border-b border-slate-200 dark:border-zinc-800">
+      <button type="button"
+              class="p-2 -ml-1 rounded-md text-slate-600 dark:text-slate-300 hover:bg-slate-200/60 dark:hover:bg-zinc-800/60 transition-colors"
+              [attr.aria-expanded]="isSidebarOpen"
+              aria-label="Toggle navigation"
+              (click)="toggleSidebar()">
+        <i class="bi bi-list text-2xl leading-none"></i>
+      </button>
+      <img src="images/webai-logo.png" alt="" class="h-7 w-7 object-contain">
+      <span class="text-sm font-semibold text-slate-900 dark:text-white">WebAI Studio</span>
+    </div>
+
+    <div class="flex-grow min-h-0 overflow-hidden flex flex-col">
+      <router-outlet></router-outlet>
+    </div>
   </div>
 </div>

--- a/webapp/src/app/components/layout/layout.component.scss
+++ b/webapp/src/app/components/layout/layout.component.scss
@@ -1,14 +1,14 @@
 webai-studio-sidebar {
-  height: 100vh;
-  position: fixed;
-
   &.collapsed {
     width: 80px !important;
   }
+}
 
-  @media screen and (min-width: 992px) {
-    position: unset;
-    visibility: visible;
+// Above the `lg` breakpoint the sidebar is a static column, never a drawer:
+// neutralize the off-canvas translation regardless of the bound classes.
+@media screen and (min-width: 1024px) {
+  webai-studio-sidebar {
+    translate: none !important;
     transform: none !important;
   }
 }

--- a/webapp/src/app/components/layout/layout.component.ts
+++ b/webapp/src/app/components/layout/layout.component.ts
@@ -1,4 +1,8 @@
-import { Component } from '@angular/core';
+import {Component, HostListener, OnDestroy, OnInit} from '@angular/core';
+import {NavigationEnd, Router} from '@angular/router';
+import {Subscription} from 'rxjs';
+import {filter} from 'rxjs/operators';
+import {SidebarService} from '../../core/services/sidebar.service';
 
 @Component({
   selector: 'magieno-webai-studio-layout',
@@ -6,6 +10,41 @@ import { Component } from '@angular/core';
   templateUrl: './layout.component.html',
   styleUrl: './layout.component.scss'
 })
-export class LayoutComponent {
+export class LayoutComponent implements OnInit, OnDestroy {
 
+  isSidebarOpen = false;
+
+  private subscriptions: Subscription[] = [];
+
+  constructor(
+    private readonly sidebarService: SidebarService,
+    private readonly router: Router,
+  ) {
+  }
+
+  ngOnInit() {
+    this.subscriptions.push(
+      this.sidebarService.isOpen$.subscribe(isOpen => this.isSidebarOpen = isOpen),
+    );
+
+    // Navigating from the drawer should dismiss it.
+    this.subscriptions.push(
+      this.router.events.pipe(
+        filter(event => event instanceof NavigationEnd),
+      ).subscribe(() => this.sidebarService.close()),
+    );
+  }
+
+  ngOnDestroy() {
+    this.subscriptions.forEach(subscription => subscription.unsubscribe());
+  }
+
+  @HostListener('document:keydown.escape')
+  closeSidebar() {
+    this.sidebarService.close();
+  }
+
+  toggleSidebar() {
+    this.sidebarService.toggle();
+  }
 }

--- a/webapp/src/app/components/sidebar/sidebar.component.scss
+++ b/webapp/src/app/components/sidebar/sidebar.component.scss
@@ -1,5 +1,12 @@
 :host {
   display: block;
   height: 100%;
-  width: 350px !important;
+  // Drawer width on small screens: never wider than the viewport.
+  width: min(85vw, 20rem);
+}
+
+@media screen and (min-width: 1024px) {
+  :host {
+    width: 350px;
+  }
 }

--- a/webapp/src/app/core/services/sidebar.service.ts
+++ b/webapp/src/app/core/services/sidebar.service.ts
@@ -1,0 +1,30 @@
+import {Injectable} from '@angular/core';
+import {BehaviorSubject} from 'rxjs';
+
+/**
+ * Controls the visibility of the navigation sidebar when it is displayed as an
+ * off-canvas drawer (small screens). On large screens the sidebar is always
+ * visible and this state is ignored.
+ */
+@Injectable({providedIn: 'root'})
+export class SidebarService {
+  private readonly isOpenSubject = new BehaviorSubject<boolean>(false);
+
+  readonly isOpen$ = this.isOpenSubject.asObservable();
+
+  get isOpen(): boolean {
+    return this.isOpenSubject.value;
+  }
+
+  open() {
+    this.isOpenSubject.next(true);
+  }
+
+  close() {
+    this.isOpenSubject.next(false);
+  }
+
+  toggle() {
+    this.isOpenSubject.next(!this.isOpenSubject.value);
+  }
+}


### PR DESCRIPTION
## Summary

Below the `lg` breakpoint the sidebar was permanently `position: fixed` and 350px wide, so it sat on top of the page content and there was no reliable way to move between sections on a phone. This turns it into a proper off-canvas drawer so the site can be navigated on mobile.

## Changes

- **`core/services/sidebar.service.ts`** (new) — `BehaviorSubject`-backed open/close/toggle state for the drawer.
- **`layout.component.ts/.html/.scss`** — sidebar renders off-screen below `lg` and as a static flex column at `lg`+. Adds a mobile-only top bar (toggle, logo, title), a click-to-dismiss backdrop, Escape-to-close, and auto-close on `NavigationEnd` so tapping a nav link dismisses the drawer.
- **`sidebar.component.scss`** — host width is `min(85vw, 20rem)` on small screens (was a hard `350px !important`, wider than most phones); `350px` at `lg`+.
- **`header.component.ts/.html`** — removes the duplicate hamburger that opened the sidebar in a CDK dialog, leaving one nav affordance. Drops the now-unused `Dialog`/`SidebarComponent` imports.

## Notes

- Tailwind v4 emits `translate-x-*` as the `translate` property, which `transform: none` does **not** cancel. The desktop reset is therefore an `!important` `translate: none` inside a `min-width: 1024px` media query in `layout.component.scss` rather than a `lg:transform-none` utility.
- Scope is navigation only — page content is not made responsive, per the request.
- `/cortex`, `/cortex-insights`, and `/bugs` sit outside the layout and still have no sidebar; unchanged.

## Testing

`ng build` passes on top of current `master` (97 routes prerendered, only pre-existing warnings). Not visually verified in a browser — no headless browser is available in this checkout, so a manual check at a narrow viewport is worth doing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)