### PR TITLE
Make best-practices comparisons measure honestly

### DIFF
--- a/webapp/src/app/components/practice-comparison/practice-comparison.component.ts
+++ b/webapp/src/app/components/practice-comparison/practice-comparison.component.ts
@@ -3,12 +3,26 @@ import { Component, ChangeDetectorRef, Input, OnInit } from '@angular/core';
 interface ComparisonSideState {
   code: string;
   output: string;
-  durationMs: number | null;
+  /** Measured samples, warm-up excluded. */
+  samples: number[];
   reported: boolean;
   running: boolean;
   editorHeight: string;
 }
 
+type RunPhase = 'idle' | 'warmup' | 'measuring' | 'done';
+
+/**
+ * Side-by-side "do" / "don't" runner.
+ *
+ * When [timed] is true the component is a benchmark, and on-device inference is
+ * noisy enough that a single sample per side is meaningless: the model loads once
+ * and stays resident, so whichever side runs first absorbs the cold start, and
+ * response-length variance alone can swing a run by more than the effect being
+ * measured. The harness therefore discards a warm-up run per side, takes three
+ * measured samples each in alternating order, compares medians, and refuses to
+ * declare a winner when the gap falls inside the observed spread.
+ */
 @Component({
   selector: 'app-practice-comparison',
   template: `
@@ -20,16 +34,23 @@ interface ComparisonSideState {
           <span class="text-xs font-bold uppercase tracking-widest text-slate-600 dark:text-zinc-400">{{ title }}</span>
         </div>
         @if (runnable) {
-          <button (click)="runBoth()" [disabled]="isAnyRunning"
-                  class="flex items-center gap-2 px-4 py-1.5 rounded-lg text-xs font-bold bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white shadow-sm transition-colors m-0">
-            @if (isAnyRunning) {
-              <span class="inline-block w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin"></span>
-              Running…
-            } @else {
-              <i class="bi bi-stopwatch"></i>
-              Run both & compare
+          <div class="flex items-center gap-3">
+            @if (phase !== 'idle' && isAnyRunning) {
+              <span class="text-[10px] font-mono text-slate-400 dark:text-zinc-500">
+                {{ phase === 'warmup' ? 'warm-up (discarded)' : 'sample ' + repIndex + '/' + REPETITIONS }}
+              </span>
             }
-          </button>
+            <button (click)="runBoth()" [disabled]="isAnyRunning"
+                    class="flex items-center gap-2 px-4 py-1.5 rounded-lg text-xs font-bold bg-indigo-600 hover:bg-indigo-700 disabled:opacity-50 disabled:cursor-not-allowed text-white shadow-sm transition-colors m-0">
+              @if (isAnyRunning) {
+                <span class="inline-block w-3 h-3 border-2 border-white/40 border-t-white rounded-full animate-spin"></span>
+                Running…
+              } @else {
+                <i [class]="timed ? 'bi bi-stopwatch' : 'bi bi-play-fill'"></i>
+                {{ timed ? 'Benchmark both' : 'Run both' }}
+              }
+            </button>
+          </div>
         }
       </div>
 
@@ -50,14 +71,14 @@ interface ComparisonSideState {
                 </span>
               </div>
               <div class="flex items-center gap-2">
-                @if (state.durationMs !== null) {
+                @if (timed && median(state) !== null) {
                   <span class="px-2 py-0.5 rounded-md text-[10px] font-mono font-bold"
                         [ngClass]="side.key === 'do' ? 'bg-emerald-100 dark:bg-emerald-500/20 text-emerald-700 dark:text-emerald-300' : 'bg-red-100 dark:bg-red-500/20 text-red-700 dark:text-red-300'">
-                    {{ state.durationMs | number: '1.0-0' }}<span class="opacity-60 ml-0.5">ms</span>
+                    {{ median(state) | number: '1.0-0' }}<span class="opacity-60 ml-0.5">ms</span>
                   </span>
                 }
                 @if (runnable) {
-                  <button (click)="run(side.key)" [disabled]="isAnyRunning"
+                  <button (click)="runSingle(side.key)" [disabled]="isAnyRunning"
                           class="flex items-center gap-1 px-2.5 py-1 rounded text-[11px] font-semibold bg-slate-200/70 hover:bg-slate-300/70 text-slate-700 dark:bg-zinc-800 dark:hover:bg-zinc-700 dark:text-slate-300 disabled:opacity-50 transition-colors m-0">
                     <i class="bi bi-play-fill"></i> Run
                   </button>
@@ -85,37 +106,49 @@ interface ComparisonSideState {
       </div>
 
       <!-- Timing comparison -->
-      @if (doState.durationMs !== null && dontState.durationMs !== null) {
+      @if (timed && median(doState) !== null && median(dontState) !== null) {
         <div class="px-5 py-4 border-t border-slate-200 dark:border-zinc-800 bg-[#ffffff] dark:bg-[#1e1e1e]">
           <div class="text-[10px] font-bold uppercase tracking-widest text-slate-500 dark:text-zinc-500 mb-3 flex items-center gap-2">
             <i class="bi bi-speedometer2"></i>
-            {{ doState.reported || dontState.reported ? 'User-perceived wait (reported by the snippets)' : 'Timing difference (total run time)' }}
+            {{ doState.reported || dontState.reported ? metricLabel : 'Total run time' }}
+            <span class="font-normal normal-case tracking-normal text-slate-400 dark:text-zinc-600">
+              — median of {{ doState.samples.length }}, warm-up discarded
+            </span>
           </div>
           <div class="flex flex-col gap-2">
-            <div class="flex items-center gap-3">
-              <span class="w-14 text-right text-[11px] font-bold text-emerald-600 dark:text-emerald-400 flex-shrink-0">{{ doLabel }}</span>
-              <div class="flex-grow h-5 rounded-md bg-slate-100 dark:bg-zinc-800 overflow-hidden">
-                <div class="h-full bg-emerald-500 dark:bg-emerald-500/80 rounded-md transition-all duration-500 flex items-center justify-end pr-2"
-                     [style.width.%]="barWidth(doState.durationMs)">
-                  <span class="text-[10px] font-mono font-bold text-white whitespace-nowrap">{{ doState.durationMs | number: '1.0-0' }} ms</span>
+            @for (side of sides; track side.key) {
+              @let state = side.key === 'do' ? doState : dontState;
+              <div class="flex items-center gap-3">
+                <span class="w-20 text-right text-[11px] font-bold flex-shrink-0"
+                      [ngClass]="side.key === 'do' ? 'text-emerald-600 dark:text-emerald-400' : 'text-red-600 dark:text-red-400'">
+                  {{ side.key === 'do' ? doLabel : dontLabel }}
+                </span>
+                <div class="flex-grow h-5 rounded-md bg-slate-100 dark:bg-zinc-800 overflow-hidden">
+                  <div class="h-full rounded-md transition-all duration-500 flex items-center justify-end pr-2"
+                       [ngClass]="side.key === 'do' ? 'bg-emerald-500 dark:bg-emerald-500/80' : 'bg-red-500 dark:bg-red-500/80'"
+                       [style.width.%]="barWidth(median(state)!)">
+                    <span class="text-[10px] font-mono font-bold text-white whitespace-nowrap">{{ median(state) | number: '1.0-0' }} ms</span>
+                  </div>
                 </div>
+                <span class="w-32 text-[10px] font-mono text-slate-400 dark:text-zinc-500 flex-shrink-0">
+                  {{ spreadLabel(state) }}
+                </span>
               </div>
-            </div>
-            <div class="flex items-center gap-3">
-              <span class="w-14 text-right text-[11px] font-bold text-red-600 dark:text-red-400 flex-shrink-0">{{ dontLabel }}</span>
-              <div class="flex-grow h-5 rounded-md bg-slate-100 dark:bg-zinc-800 overflow-hidden">
-                <div class="h-full bg-red-500 dark:bg-red-500/80 rounded-md transition-all duration-500 flex items-center justify-end pr-2"
-                     [style.width.%]="barWidth(dontState.durationMs)">
-                  <span class="text-[10px] font-mono font-bold text-white whitespace-nowrap">{{ dontState.durationMs | number: '1.0-0' }} ms</span>
-                </div>
-              </div>
-            </div>
+            }
           </div>
           <div class="mt-3 text-xs font-medium text-slate-600 dark:text-slate-400">
-            @if (dontState.durationMs > doState.durationMs) {
-              <span class="text-emerald-600 dark:text-emerald-400 font-bold">{{ speedupLabel }}</span> — the recommended approach was faster on this run.
-            } @else {
-              On this run the two approaches were close — timing varies with hardware and model warm-up. Run again or focus on the qualitative difference in the outputs.
+            @switch (verdict) {
+              @case ('do') {
+                <span class="text-emerald-600 dark:text-emerald-400 font-bold">{{ speedupLabel }}</span> — the gap is larger than the run-to-run spread, so this is a real difference on your hardware.
+              }
+              @case ('dont') {
+                <span class="text-amber-600 dark:text-amber-400 font-bold">The "don't" side measured faster here.</span>
+                Worth investigating rather than ignoring — on some hardware the effect this lesson describes is genuinely small.
+              }
+              @default {
+                <span class="text-slate-500 dark:text-slate-400 font-bold">Within measurement noise on this device.</span>
+                The medians differ by less than the spread between repeat runs, so no winner can be claimed from this sample.
+              }
             }
           </div>
         </div>
@@ -131,13 +164,30 @@ export class PracticeComparisonComponent implements OnInit {
   @Input() doCode: string = '';
   @Input() dontCode: string = '';
   @Input() runnable: boolean = true;
+  /**
+   * Set false when the effect is smaller than on-device timing noise. The pair
+   * still runs so the outputs can be compared, but no stopwatch is shown —
+   * a misleading number is worse than no number.
+   */
+  @Input() timed: boolean = true;
+  /** Shown above the bars when the snippets report their own metric. */
+  @Input() metricLabel: string = 'User-perceived wait (reported by the snippets)';
 
-  doState: ComparisonSideState = { code: '', output: '', durationMs: null, reported: false, running: false, editorHeight: '100px' };
-  dontState: ComparisonSideState = { code: '', output: '', durationMs: null, reported: false, running: false, editorHeight: '100px' };
+  readonly REPETITIONS = 3;
+
+  doState: ComparisonSideState = this.newState();
+  dontState: ComparisonSideState = this.newState();
+
+  phase: RunPhase = 'idle';
+  repIndex = 0;
 
   readonly sides: { key: 'do' | 'dont' }[] = [{ key: 'do' }, { key: 'dont' }];
 
   constructor(private cdr: ChangeDetectorRef) {}
+
+  private newState(): ComparisonSideState {
+    return { code: '', output: '', samples: [], reported: false, running: false, editorHeight: '100px' };
+  }
 
   ngOnInit() {
     this.doState.code = this.doCode;
@@ -159,20 +209,68 @@ export class PracticeComparisonComponent implements OnInit {
     return this.doState.running || this.dontState.running;
   }
 
+  median(state: ComparisonSideState): number | null {
+    if (!state.samples.length) {
+      return null;
+    }
+    const sorted = [...state.samples].sort((a, b) => a - b);
+    const mid = Math.floor(sorted.length / 2);
+    return sorted.length % 2 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2;
+  }
+
+  private spread(state: ComparisonSideState): number {
+    if (state.samples.length < 2) {
+      return 0;
+    }
+    return Math.max(...state.samples) - Math.min(...state.samples);
+  }
+
+  spreadLabel(state: ComparisonSideState): string {
+    if (state.samples.length < 2) {
+      return 'single run';
+    }
+    return `${Math.min(...state.samples).toFixed(0)}–${Math.max(...state.samples).toFixed(0)} ms`;
+  }
+
+  /** 'do' | 'dont' when the median gap clears the noise floor, else 'noise'. */
+  get verdict(): 'do' | 'dont' | 'noise' {
+    const doMedian = this.median(this.doState);
+    const dontMedian = this.median(this.dontState);
+    if (doMedian === null || dontMedian === null) {
+      return 'noise';
+    }
+    // With only one sample each there is no spread to compare against, so the
+    // noise floor is unknown — never claim a winner.
+    if (this.doState.samples.length < 2 || this.dontState.samples.length < 2) {
+      return 'noise';
+    }
+    const noiseFloor = Math.max(this.spread(this.doState), this.spread(this.dontState));
+    const gap = dontMedian - doMedian;
+    if (gap > noiseFloor) {
+      return 'do';
+    }
+    if (-gap > noiseFloor) {
+      return 'dont';
+    }
+    return 'noise';
+  }
+
   get speedupLabel(): string {
-    if (this.doState.durationMs === null || this.dontState.durationMs === null || this.doState.durationMs <= 0) {
+    const doMedian = this.median(this.doState);
+    const dontMedian = this.median(this.dontState);
+    if (doMedian === null || dontMedian === null || doMedian <= 0) {
       return '';
     }
-    const factor = this.dontState.durationMs / this.doState.durationMs;
+    const factor = dontMedian / doMedian;
     if (factor >= 2) {
       return `${factor.toFixed(1)}× faster`;
     }
-    const saved = this.dontState.durationMs - this.doState.durationMs;
+    const saved = dontMedian - doMedian;
     return `${saved.toFixed(0)} ms saved (${((1 - 1 / factor) * 100).toFixed(0)}% faster)`;
   }
 
   barWidth(durationMs: number): number {
-    const max = Math.max(this.doState.durationMs ?? 0, this.dontState.durationMs ?? 0);
+    const max = Math.max(this.median(this.doState) ?? 0, this.median(this.dontState) ?? 0);
     if (max <= 0) {
       return 0;
     }
@@ -185,18 +283,65 @@ export class PracticeComparisonComponent implements OnInit {
     state.editorHeight = this.calculateHeight(newCode);
   }
 
-  async runBoth() {
-    // Sequential on purpose: running both at once would contend for the on-device model
-    // and skew the timing comparison.
-    await this.run('dont');
-    await this.run('do');
+  async runSingle(side: 'do' | 'dont') {
+    const state = side === 'do' ? this.doState : this.dontState;
+    state.samples = [];
+    this.phase = 'idle';
+    const ms = await this.execute(side);
+    if (ms !== null) {
+      state.samples = [ms];
+    }
+    this.cdr.detectChanges();
   }
 
-  async run(side: 'do' | 'dont') {
+  async runBoth() {
+    this.doState.samples = [];
+    this.dontState.samples = [];
+
+    if (!this.timed) {
+      await this.execute('dont');
+      await this.execute('do');
+      this.cdr.detectChanges();
+      return;
+    }
+
+    // 1. Warm-up, discarded. The first execution of either side pays for loading
+    // the model into memory; without this, whichever side ran first would carry
+    // a multi-second penalty that has nothing to do with the practice.
+    this.phase = 'warmup';
+    this.repIndex = 0;
+    this.cdr.detectChanges();
+    await this.execute('dont');
+    await this.execute('do');
+
+    // 2. Measured samples in alternating order, so any residual drift (thermal
+    // throttling, background load) is shared evenly rather than charged to one side.
+    this.phase = 'measuring';
+    const orders: ('do' | 'dont')[][] = [
+      ['do', 'dont'],
+      ['dont', 'do'],
+      ['do', 'dont'],
+    ];
+    for (let i = 0; i < this.REPETITIONS; i++) {
+      this.repIndex = i + 1;
+      for (const side of orders[i % orders.length]) {
+        const ms = await this.execute(side);
+        if (ms !== null) {
+          (side === 'do' ? this.doState : this.dontState).samples.push(ms);
+        }
+        this.cdr.detectChanges();
+      }
+    }
+
+    this.phase = 'done';
+    this.cdr.detectChanges();
+  }
+
+  /** Runs one side once and returns its duration, or null if it threw. */
+  private async execute(side: 'do' | 'dont'): Promise<number | null> {
     const state = side === 'do' ? this.doState : this.dontState;
     state.running = true;
     state.output = 'Executing…';
-    state.durationMs = null;
     this.cdr.detectChanges();
 
     const outputBuffer: string[] = [];
@@ -212,15 +357,15 @@ export class PracticeComparisonComponent implements OnInit {
       },
     };
 
-    // Snippets can call reportTiming(ms) to drive the comparison bar with a
-    // user-perceived duration (e.g. time to first token) instead of the total
-    // wall time of the snippet, which includes setup both sides share.
+    // Snippets call reportTiming(ms) to time exactly the region the lesson is
+    // about, excluding setup both sides share (session creation, model load).
     let reportedMs: number | null = null;
     const reportTiming = (ms: number) => {
       reportedMs = Number(ms);
     };
 
     const start = performance.now();
+    let failed = false;
     try {
       // Same execution strategy as CodeSnippetComponent: an async IIFE built with the
       // native parser so top-level await works regardless of TypeScript downleveling.
@@ -240,12 +385,19 @@ export class PracticeComparisonComponent implements OnInit {
         outputBuffer.push('Execution completed with no output.');
       }
     } catch (err: any) {
+      failed = true;
       outputBuffer.push('Exception: ' + (err.message || String(err)));
     }
+
+    const wallMs = performance.now() - start;
     state.reported = reportedMs !== null;
-    state.durationMs = reportedMs !== null ? reportedMs : performance.now() - start;
     state.output = outputBuffer.join('\n');
     state.running = false;
     this.cdr.detectChanges();
+
+    if (failed) {
+      return null;
+    }
+    return reportedMs !== null ? reportedMs : wallMs;
   }
 }

--- a/webapp/src/app/components/practice-mock/practice-mock.component.ts
+++ b/webapp/src/app/components/practice-mock/practice-mock.component.ts
@@ -179,13 +179,13 @@ export type PracticeMockScenario = 'prewarm' | 'clone' | 'input-hygiene' | 'cach
                       @if (side === 'do') {
                         <div class="flex items-center justify-between mb-1">
                           <span class="font-sans font-bold text-[9px] uppercase tracking-wider text-emerald-600 dark:text-emerald-400">element.innerText</span>
-                          <span class="px-1.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 font-bold">~1,200 chars</span>
+                          <span class="px-1.5 rounded bg-emerald-50 dark:bg-emerald-500/10 text-emerald-600 dark:text-emerald-400 font-bold">~2,300 chars</span>
                         </div>
                         <div>On-device AI on the web. Built-in AI APIs let websites run inference locally…</div>
                       } @else {
                         <div class="flex items-center justify-between mb-1">
                           <span class="font-sans font-bold text-[9px] uppercase tracking-wider text-red-600 dark:text-red-400">element.innerHTML</span>
-                          <span class="px-1.5 rounded bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 font-bold">~9,400 chars</span>
+                          <span class="px-1.5 rounded bg-red-50 dark:bg-red-500/10 text-red-600 dark:text-red-400 font-bold">~4,600 chars</span>
                         </div>
                         <div class="whitespace-nowrap">&lt;div class="wrapper" data-analytics-id="a-4821" style="margin:0"&gt;</div>
                         <div class="whitespace-nowrap">&nbsp;&nbsp;&lt;h1 class="title xl:text-4xl font-extrabold"&gt;On-device AI…&lt;/h1&gt;</div>
@@ -196,19 +196,19 @@ export type PracticeMockScenario = 'prewarm' | 'clone' | 'input-hygiene' | 'cach
                     <div class="flex items-center gap-2 mb-1 text-[10px] text-slate-500 dark:text-zinc-400">
                       <i class="bi bi-arrow-down"></i> tokenize + inference
                       @if (side === 'do' && on(4.6, 8)) { <span class="text-emerald-600 dark:text-emerald-400 font-bold">done in ~2 s</span> }
-                      @if (side === 'dont' && on(7.4, 8)) { <span class="text-red-600 dark:text-red-400 font-bold">~5 s — same summary</span> }
+                      @if (side === 'dont' && on(6.4, 8)) { <span class="text-red-600 dark:text-red-400 font-bold">~3.5 s — same summary</span> }
                     </div>
                     <div class="h-2 rounded-full bg-slate-100 dark:bg-zinc-800 overflow-hidden mb-3">
                       @if (side === 'do') {
                         <div class="h-full rounded-full bg-emerald-400 dark:bg-emerald-500 transition-[width] duration-150 ease-linear" [style.width.%]="frac(2, 4.5) * 100"></div>
                       } @else {
-                        <div class="h-full rounded-full bg-red-400 dark:bg-red-500/80 transition-[width] duration-150 ease-linear" [style.width.%]="frac(2, 7.4) * 100"></div>
+                        <div class="h-full rounded-full bg-red-400 dark:bg-red-500/80 transition-[width] duration-150 ease-linear" [style.width.%]="frac(2, 6.4) * 100"></div>
                       }
                     </div>
 
                     <div class="rounded-lg bg-slate-50 dark:bg-zinc-800/60 border border-slate-100 dark:border-zinc-800 p-2.5 min-h-[40px] text-slate-700 dark:text-slate-300">
                       @if (side === 'do' && on(4.6, 8)) { <i class="bi bi-card-text text-emerald-500 mr-1"></i> TL;DR: Built-in AI runs privately, on-device. }
-                      @if (side === 'dont' && on(7.4, 8)) { <i class="bi bi-card-text text-emerald-500 mr-1"></i> TL;DR: Built-in AI runs privately, on-device. }
+                      @if (side === 'dont' && on(6.4, 8)) { <i class="bi bi-card-text text-emerald-500 mr-1"></i> TL;DR: Built-in AI runs privately, on-device. }
                     </div>
                   }
 

--- a/webapp/src/app/pages/best-practices/performance/performance.page.ts
+++ b/webapp/src/app/pages/best-practices/performance/performance.page.ts
@@ -39,11 +39,12 @@ import { Component } from '@angular/core';
           </app-practice-mock>
           <div class="max-w-4xl">
             <p class="text-xs text-slate-500 dark:text-slate-500 leading-relaxed mb-2">
-              The comparison below builds the same article both ways and summarizes it. Watch the input size in the output — the markup version is several times larger before the model even starts.
+              The benchmark below builds the same article both ways and summarizes it. Watch the input size printed in the output — the markup version is about twice as large before the model even starts. It runs a discarded warm-up, then three measured samples per side, and only claims a winner when the gap beats the run-to-run spread.
             </p>
           </div>
           <app-practice-comparison
             title="Clean text input vs. raw HTML input"
+            metricLabel="summarize() inference time — summarizer creation excluded"
             [doCode]="inputDoCode"
             [dontCode]="inputDontCode">
           </app-practice-comparison>
@@ -72,6 +73,7 @@ import { Component } from '@angular/core';
           </div>
           <app-practice-comparison
             title="Cached repeat query vs. re-running inference"
+            metricLabel="Time to answer the question twice — session setup excluded"
             [doCode]="cacheDoCode"
             [dontCode]="cacheDontCode">
           </app-practice-comparison>
@@ -96,46 +98,61 @@ import { Component } from '@angular/core';
   host: { class: 'block h-full' },
 })
 export class PerformancePage {
-  inputDoCode = `// Same article, but only the text the model actually needs.
+  inputDoCode = `// A realistically sized article — one section repeated to article length.
 const article = document.createElement('article');
-article.innerHTML = \`
-  <div class="wrapper" data-analytics-id="a-4821" style="margin:0;padding:16px">
-    <h1 class="title xl:text-4xl font-extrabold">On-device AI on the web</h1>
-    <p class="lead" data-track="impression">Built-in AI APIs let websites run
-    inference locally: no API keys, no server round-trips, and user data
-    never leaves the device.</p>
-    <p><a href="/pricing?utm_source=x&utm_campaign=y">The Summarizer, Writer and
-    Rewriter APIs</a> share one lifecycle: availability, create, inference.</p>
-  </div>\`;
+article.innerHTML = Array.from({ length: 6 }, (_, i) => \`
+  <section class="prose-block" data-analytics-id="sec-\${i}" data-track="impression">
+    <h2 class="title xl:text-3xl font-extrabold tracking-tight">On-device AI, part \${i + 1}</h2>
+    <p class="lead text-slate-600" data-testid="lead-\${i}">Built-in AI APIs let websites run
+    inference locally: no API keys, no server round-trips, and user data never
+    leaves the device.</p>
+    <p class="body" style="margin:0 0 16px 0;line-height:1.6">The Summarizer, Writer and
+    Rewriter APIs share one lifecycle — availability, create, inference — so the code you
+    write for one transfers directly to the others.</p>
+    <p><a class="link underline" href="/docs?utm_source=x&utm_campaign=y">Read the guide</a>
+    for hardware requirements and download tracking.</p>
+  </section>\`).join('');
 
 const cleanText = article.innerText; // markup stripped
 console.log(\`Input size: \${cleanText.length} characters\`);
 
 const summarizer = await Summarizer.create({ type: 'tldr', length: 'short' });
+
+// Timed region: summarize() only. Creating the summarizer is identical on
+// both sides, so including it would just add shared noise.
 const start = performance.now();
 console.log(await summarizer.summarize(cleanText));
-console.log(\`Inference: \${(performance.now() - start).toFixed(0)} ms\`);
+const inference = performance.now() - start;
+console.log(\`Inference: \${inference.toFixed(0)} ms\`);
+reportTiming(inference);
 summarizer.destroy();`;
 
-  inputDontCode = `// Raw innerHTML: tags, classes and tracking attributes all become tokens.
+  inputDontCode = `// Identical article — but the raw markup is handed to the model.
 const article = document.createElement('article');
-article.innerHTML = \`
-  <div class="wrapper" data-analytics-id="a-4821" style="margin:0;padding:16px">
-    <h1 class="title xl:text-4xl font-extrabold">On-device AI on the web</h1>
-    <p class="lead" data-track="impression">Built-in AI APIs let websites run
-    inference locally: no API keys, no server round-trips, and user data
-    never leaves the device.</p>
-    <p><a href="/pricing?utm_source=x&utm_campaign=y">The Summarizer, Writer and
-    Rewriter APIs</a> share one lifecycle: availability, create, inference.</p>
-  </div>\`;
+article.innerHTML = Array.from({ length: 6 }, (_, i) => \`
+  <section class="prose-block" data-analytics-id="sec-\${i}" data-track="impression">
+    <h2 class="title xl:text-3xl font-extrabold tracking-tight">On-device AI, part \${i + 1}</h2>
+    <p class="lead text-slate-600" data-testid="lead-\${i}">Built-in AI APIs let websites run
+    inference locally: no API keys, no server round-trips, and user data never
+    leaves the device.</p>
+    <p class="body" style="margin:0 0 16px 0;line-height:1.6">The Summarizer, Writer and
+    Rewriter APIs share one lifecycle — availability, create, inference — so the code you
+    write for one transfers directly to the others.</p>
+    <p><a class="link underline" href="/docs?utm_source=x&utm_campaign=y">Read the guide</a>
+    for hardware requirements and download tracking.</p>
+  </section>\`).join('');
 
 const dirtyText = article.innerHTML; // markup included
 console.log(\`Input size: \${dirtyText.length} characters\`);
 
 const summarizer = await Summarizer.create({ type: 'tldr', length: 'short' });
+
+// Same timed region as the "do" side: summarize() only.
 const start = performance.now();
 console.log(await summarizer.summarize(dirtyText));
-console.log(\`Inference: \${(performance.now() - start).toFixed(0)} ms\`);
+const inference = performance.now() - start;
+console.log(\`Inference: \${inference.toFixed(0)} ms\`);
+reportTiming(inference);
 summarizer.destroy();`;
 
   cacheDoCode = `const TTL_MS = 60 * 60 * 1000; // 1 hour
@@ -162,6 +179,7 @@ const question = 'In one sentence, what is WebGPU?';
 
 // Note: the cache lives in sessionStorage, so if you re-run this snippet
 // BOTH attempts will be cache hits. Pass forceRefresh = true to bypass.
+const totalStart = performance.now(); // timed region: the two asks, not setup
 for (const attempt of [1, 2]) {
   const start = performance.now();
   const { value, cached } = await getAiResponse(session, question);
@@ -169,12 +187,14 @@ for (const attempt of [1, 2]) {
               \`\${(performance.now() - start).toFixed(1)} ms\`);
   console.log(value);
 }
+reportTiming(performance.now() - totalStart);
 session.destroy();`;
 
   cacheDontCode = `// Same question asked twice, full inference both times.
 const session = await LanguageModel.create();
 const question = 'In one sentence, what is WebGPU?';
 
+const totalStart = performance.now(); // same timed region as the "do" side
 for (const attempt of [1, 2]) {
   const start = performance.now();
   const value = await session.prompt(question);
@@ -182,5 +202,6 @@ for (const attempt of [1, 2]) {
               \`\${(performance.now() - start).toFixed(1)} ms\`);
   console.log(value);
 }
+reportTiming(performance.now() - totalStart);
 session.destroy();`;
 }

--- a/webapp/src/app/pages/best-practices/session-management/session-management.page.ts
+++ b/webapp/src/app/pages/best-practices/session-management/session-management.page.ts
@@ -17,6 +17,13 @@ import { Component } from '@angular/core';
           <p class="text-base text-slate-600 dark:text-slate-400 leading-relaxed">
             Creating a session is the most expensive step of using a built-in AI API — the browser may need to load model weights into memory before your first inference can run. When and how you create, reuse, and destroy sessions determines whether your feature feels instant or sluggish.
           </p>
+
+          <div class="flex items-start gap-3 p-4 rounded-xl bg-slate-50 dark:bg-zinc-800/40 border border-slate-200 dark:border-zinc-800 mt-6">
+            <i class="bi bi-rulers text-slate-400 dark:text-zinc-500 mt-0.5"></i>
+            <p class="text-xs text-slate-600 dark:text-slate-400 leading-relaxed m-0">
+              <strong>Why there's no stopwatch on this page.</strong> These three practices all save session-setup cost, and the browser loads the model only once per page — after the first run it stays resident, so a warm <code>create()</code> costs tens of milliseconds. That's smaller than the natural run-to-run variance of on-device inference, where a slightly longer response can swing a measurement by a second. Timing these in-page would produce a number that flips between runs and teaches the wrong lesson, so the snippets below print their own numbers and the animations carry the comparison. The pages with effects that reliably beat the noise — <a routerLink="/best-practices/performance" class="text-indigo-600 dark:text-indigo-400 hover:underline">Performance</a>, <a routerLink="/best-practices/streaming" class="text-indigo-600 dark:text-indigo-400 hover:underline">Streaming</a>, <a routerLink="/best-practices/structured-output" class="text-indigo-600 dark:text-indigo-400 hover:underline">Structured Output</a> — do benchmark, with repeat runs and a noise floor.
+            </p>
+          </div>
         </div>
 
         <hr class="border-t border-slate-200 dark:border-zinc-800 mb-10 max-w-4xl">
@@ -45,10 +52,11 @@ import { Component } from '@angular/core';
           </app-practice-mock>
           <div class="max-w-4xl">
             <p class="text-xs text-slate-500 dark:text-slate-500 leading-relaxed mb-2">
-              Now run it for real. The "Do" side simulates pre-warming: the session is created first (that cost happens on hover, before the click), so only the inference is on the user's critical path. The "Don't" side pays for everything after the click. Tip: run it twice — the first run also includes true cold-start loading.
+              Now run it for real. The "Do" side simulates pre-warming: the session is created first (that cost happens on hover, before the click), so only the inference is on the user's critical path. The "Don't" side pays for everything after the click. Each snippet prints its own user-perceived wait.
             </p>
           </div>
           <app-practice-comparison
+            [timed]="false"
             title="Pre-warm on intent vs. cold start on click"
             [doCode]="prewarmDoCode"
             [dontCode]="prewarmDontCode">
@@ -67,6 +75,7 @@ import { Component } from '@angular/core';
             </p>
           </div>
           <app-practice-comparison
+            [timed]="false"
             title="initialPrompts at create() vs. instructions in the first prompt"
             [doCode]="initialPromptsDoCode"
             [dontCode]="initialPromptsDontCode">
@@ -96,6 +105,7 @@ import { Component } from '@angular/core';
             dontCaption="create() every time">
           </app-practice-mock>
           <app-practice-comparison
+            [timed]="false"
             title="clone() a base session vs. create() per task"
             [doCode]="cloneDoCode"
             [dontCode]="cloneDontCode">
@@ -143,7 +153,6 @@ const result = await session.prompt(
 const wait = performance.now() - start;
 console.log(\`User-perceived wait: \${wait.toFixed(0)} ms\`);
 console.log(result);
-reportTiming(wait); // feeds the comparison bar below
 session.destroy();`;
 
   prewarmDontCode = `// Cold start: nothing happens until the user clicks "Generate".
@@ -157,7 +166,6 @@ const result = await session.prompt(
 const wait = performance.now() - start;
 console.log(\`User-perceived wait: \${wait.toFixed(0)} ms\`);
 console.log(result);
-reportTiming(wait); // feeds the comparison bar below
 session.destroy();`;
 
   initialPromptsDoCode = `// System instructions are pre-processed at creation time.
@@ -176,7 +184,6 @@ const review = await session.prompt(
 const firstPromptMs = performance.now() - start;
 console.log(\`First prompt: \${firstPromptMs.toFixed(0)} ms\`);
 console.log(review);
-reportTiming(firstPromptMs); // feeds the comparison bar below
 session.destroy();`;
 
   initialPromptsDontCode = `// Empty session: instructions travel with the first prompt,
@@ -192,7 +199,6 @@ const review = await session.prompt(
 const firstPromptMs = performance.now() - start;
 console.log(\`First prompt: \${firstPromptMs.toFixed(0)} ms\`);
 console.log(review);
-reportTiming(firstPromptMs); // feeds the comparison bar below
 session.destroy();`;
 
   cloneDoCode = `// One base session holds the instructions...

--- a/webapp/src/app/pages/best-practices/streaming/streaming.page.ts
+++ b/webapp/src/app/pages/best-practices/streaming/streaming.page.ts
@@ -39,6 +39,7 @@ import { Component } from '@angular/core';
           </app-practice-mock>
           <app-practice-comparison
             title="Streaming vs. waiting for the full response"
+            metricLabel="Time to first visible output"
             doLabel="Stream"
             dontLabel="Block"
             [doCode]="streamDoCode"
@@ -62,6 +63,7 @@ import { Component } from '@angular/core';
           </div>
           <app-practice-comparison
             title="Sanitized combined output vs. innerHTML per chunk"
+            [timed]="false"
             doLabel="Sanitize"
             dontLabel="innerHTML"
             [doCode]="sanitizeDoCode"

--- a/webapp/src/app/pages/best-practices/structured-output/structured-output.page.ts
+++ b/webapp/src/app/pages/best-practices/structured-output/structured-output.page.ts
@@ -39,6 +39,7 @@ import { Component } from '@angular/core';
           </app-practice-mock>
           <app-practice-comparison
             title="responseConstraint schema vs. 'please output JSON'"
+            metricLabel="prompt() latency — session setup excluded"
             doLabel="Schema"
             dontLabel="Prose"
             [doCode]="schemaDoCode"
@@ -59,6 +60,7 @@ import { Component } from '@angular/core';
           </div>
           <app-practice-comparison
             title="Generate freely + truncate in UI vs. 'exactly 40 characters'"
+            [timed]="false"
             doLabel="Truncate"
             dontLabel="Constrain"
             [doCode]="lengthDoCode"
@@ -102,9 +104,12 @@ const schema = {
 };
 
 const post = 'My tabby knocked the router off the shelf again. No wifi, but look at him.';
+
+const start = performance.now(); // timed region: the prompt, not session setup
 const result = await session.prompt(\`Is this post about cats?\\n\\n\${post}\`, {
   responseConstraint: schema,
 });
+reportTiming(performance.now() - start);
 
 console.log('Raw output:', result);
 const parsed = JSON.parse(result); // guaranteed to parse
@@ -114,10 +119,12 @@ session.destroy();`;
   schemaDontCode = `const session = await LanguageModel.create();
 
 const post = 'My tabby knocked the router off the shelf again. No wifi, but look at him.';
+const start = performance.now(); // same timed region as the "do" side
 const result = await session.prompt(
   'Is this post about cats? Respond ONLY with JSON like ' +
   '{"isTopicCats": true}. No other text.\\n\\n' + post
 );
+reportTiming(performance.now() - start);
 
 console.log('Raw output:', result);
 try {


### PR DESCRIPTION
## Problem

The side-by-side runners on the Best Practices pages could report the **"don't" side as faster**, inverting the lesson. Investigation found four stacked causes:

1. **Ordering + one-time model load.** `runBoth()` always ran "don't" first, so it absorbed the multi-second cold start. Run #1 wildly overstated the benefit; on every run after, the model stays resident in Chrome, a warm `create()` drops to tens of milliseconds, and the effect being taught essentially disappeared. There is no API to unload the model, so no honest second cold start is possible.
2. **Output length was uncontrolled and dominated.** The two sides sent different prompts and got different-length answers. At ~20–30 tok/s decode, a 30-token difference in chattiness is ~1.2 s of swing — an order of magnitude larger than the ~50–100 ms effects being measured. That's why "don't" didn't merely tie, it won.
3. **n = 1**, yet the UI printed `"3.2× faster"` from a single sample.
4. **Four of six comparisons timed the wrong region.** Worst was clone: the timing bar included base-session creation, contradicting both the snippet's own `console.log` and the lesson stating that cost is amortized.

## Changes

**Fair-measurement harness** in `PracticeComparisonComponent`:
- A discarded **warm-up run** per side (API-agnostic — warms whichever model the snippet uses).
- **3 measured samples per side in alternating order**, so residual drift is shared rather than charged to one side.
- **Median** comparison with a **min–max spread** shown per side.
- Verdict only names a winner when the median gap **exceeds the observed spread**; otherwise it says *"Within measurement noise on this device."* If "don't" genuinely wins, it says so rather than hiding it.

**Demoted to no-stopwatch** (`[timed]="false"`) — still runnable, still printing their own numbers, with the animated mocks carrying the lesson:
- pre-warm, initialPrompts, clone (effects below on-device noise once warm)
- the "exactly 40 characters" comparison (about output *quality*; the "don't" side generates fewer tokens so it would legitimately win on speed)
- the sanitizer demo (a security demonstration where both sides share an identical 300 ms settle delay)

Session Management now opens with a callout explaining why it has no stopwatch, linking to the pages that do benchmark.

**The four remaining benchmarks** time only the lesson's region via `reportTiming()`, each with an explicit metric label: summarize-only (excludes summarizer creation), both-queries (excludes session setup), prompt-only (excludes session setup), and time-to-first-output.

**Input-hygiene correction:** the article was only ~250 chars — likely below the noise floor — while the mock above it claimed "~1,200 vs ~9,400 chars". The article is now realistically sized, and the measured result (**2,266 vs 4,620 chars, 2.0×**, verified in-browser) is reflected in the mock's badges and timings so illustration and runnable code agree.

## Testing

- `ng build` passes; all six best-practices routes prerender.
- Verified by screenshot that Session Management renders "Run both" with no timing UI, and Performance renders "Benchmark both" with the corrected sizes.
- **Not verified:** actual on-device timings. A headless Chrome profile reports `availability: "downloadable"`, and I did not trigger a multi-GB model download. The harness logic is unexercised against a real model — worth a manual run on a machine with the model present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013P7boGwZ2Y4o9182czR3wR