### PR TITLE
Add a speech-to-text mode to the hardware dashboard

### DIFF
--- a/webapp/angular.json
+++ b/webapp/angular.json
@@ -80,8 +80,8 @@
                 },
                 {
                   "type": "anyComponentStyle",
-                  "maximumWarning": "6kB",
-                  "maximumError": "10kB"
+                  "maximumWarning": "8kB",
+                  "maximumError": "12kB"
                 }
               ],
               "outputHashing": "all",

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/audio-model-classes.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/audio-model-classes.constant.ts
@@ -1,0 +1,47 @@
+import {ModelClassEnum} from '../enums/model-class.enum';
+import {ModelClassInterface} from '../interfaces/model-class.interface';
+
+/**
+ * Whisper-family sizes, smallest first.
+ *
+ * `quantisedWeightsGb` is the *decoder* at 4-bit — the only part that streams per token —
+ * while `encoderParamsB` is the half that runs once per second of audio as dense matrix
+ * multiplication. `memoryNeededGb` is the whole model, which is small enough that memory
+ * capacity is essentially never the constraint here.
+ *
+ * None of these names a source column, because no column measures them: nothing in the
+ * dataset was benchmarked on transcription. Every figure the page shows for speech is
+ * modelled, and it says so.
+ */
+export const AUDIO_MODEL_CLASSES: ModelClassInterface[] = [
+  {
+    key: ModelClassEnum.WhisperTiny, name: 'Tiny', sizeLabel: '39M', exampleName: 'whisper-tiny',
+    multiplier: 1,
+    quantisedWeightsGb: 0.016, memoryNeededGb: 0.4, kvCacheKbPerToken: 2,
+    encoderParamsB: 0.008, contextCapTokens: 448, followsBandwidthLaw: true,
+  },
+  {
+    key: ModelClassEnum.WhisperBase, name: 'Base', sizeLabel: '74M', exampleName: 'whisper-base',
+    multiplier: 1,
+    quantisedWeightsGb: 0.027, memoryNeededGb: 0.5, kvCacheKbPerToken: 4,
+    encoderParamsB: 0.020, contextCapTokens: 448, followsBandwidthLaw: true,
+  },
+  {
+    key: ModelClassEnum.WhisperSmall, name: 'Small', sizeLabel: '244M', exampleName: 'whisper-small',
+    multiplier: 1,
+    quantisedWeightsGb: 0.078, memoryNeededGb: 0.7, kvCacheKbPerToken: 8,
+    encoderParamsB: 0.088, contextCapTokens: 448, followsBandwidthLaw: true,
+  },
+  {
+    key: ModelClassEnum.WhisperMedium, name: 'Medium', sizeLabel: '769M', exampleName: 'whisper-medium',
+    multiplier: 1,
+    quantisedWeightsGb: 0.23, memoryNeededGb: 1.2, kvCacheKbPerToken: 16,
+    encoderParamsB: 0.306, contextCapTokens: 448, followsBandwidthLaw: true,
+  },
+  {
+    key: ModelClassEnum.WhisperLarge, name: 'Large', sizeLabel: '1.5B', exampleName: 'whisper-large-v3',
+    multiplier: 1,
+    quantisedWeightsGb: 0.46, memoryNeededGb: 2, kvCacheKbPerToken: 24,
+    encoderParamsB: 0.635, contextCapTokens: 448, followsBandwidthLaw: true,
+  },
+];

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/model-classes.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/model-classes.constant.ts
@@ -1,5 +1,7 @@
 import {ModelClassEnum} from '../enums/model-class.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 import {SourceColumnEnum} from '../enums/source-column.enum';
+import {AUDIO_MODEL_CLASSES} from './audio-model-classes.constant';
 import {ModelClassInterface} from '../interfaces/model-class.interface';
 
 /**
@@ -70,8 +72,23 @@ export const MODEL_CLASSES: ModelClassInterface[] = [
 export const PROJECTED_MODEL_CLASSES: ModelClassInterface[] =
   MODEL_CLASSES.filter(modelClass => modelClass.followsBandwidthLaw);
 
+/** Every size the page can show, across both tasks. */
+export const ALL_MODEL_CLASSES: ModelClassInterface[] = [...MODEL_CLASSES, ...AUDIO_MODEL_CLASSES];
+
+/** The sizes shown for each task, in the order their columns appear. */
+export const MODEL_CLASSES_BY_MODE: Record<TaskModeEnum, ModelClassInterface[]> = {
+  [TaskModeEnum.Text]: MODEL_CLASSES,
+  [TaskModeEnum.Audio]: AUDIO_MODEL_CLASSES,
+};
+
+/** Where the Horizon chart starts in each task: the size most readers are choosing about. */
+export const DEFAULT_HORIZON_CLASS_BY_MODE: Record<TaskModeEnum, ModelClassEnum> = {
+  [TaskModeEnum.Text]: ModelClassEnum.Nano2B,
+  [TaskModeEnum.Audio]: ModelClassEnum.WhisperSmall,
+};
+
 /** Model sizes indexed by key, for the many lookups the views do. */
-export const MODEL_CLASS_BY_KEY: Record<ModelClassEnum, ModelClassInterface> = MODEL_CLASSES
+export const MODEL_CLASS_BY_KEY: Record<ModelClassEnum, ModelClassInterface> = ALL_MODEL_CLASSES
   .reduce((map, modelClass) => {
     map[modelClass.key] = modelClass;
     return map;

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/speech-model.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/speech-model.constant.ts
@@ -1,0 +1,34 @@
+import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
+
+/**
+ * Text tokens a second of speech turns into. Speech runs at roughly 2.5 words a second,
+ * so about three tokens — call it five once timestamps and beam search are counted.
+ * Greedy decoding is nearer two.
+ */
+export const DEFAULT_TOKENS_PER_SECOND_OF_AUDIO = 5;
+
+/**
+ * The encoder is compute-bound and this dataset carries only bandwidth, so compute is
+ * estimated as FLOP per byte of bandwidth. It is the one figure on the page not derived
+ * from the data, and it is calibrated against published whisper-large throughput.
+ */
+export const DEFAULT_FLOP_PER_BYTE: Record<HardwareSegmentEnum, number> = {
+  [HardwareSegmentEnum.DiscreteGpu]: 30,
+  [HardwareSegmentEnum.AppleSoc]: 10,
+  [HardwareSegmentEnum.CpuIntegrated]: 4,
+  [HardwareSegmentEnum.Edge]: 2.5,
+};
+
+/** Encoder positions per second of audio: 3000 spectrogram frames per 30 seconds, halved twice. */
+export const ENCODER_FRAMES_PER_SECOND = 50;
+
+/** Bounds for the two speech figures, as the inputs enforce them. */
+export const TOKENS_PER_SECOND_RANGE = {min: 1, max: 40, step: 0.5};
+export const FLOP_PER_BYTE_RANGE = {min: 0.5, max: 200, step: 0.5};
+
+/**
+ * The share of realised bandwidth a decode step converts into tokens. The text classes
+ * all settle near this, and no source measures a speech model, so the speech decoder
+ * borrows it rather than inventing one.
+ */
+export const SPEECH_DECODER_EFFICIENCY = 0.57;

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/speed-bands.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/speed-bands.constant.ts
@@ -1,6 +1,13 @@
 import {SpeedBandEnum} from '../enums/speed-band.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 
-/** Slowest first, so the index doubles as the step of the speed ramp. */
+/**
+ * Slowest first, so the index doubles as the step of the speed ramp.
+ *
+ * One set of names for both tasks. A reader who has learned what "readable" looks like on
+ * a matrix of text speeds should not have to learn a second vocabulary to read the same
+ * matrix of transcription speeds — only the numbers behind the names change with the task.
+ */
 export const SPEED_BAND_META: {key: SpeedBandEnum, name: string}[] = [
   {key: SpeedBandEnum.Crawling, name: 'crawling'},
   {key: SpeedBandEnum.Slow, name: 'slow'},
@@ -15,8 +22,33 @@ export const SPEED_BAND_META: {key: SpeedBandEnum, name: string}[] = [
  */
 export const DEFAULT_BAND_EDGES = [10, 20, 35, 50];
 
+/**
+ * The same four edges for transcription, in multiples of realtime. 1× is the one that
+ * matters — below it the machine falls behind the recording.
+ */
+export const DEFAULT_AUDIO_BAND_EDGES = [1, 3, 10, 30];
+
+export const BAND_EDGES_BY_MODE: Record<TaskModeEnum, number[]> = {
+  [TaskModeEnum.Text]: DEFAULT_BAND_EDGES,
+  [TaskModeEnum.Audio]: DEFAULT_AUDIO_BAND_EDGES,
+};
+
+/** Top of the slider range, in each task's own unit. */
+export const BAND_SLIDER_MAX_BY_MODE: Record<TaskModeEnum, number> = {
+  [TaskModeEnum.Text]: 90,
+  [TaskModeEnum.Audio]: 60,
+};
+
+/** Short and long forms of what a figure is counted in. */
+export const BAND_UNIT_BY_MODE: Record<TaskModeEnum, string> = {
+  [TaskModeEnum.Text]: 'tok/s',
+  [TaskModeEnum.Audio]: '×',
+};
+
+export const BAND_UNIT_LONG_BY_MODE: Record<TaskModeEnum, string> = {
+  [TaskModeEnum.Text]: 'tok/s',
+  [TaskModeEnum.Audio]: '× realtime',
+};
+
 /** Fastest band the reader is likely to care about, used as the forecast reference. */
 export const DEFAULT_REFERENCE_BAND_INDEX = 3;
-
-/** Top of the slider range, tok/s. */
-export const BAND_SLIDER_MAX = 90;

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/task-copy.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/task-copy.constant.ts
@@ -1,0 +1,21 @@
+import {TaskModeEnum} from '../enums/task-mode.enum';
+
+/** The short strings that name a task, wherever a view has to say which one it is showing. */
+export interface TaskCopyInterface {
+  /** How the switch names this task. */
+  switchLabel: string;
+
+  /** How the eyebrow describes the columns. */
+  sizesLabel: string;
+}
+
+export const TASK_COPY: Record<TaskModeEnum, TaskCopyInterface> = {
+  [TaskModeEnum.Text]: {
+    switchLabel: 'Text \u2192 text',
+    sizesLabel: 'eight model sizes',
+  },
+  [TaskModeEnum.Audio]: {
+    switchLabel: 'Speech \u2192 text',
+    sizesLabel: 'five transcription model sizes',
+  },
+};

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/url-params.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/url-params.constant.ts
@@ -3,6 +3,7 @@
  * lists, and stable, because they end up in URLs people paste to each other.
  */
 export const URL_PARAMS = {
+  mode: 'task',
   tab: 'view',
   year: 'year',
   modelled: 'modelled',
@@ -13,6 +14,8 @@ export const URL_PARAMS = {
   context: 'ctx',
   realised: 'realised',
   overhead: 'overhead',
+  audioTokens: 'asrTok',
+  flopPerByte: 'flopByte',
   grouping: 'group',
   matrixFilter: 'only',
   matrixSearch: 'q',

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/url-params.constant.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/constants/url-params.constant.ts
@@ -1,0 +1,24 @@
+/**
+ * Query-parameter names for the shareable view. Short, because several of them carry
+ * lists, and stable, because they end up in URLs people paste to each other.
+ */
+export const URL_PARAMS = {
+  tab: 'view',
+  year: 'year',
+  modelled: 'modelled',
+  advanced: 'tuner',
+  bandLows: 'bands',
+  /** Only written when the reader has left a band's ceiling disagreeing with its neighbour. */
+  bandHighs: 'bandsTo',
+  context: 'ctx',
+  realised: 'realised',
+  overhead: 'overhead',
+  grouping: 'group',
+  matrixFilter: 'only',
+  matrixSearch: 'q',
+  explorerSearch: 'dq',
+  sort: 'sort',
+  horizonClass: 'size',
+  horizonYears: 'years',
+  horizonCategories: 'cats',
+} as const;

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.html
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.html
@@ -14,27 +14,58 @@
 
         <p class="text-[11px] font-mono uppercase tracking-[0.14em] text-slate-400 dark:text-slate-500 mb-3">
           @if (dataset) {
-            {{ dataset.devices.length }} machines · {{ yearRangeLabel }} · eight model sizes
+            {{ dataset.devices.length }} machines · {{ yearRangeLabel }} · {{ taskCopy.sizesLabel }}
           } @else {
             Consumer hardware · local inference
           }
         </p>
 
-        <h1 class="text-3xl md:text-4xl xl:text-[2.9rem] font-extrabold text-slate-900 dark:text-white tracking-tight leading-[1.05] mb-4">
-          Local models run at the speed of the
-          <span class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 to-violet-600 dark:from-indigo-400 dark:to-violet-400">memory bus</span>.
-        </h1>
+        <!-- Two different questions of the same machines, not two filters on one answer:
+             each task has its own model sizes, its own arithmetic and its own unit. -->
+        <div class="inline-flex items-center p-1 rounded-xl bg-slate-100 dark:bg-zinc-800/80 mb-4"
+             role="group" aria-label="What the hardware is being asked to do">
+          @for (option of [modeEnum.Text, modeEnum.Audio]; track option) {
+            <button type="button" class="px-3.5 py-1.5 rounded-lg text-xs font-semibold transition-all duration-150 border-none"
+                    [attr.aria-pressed]="mode === option"
+                    [ngClass]="mode === option
+                      ? 'bg-[#ffffff] dark:bg-zinc-700 !text-slate-900 dark:!text-white shadow-sm ring-1 ring-slate-200/60 dark:ring-zinc-600/50'
+                      : 'bg-transparent !text-slate-500 dark:!text-slate-400 hover:!text-slate-800 dark:hover:!text-slate-200'"
+                    (click)="onModeChange(option)">{{ taskCopyFor(option).switchLabel }}</button>
+          }
+        </div>
 
-        <p class="text-base text-slate-600 dark:text-slate-400 leading-relaxed max-w-2xl mb-5">
-          Generating a token means reading the whole model out of memory, so how fast a machine answers comes down to
-          how fast its memory bus is. Two things stand between the spec sheet and reality: a machine only
-          <strong class="text-slate-900 dark:text-slate-100">realises part of its rated peak</strong>
-          @if (realisedRangeLabel) { ({{ realisedRangeLabel }} here) },
-          and the engine only keeps part of what it gets
-          @if (engineShareRangeLabel) { — <strong class="text-slate-900 dark:text-slate-100">{{ engineShareRangeLabel }}</strong> of a token goes on streaming weights, least on the smallest models },
-          because fixed per-token overhead swamps a small model's streaming time. Both are tunable in Advanced
-          settings. Pick a year to see what each kind of consumer hardware averaged on each size of model.
-        </p>
+        @if (isAudio) {
+          <h1 class="text-3xl md:text-4xl xl:text-[2.9rem] font-extrabold text-slate-900 dark:text-white tracking-tight leading-[1.05] mb-4">
+            Transcription is a
+            <span class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 to-violet-600 dark:from-indigo-400 dark:to-violet-400">compute</span>
+            problem with a memory tail.
+          </h1>
+
+          <p class="text-base text-slate-600 dark:text-slate-400 leading-relaxed max-w-2xl mb-5">
+            A Whisper-style model does two different jobs for every second of audio: an encoder pass over 50 frames,
+            which is pure compute and never autoregressive, then a handful of decoder tokens, which stream weights out
+            of memory like any other model. The encoder dominates on slow machines and the decoder's per-token
+            overhead on fast ones. Everything below is speed against realtime —
+            <strong class="text-slate-900 dark:text-slate-100">1× transcribes an hour of audio in an hour</strong>.
+            Pick a year to see what each kind of consumer hardware managed.
+          </p>
+        } @else {
+          <h1 class="text-3xl md:text-4xl xl:text-[2.9rem] font-extrabold text-slate-900 dark:text-white tracking-tight leading-[1.05] mb-4">
+            Local models run at the speed of the
+            <span class="text-transparent bg-clip-text bg-gradient-to-r from-indigo-600 to-violet-600 dark:from-indigo-400 dark:to-violet-400">memory bus</span>.
+          </h1>
+
+          <p class="text-base text-slate-600 dark:text-slate-400 leading-relaxed max-w-2xl mb-5">
+            Generating a token means reading the whole model out of memory, so how fast a machine answers comes down to
+            how fast its memory bus is. Two things stand between the spec sheet and reality: a machine only
+            <strong class="text-slate-900 dark:text-slate-100">realises part of its rated peak</strong>
+            @if (realisedRangeLabel) { ({{ realisedRangeLabel }} here) },
+            and the engine only keeps part of what it gets
+            @if (engineShareRangeLabel) { — <strong class="text-slate-900 dark:text-slate-100">{{ engineShareRangeLabel }}</strong> of a token goes on streaming weights, least on the smallest models },
+            because fixed per-token overhead swamps a small model's streaming time. Both are tunable in Advanced
+            settings. Pick a year to see what each kind of consumer hardware averaged on each size of model.
+          </p>
+        }
 
         @if (efficiencyItems.length) {
           <ul class="flex flex-wrap gap-x-4 gap-y-1.5 list-none p-0 m-0 font-mono text-[11px] text-slate-400 dark:text-slate-500">
@@ -81,7 +112,7 @@
           <p class="font-mono text-[10.5px] text-slate-400 dark:text-slate-500 mt-3 mb-2.5">{{ yearHint }}</p>
 
           <div class="overflow-x-auto">
-            <div class="min-w-[600px]" style="--chw-label-width: 104px">
+            <div class="min-w-[600px]" [style]="{'--chw-label-width': '104px', '--chw-columns': modelClasses.length}">
               <div class="chw-matrix-row mb-1">
                 <div></div>
                 @for (modelClass of modelClasses; track modelClass.key) {
@@ -123,14 +154,20 @@
             @for (band of bandsFastestFirst; track band.key) {
               <span class="flex items-center gap-1.5">
                 <span class="w-3 h-3 rounded-sm chw-fill-swatch" [attr.data-speed]="band.index"></span>
-                {{ band.name }} · {{ band.rangeLabel }}
+                {{ band.name }} · {{ withUnit(band.rangeLabel) }}
               </span>
             }
             <span class="flex items-center gap-1.5">
               <span class="w-3 h-3 rounded-sm chw-cell-hatched border border-slate-200 dark:border-zinc-800"></span>
               won't fit
             </span>
-            <span class="ml-auto font-mono text-[10px] text-slate-400 dark:text-slate-500">{{ model.contextLabel }} context · hover any cell for tok/s</span>
+            <span class="ml-auto font-mono text-[10px] text-slate-400 dark:text-slate-500">
+              @if (isAudio) {
+                {{ audioContextCap }}-token window · hover any cell for {{ unitLong }}
+              } @else {
+                {{ model.contextLabel }} context · hover any cell for {{ unit }}
+              }
+            </span>
           </div>
         } @else {
           <div class="h-72 rounded-2xl bg-slate-50 dark:bg-zinc-900/60 animate-pulse"></div>
@@ -153,13 +190,21 @@
         <span class="font-mono text-[10px] opacity-60">{{ advancedSummary }}</span>
       </button>
 
-      <label class="flex items-center gap-2 text-xs text-slate-500 dark:text-slate-400 cursor-pointer select-none">
-        <input type="checkbox" class="chw-range w-4 h-4" [checked]="showModelledValues" (change)="onModelledToggle($event)">
+      <!-- Nothing in the file was benchmarked on transcription, so there are no gaps to
+           fill in there and the switch has nothing to act on. It keeps its label either
+           way: it is the same control, not a different one. -->
+      <label class="flex items-center gap-2 text-xs select-none"
+             [ngClass]="isAudio
+               ? 'text-slate-300 dark:text-slate-600 cursor-not-allowed'
+               : 'text-slate-500 dark:text-slate-400 cursor-pointer'"
+             [attr.title]="isAudio ? 'Every transcription figure is modelled — there is nothing measured to fall back to' : null">
+        <input type="checkbox" class="chw-range w-4 h-4" [checked]="showModelledValues" [disabled]="isAudio"
+               (change)="onModelledToggle($event)">
         Fill gaps with modelled values
       </label>
 
       <div class="flex items-center p-1 rounded-xl bg-slate-100 dark:bg-zinc-800/80 ml-auto" role="tablist" aria-label="Dashboard views">
-        @for (tab of [tabEnum.Horizon, tabEnum.Matrix, tabEnum.Explorer]; track tab) {
+        @for (tab of [tabEnum.Horizon, tabEnum.Matrix, tabEnum.Explorer, tabEnum.Notes]; track tab) {
           <button type="button" role="tab" class="px-3.5 py-1.5 rounded-lg text-xs font-semibold capitalize transition-all duration-150 border-none"
                   [id]="'chw-tab-' + tab"
                   [attr.aria-controls]="'chw-panel-' + tab"
@@ -167,7 +212,7 @@
                   [ngClass]="activeTab === tab
                     ? 'bg-[#ffffff] dark:bg-zinc-700 !text-slate-900 dark:!text-white shadow-sm ring-1 ring-slate-200/60 dark:ring-zinc-600/50'
                     : 'bg-transparent !text-slate-500 dark:!text-slate-400 hover:!text-slate-800 dark:hover:!text-slate-200'"
-                  (click)="onTabChange(tab)">{{ tab === tabEnum.Explorer ? 'Data Explorer' : tab }}</button>
+                  (click)="onTabChange(tab)">{{ tabLabel(tab) }}</button>
         }
       </div>
     </div>
@@ -175,7 +220,7 @@
     @if (advancedOpen) {
       <div id="chw-advanced" class="max-w-7xl mx-auto px-6 pb-3 pt-1 border-t border-slate-100 dark:border-zinc-800/70 flex flex-wrap items-start gap-x-5 gap-y-3">
         <span class="font-mono text-[10px] uppercase tracking-[0.1em] text-slate-400 dark:text-slate-500 whitespace-nowrap pt-2">
-          Speed bands · tok/s
+          Speed bands · {{ unitLong }}
         </span>
 
         <!-- Five bands, five columns, so the scale reads left to right as one strip. -->
@@ -199,11 +244,11 @@
                 <div class="chw-fill-bar" [style.left.%]="slider.fillLeftPercent" [style.right.%]="slider.fillRightPercent"></div>
                 <input type="range" min="0" [max]="sliderMax" step="1" [value]="slider.lowPosition"
                        [disabled]="slider.lowLocked"
-                       [attr.aria-label]="slider.lowLocked ? slider.name + ' starts at zero' : slider.name + ' starts at, tokens per second'"
+                       [attr.aria-label]="slider.lowLocked ? slider.name + ' starts at zero' : slider.name + ' starts at, ' + unitLong"
                        (input)="onBandEdgeInput(slider.index, 'low', $event)">
                 <input type="range" min="0" [max]="sliderMax" step="1" [value]="slider.highPosition"
                        [disabled]="slider.highLocked"
-                       [attr.aria-label]="slider.highLocked ? slider.name + ' has no ceiling' : slider.name + ' ends at, tokens per second'"
+                       [attr.aria-label]="slider.highLocked ? slider.name + ' has no ceiling' : slider.name + ' ends at, ' + unitLong"
                        (input)="onBandEdgeInput(slider.index, 'high', $event)">
               </div>
             </div>
@@ -225,6 +270,39 @@
             <span class="font-mono text-xs font-semibold text-slate-900 dark:text-white min-w-[96px]">{{ contextValueLabel }}</span>
             <span class="font-mono text-[10.5px] text-slate-400 dark:text-slate-500">{{ contextCostHint }}</span>
           </div>
+
+          @if (isAudio) {
+            <div class="flex flex-wrap items-center gap-2">
+              <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-slate-400 dark:text-slate-500 min-w-[132px]">Transcription</span>
+
+              <label class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 dark:border-zinc-800 bg-[#ffffff] dark:bg-[#161616] pl-2.5 pr-1.5 py-1 text-[11.5px] text-slate-600 dark:text-slate-400">
+                <span>Text tokens / s of audio</span>
+                <input type="number" class="w-[52px] text-right font-mono text-[11.5px] px-1 py-0.5 rounded border border-slate-200 dark:border-zinc-700 bg-slate-50 dark:bg-zinc-800 text-slate-900 dark:text-slate-100"
+                       [min]="audioTokensRange.min" [max]="audioTokensRange.max" [step]="audioTokensRange.step"
+                       [value]="model.tokensPerSecondOfAudio"
+                       aria-label="Text tokens per second of audio"
+                       (input)="onAudioTokens($event)">
+              </label>
+
+              @for (segment of segments; track segment) {
+                <label class="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 dark:border-zinc-800 bg-[#ffffff] dark:bg-[#161616] pl-2.5 pr-1.5 py-1 text-[11.5px] text-slate-600 dark:text-slate-400">
+                  <span>{{ segmentLabels[segment] }}</span>
+                  <input type="number" class="w-[52px] text-right font-mono text-[11.5px] px-1 py-0.5 rounded border border-slate-200 dark:border-zinc-700 bg-slate-50 dark:bg-zinc-800 text-slate-900 dark:text-slate-100"
+                         [min]="flopPerByteRange.min" [max]="flopPerByteRange.max" [step]="flopPerByteRange.step"
+                         [value]="model.flopPerByte[segment]"
+                         [attr.aria-label]="segmentLabels[segment] + ' compute, FLOP per byte of bandwidth'"
+                         (input)="onFlopPerByte(segment, $event)">
+                  <span class="text-[10px] text-slate-400 dark:text-slate-500">FLOP/B</span>
+                </label>
+              }
+
+              <span class="basis-full font-mono text-[10.5px] text-slate-400 dark:text-slate-500">
+                the encoder is compute-bound and this dataset only carries bandwidth, so compute is estimated as FLOP
+                per byte of bandwidth — the one figure here not derived from the data. Token rate covers beam search
+                and timestamps; greedy decoding is nearer 2.
+              </span>
+            </div>
+          }
 
           <div class="flex flex-wrap items-center gap-2">
             <span class="font-mono text-[10.5px] uppercase tracking-[0.12em] text-slate-400 dark:text-slate-500 min-w-[132px]">Realised bandwidth</span>
@@ -344,7 +422,7 @@
                while the rows go by. Capped short of the viewport so the page around it
                stays obviously scrollable. -->
           <div class="overflow-auto lg:max-h-[620px] rounded-lg">
-            <div class="min-w-[980px]">
+            <div class="min-w-[980px]" [style]="{'--chw-columns': modelClasses.length}">
 
               <div class="chw-matrix-row sticky top-0 z-10 bg-[#ffffff] dark:bg-[#121212] pb-1.5 pt-1">
                 <div></div>
@@ -408,7 +486,7 @@
             @for (band of bandsFastestFirst; track band.key) {
               <span class="flex items-center gap-1.5">
                 <span class="w-3 h-3 rounded-sm chw-fill-swatch" [attr.data-speed]="band.index"></span>
-                {{ band.name }} · {{ band.rangeLabel }}
+                {{ band.name }} · {{ withUnit(band.rangeLabel) }}
               </span>
             }
             <span class="flex items-center gap-1.5">
@@ -500,9 +578,15 @@
                 Where each kind of hardware is heading
               </h2>
               <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed mb-4">
-                The table at the top of the page shows one year at a time. This is every year at once — the average
-                speed each category of machine manages on a given size of model, from {{ yearRangeLabel }}, and where
-                its own trend points next.
+                @if (isAudio) {
+                  The table at the top of the page shows one year at a time. This is every year at once — how fast each
+                  category of machine transcribes at a given model size, from {{ yearRangeLabel }}, and where its own
+                  trend points next.
+                } @else {
+                  The table at the top of the page shows one year at a time. This is every year at once — the average
+                  speed each category of machine manages on a given size of model, from {{ yearRangeLabel }}, and where
+                  its own trend points next.
+                }
               </p>
               <p class="text-sm text-slate-600 dark:text-slate-400 leading-relaxed">
                 Each line is fitted from that category's own history and nothing else. It is not a roadmap or a leak;
@@ -518,14 +602,25 @@
                   The solid line is measured hardware, averaged per year. Dashed beyond it is extrapolation, on the
                   shaded side of the chart.
                 </li>
-                <li>
-                  Background stripes are the speed bands you set in Advanced settings, named down both edges. A line
-                  entering the green stripe is a category that has become <em>fast enough</em> for that model size.
-                </li>
-                <li>
-                  Where a line stops or never starts, either the machines of that category cannot hold the model, or
-                  the source has no figure for it — the Tiny row is measured only, never modelled.
-                </li>
+                @if (isAudio) {
+                  <li>
+                    Background stripes are the speed bands you set in Advanced settings, named down both edges. A line
+                    above the 1× stripe transcribes <em>faster than the audio plays</em>.
+                  </li>
+                  <li>
+                    Every figure here is modelled — no machine in this dataset was benchmarked on transcription. The
+                    encoder half rests on a compute estimate, which is the least certain thing on the page.
+                  </li>
+                } @else {
+                  <li>
+                    Background stripes are the speed bands you set in Advanced settings, named down both edges. A line
+                    entering the green stripe is a category that has become <em>fast enough</em> for that model size.
+                  </li>
+                  <li>
+                    Where a line stops or never starts, either the machines of that category cannot hold the model, or
+                    the source has no figure for it — the Tiny row is measured only, never modelled.
+                  </li>
+                }
               </ol>
             </div>
           </div>
@@ -617,7 +712,7 @@
                           [attr.y1]="horizonChart.plotTop" [attr.y2]="horizonChart.plotBottom"></line>
                     <line class="chw-axis-line" [attr.x1]="horizonChart.plotLeft" [attr.x2]="horizonChart.plotRight"
                           [attr.y1]="horizonChart.plotBottom" [attr.y2]="horizonChart.plotBottom"></line>
-                    <text class="chw-mark-label-strong" text-anchor="end" [attr.x]="horizonChart.plotLeft - 8" [attr.y]="horizonChart.plotTop - 14">tok/s</text>
+                    <text class="chw-mark-label-strong" text-anchor="end" [attr.x]="horizonChart.plotLeft - 8" [attr.y]="horizonChart.plotTop - 14">{{ unitLong }}</text>
 
                     @for (series of horizonChart.series; track series.type) {
                       @if (series.projectedPoints) {
@@ -690,15 +785,294 @@
         </section>
       }
 
+      <!-- ── How it works ──────────────────────────────────────────────────── -->
+      @if (activeTab === tabEnum.Notes) {
+        <section id="chw-panel-notes" role="tabpanel" aria-labelledby="chw-tab-notes" tabindex="0"
+                 class="chw-article max-w-[72ch]">
+
+          @if (isAudio) {
+            <h2>How transcription spends its time</h2>
+            <p class="chw-standfirst">
+              Speech recognition looks like a language model and behaves like something else entirely. Half of the work
+              is a compute-bound pass that never generates a token, and the half that does generate tokens only needs a
+              handful of them per second of audio. Both halves matter, and which one is holding you up depends on what
+              you are running it on.
+            </p>
+
+            <h3>What actually happens to a second of audio</h3>
+            <p>A Whisper-style model runs a fixed pipeline on a 30-second window.</p>
+            <p>
+              The audio becomes a <b>log-Mel spectrogram</b>, 3000 frames for those 30 seconds. Two strided convolutions
+              halve that to 1500 positions — <b>50 for every second of audio</b>, regardless of how fast anybody is
+              speaking.
+            </p>
+            <p>
+              The <b>encoder</b> then processes all 1500 positions in a single forward pass. There is no autoregression
+              here and nothing to wait for: it is a stack of large dense matrix multiplications with high arithmetic
+              intensity, which is to say it is compute-bound in the ordinary way that training is compute-bound. It does
+              not care much about memory bandwidth.
+            </p>
+            <p>
+              The <b>decoder</b> then writes text, one token at a time, cross-attending to what the encoder produced.
+              This half <em>is</em> memory-bound and behaves exactly like a small language model. But speech is only
+              about 2.5 words a second, so a second of audio needs roughly three text tokens — call it five once
+              timestamps and beam search are included. Compare that with the 50 encoder positions and the shape of the
+              problem becomes clear.
+            </p>
+
+            <h3>The two costs of a second of audio</h3>
+            <p class="chw-calc">
+              encoder = 2 × encoder params × 50 frames ÷ effective FLOPS<br>
+              decoder = tokens × [ (decoder weights + cache) ÷ (bandwidth × realised) + overhead ]<br>
+              × realtime = 1000 ÷ (encoder ms + decoder ms)
+            </p>
+            <p>
+              For whisper-large-v3 the encoder is 635M of the 1.55B parameters, so it costs about
+              <b>63.5 GFLOP per second of audio</b> — a fixed toll that does not depend on how fast your memory is. The
+              decoder's 915M parameters at 4-bit are only 0.46 GB, and it reads them about five times a second. Memory
+              capacity is essentially never the constraint here: the entire model fits in under a gigabyte.
+            </p>
+            <p>
+              This page has bandwidth figures for every machine but no compute figures, so effective FLOPS are estimated
+              as a fixed ratio of FLOP per byte of bandwidth — around 30 for graphics cards, 4 for laptop chips. It is
+              the least certain assumption on the site, it is tunable in Advanced settings, and it is calibrated against
+              published whisper-large throughput.
+            </p>
+
+            <h3>Four machines, worked through</h3>
+            <div class="overflow-x-auto">
+              <table class="chw-worked">
+                <thead>
+                  <tr><th>Machine</th><th>Model</th><th>Compute</th><th>Encoder</th><th>Decoder</th><th>Result</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>RTX 4090</td><td>large-v3</td><td>25.7 TFLOPS</td><td>2.5 ms</td><td>12.7 ms</td><td><b>66× realtime</b></td></tr>
+                  <tr><td>M4 Max</td><td>large-v3</td><td>4.6 TFLOPS</td><td>13.7 ms</td><td>55.1 ms</td><td><b>15×</b></td></tr>
+                  <tr><td>Lunar Lake laptop</td><td>large-v3</td><td>0.27 TFLOPS</td><td>231.8 ms</td><td>259.3 ms</td><td><b>2.0×</b></td></tr>
+                  <tr><td>Raspberry Pi 5</td><td>small</td><td>0.02 TFLOPS</td><td>460.1 ms</td><td>453.2 ms</td><td><b>1.1×</b></td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              The interesting column is the split. On a 4090 the decoder costs five times the encoder — the machine is
+              fast enough that the fixed per-token overhead of five decoder steps outweighs a 63 GFLOP matmul. On the
+              laptop and the Pi the two halves are nearly equal. Different machines are bottlenecked at different ends
+              of the same model, and an optimisation that transforms one will do nothing for the other.
+            </p>
+            <p>
+              Note also what transcription makes possible. A Raspberry Pi 5 cannot hold a conversation with any text
+              model on this page — it crawls on everything. It transcribes with whisper-small faster than the audio
+              plays.
+            </p>
+
+            <h3>Where software makes the difference</h3>
+            <p>
+              <b>Silence is free if you remove it.</b> Voice activity detection is usually the largest single win on
+              real recordings, and it is not an optimisation of the model at all. Meetings, interviews and voice notes
+              are commonly 20–50% silence; cutting it removes that share of the work outright. Nothing else on this list
+              is so cheap.
+            </p>
+            <p>
+              <b>Batch the encoder.</b> Long audio is a sequence of independent 30-second windows, and the encoder is
+              compute-bound, so pushing several windows through together fills the machine properly. Batched pipelines
+              routinely give 3–5× on long files. This is the opposite of the text case, where batching does nothing for
+              a single user.
+            </p>
+            <p>
+              <b>Beam size is a direct multiplier on the decoder half.</b> Going from beam 5 to greedy cuts decoder work
+              by most of that factor. On a 4090, where the decoder is 84% of the time, that is transformative; on a Pi
+              it is worth about half. Accuracy loss is small on clean audio and more noticeable on hard audio.
+            </p>
+            <p>
+              <b>Distilled models attack the same half structurally.</b> distil-large-v3 keeps the full encoder but
+              replaces the 32-layer decoder with 2, so the decoder term nearly vanishes while accuracy stays within
+              about a point of the original. On decoder-bound hardware this is close to a free 3–5×.
+            </p>
+            <p>
+              <b>The runtime is worth more here than in text.</b> CTranslate2 and whisper.cpp are typically several
+              times faster than the reference PyTorch implementation at identical output, because the reference was
+              written to be readable. Very few workloads on this page have that much headroom sitting in the engine
+              choice.
+            </p>
+            <p>
+              <b>Consider leaving the architecture behind.</b> CTC and transducer models — Parakeet, Canary — have no
+              autoregressive decoder at all. They emit the whole transcript in one pass, deleting the entire second half
+              of this article's arithmetic, and reach thousands of times realtime on a graphics card. The trade is less
+              robust formatting, weaker punctuation and no free translation.
+            </p>
+            <p>
+              <b>Quantisation helps less than it does for text.</b> The decoder half responds the same way, but the
+              encoder is compute-bound, so shrinking its weights does not speed it up unless the hardware has genuinely
+              faster low-precision matmul to exploit.
+            </p>
+
+            <h3>What this model does not capture</h3>
+            <p>
+              No machine in this dataset was benchmarked on transcription, so every figure here is modelled, and the
+              encoder half rests on a compute estimate rather than a measurement. Accuracy is ignored entirely — a model
+              that runs at 40× and mangles names is not better than one at 10× that does not. Long-form scheduling, VAD,
+              and chunking strategy can move real throughput by more than the hardware differences shown here. And
+              streaming transcription, where latency matters more than throughput, is a different problem with a
+              different answer.
+            </p>
+          } @else {
+            <h2>How text generation spends its time</h2>
+            <p class="chw-standfirst">
+              Every number on this page comes out of one observation: to produce a single token, a language model has to
+              read all of its weights. That one fact decides which hardware matters, which upgrades are wasted, and why
+              a laptop that benchmarks well feels slow.
+            </p>
+
+            <h3>Two phases, two different machines</h3>
+            <p>Answering a prompt is not one workload but two, and they stress opposite parts of a computer.</p>
+            <p>
+              <b>Prefill</b> reads your prompt. Every prompt token is processed at once, in parallel, as a few very
+              large matrix multiplications. There is plenty of arithmetic per byte fetched, so the compute units stay
+              busy and the memory bus is not the limit. Prefill decides your <em>time to first token</em>, and it is why
+              a long document takes a moment before anything appears.
+            </p>
+            <p>
+              <b>Decode</b> writes the answer, one token at a time. Each token depends on the one before it, so there is
+              nothing to parallelise. To produce it, the machine reads every weight in the model, does about two
+              floating-point operations per byte it fetched, and throws the weights away — then does it again for the
+              next token. Decode decides your <em>tokens per second</em>, and it is the phase this page models.
+            </p>
+            <p>
+              At batch size one, decode has an arithmetic intensity of roughly 1 FLOP per byte. A modern GPU can sustain
+              a hundred or more. The compute units spend almost all of their time waiting for memory, which is why a
+              graphics card's advertised TFLOPS tell you very little about how fast it will chat with you, and its GB/s
+              tell you almost everything.
+            </p>
+
+            <h3>The three costs of a token</h3>
+            <p>Every generated token pays for three things:</p>
+            <ol>
+              <li><b>The weights.</b> An 8B model at 4-bit is about 4.7 GB. All of it moves, every token.</li>
+              <li>
+                <b>The KV cache.</b> Attention re-reads the key and value vectors of every previous token. The cache
+                grows with the conversation, and at 4K context on an 8B model it adds about 0.5 GB to each token's
+                traffic.
+              </li>
+              <li>
+                <b>A fixed overhead.</b> Kernel launches, sampling, attention bookkeeping, framework dispatch. It is
+                roughly constant — a few milliseconds — and does not shrink when the model does. This is the term most
+                people leave out, and it is the one that explains the odd results.
+              </li>
+            </ol>
+            <p class="chw-calc">
+              time per token = (weights + cache) ÷ (bandwidth × realised) + overhead<br>
+              tokens per second = 1000 ÷ time per token
+            </p>
+            <p>
+              <em>Realised</em> matters. No machine moves data at its rated peak. A graphics card gets close to 85%; a
+              laptop running on system RAM manages about half that, partly because it has two memory channels instead of
+              a wide GDDR bus, and partly because dequantising 4-bit weights costs enough compute that the CPU cannot
+              even issue memory requests fast enough to saturate what it has.
+            </p>
+
+            <h3>Three machines, worked through</h3>
+            <div class="overflow-x-auto">
+              <table class="chw-worked">
+                <thead>
+                  <tr><th>Machine</th><th>Model</th><th>Bandwidth</th><th>Stream</th><th>Overhead</th><th>Result</th></tr>
+                </thead>
+                <tbody>
+                  <tr><td>RTX 4090</td><td>8B</td><td>1008 × 85% = 857 GB/s</td><td>5.2 GB ÷ 857 = 5.6 ms</td><td>2 ms</td><td><b>132 tok/s</b></td></tr>
+                  <tr><td>M4 Max</td><td>14B</td><td>546 × 85% = 464 GB/s</td><td>9.3 GB ÷ 464 = 20.2 ms</td><td>10 ms</td><td><b>33 tok/s</b></td></tr>
+                  <tr><td>Lunar Lake laptop</td><td>4B</td><td>137 × 50% = 68 GB/s</td><td>2.9 GB ÷ 68 = 42.0 ms</td><td>45 ms</td><td><b>11 tok/s</b></td></tr>
+                </tbody>
+              </table>
+            </div>
+            <p>
+              Look at the last row. The laptop spends more time on fixed overhead than on reading the model. Doubling
+              its memory bandwidth would take it from 11 to about 15 tokens per second — not to 22. That is the single
+              most useful thing this model tells you, and it is invisible if you think of throughput as bandwidth
+              divided by model size.
+            </p>
+
+            <h3>Where the bottleneck actually sits</h3>
+            <p>There are three regimes, and they want different things from you.</p>
+            <p>
+              <b>Below about 2B, overhead rules.</b> The weights stream in a millisecond or two and then the machine
+              sits in per-token bookkeeping. This is why an 819 GB/s M3 Ultra and a 120 GB/s M4 land in the same place
+              on a 4B model in real benchmarks — seven times the bandwidth, no faster, because bandwidth was never what
+              they were waiting for. If you run small models, buy a better engine, not a better bus.
+            </p>
+            <p>
+              <b>Between roughly 7B and 30B, bandwidth rules.</b> Streaming dominates the token, and throughput tracks
+              GB/s almost linearly. This is the range where the spec sheet means what you think it means.
+            </p>
+            <p>
+              <b>Above 30B, capacity rules.</b> Speed stops being the question. A model that does not fit is not slow,
+              it is absent; and a model that half-fits, spilling layers to system memory or disk, is ten to a hundred
+              times slower than one that fits. This is why a 512 GB Mac Studio is interesting despite unremarkable
+              bandwidth, and why a 16 GB graphics card with twice the bandwidth is not.
+            </p>
+
+            <h3>Where software makes the difference</h3>
+            <p>
+              <b>Quantisation is the largest single lever.</b> It is not a compression trick that happens to save disk —
+              it directly divides the number that this whole page is about. FP16 to 4-bit is four times less to read,
+              therefore close to four times faster, and the quality cost on a well-made 4-bit quant is small. Going
+              below 4 bits buys progressively less speed for progressively more damage.
+            </p>
+            <p>
+              <b>Quantising the KV cache</b> is the same trick applied to the second term. It does nothing at short
+              context and a great deal at long context: on an 8B model at 32K tokens the cache is larger than the
+              weights, so halving it to 8-bit is worth 20–30%.
+            </p>
+            <p>
+              <b>Batching multiplies throughput but not latency.</b> Weights read once serve every sequence in the
+              batch, so eight concurrent users cost barely more than one. This is decisive for a server and irrelevant
+              to a single chat window — which is exactly why server benchmarks look nothing like what you get at home.
+            </p>
+            <p>
+              <b>Speculative decoding attacks the sequential dependency itself.</b> A small draft model proposes several
+              tokens; the large model checks them all in one pass, keeping the ones it agrees with. When the draft is
+              good, several tokens cost one read of the big model, for 1.5–3× with no change in output quality. It is
+              the rare optimisation that improves single-user latency.
+            </p>
+            <p>
+              <b>The engine matters most where overhead matters most.</b> llama.cpp, MLX, vLLM and ExLlama differ mainly
+              in kernel quality and dispatch cost — the third term. On a 70B model they land within a few percent of
+              each other because all of them are waiting for the same bus. On a 1B model the choice of engine can be the
+              whole result.
+            </p>
+            <p>
+              <b>Things that help less than expected:</b> more CPU cores, higher clocks, a faster GPU sharing the same
+              memory, and faster storage after the first load. If the bus is saturated, none of them are the constraint.
+            </p>
+
+            <h3>What this model does not capture</h3>
+            <p>
+              Fixed overhead is treated as one number per hardware family, when it really varies by engine, by runtime,
+              and by how warm the machine is. Prefill is not modelled at all, so a workload dominated by long documents
+              will behave differently from these figures. Sustained performance on a laptop drifts downward as it heats.
+              And the source dataset's own figures are a mix of measurements and estimates — treat single-digit
+              precision as decorative.
+            </p>
+          }
+        </section>
+      }
+
       <footer class="mt-14 pt-6 border-t border-slate-200 dark:border-zinc-800 text-[11px] text-slate-400 dark:text-slate-500 leading-relaxed">
         Built from <span class="font-mono">llm-hardware-inference-table.csv</span> — {{ dataset.devices.length }} machines
         released {{ yearRangeLabel }}, carrying {{ dataset.figureCountAtOneBillionPlus }} measured throughput figures at
-        1B and above and {{ dataset.figureCountSubBillion }} below it. The 1B and 2B columns are scaled from the source's
-        single 1–4B figure; everything else not measured is modelled from memory bandwidth. Every figure is charged for a
-        {{ model.contextLabel }} context, a realised bandwidth of {{ realisedRangeLabel }} of rated peak depending on the
-        machine, and a fixed per-token overhead of
-        {{ model.overheadMsPerToken[segments[0]] }}–{{ model.overheadMsPerToken[segments[segments.length - 1]] }} ms —
-        all tunable in Advanced settings. Figures marked [E] in the source are estimates; treat single-digit precision as
+        1B and above and {{ dataset.figureCountSubBillion }} below it.
+        @if (isAudio) {
+          None of them is a transcription figure: the speech numbers here are modelled throughout — the decoder from
+          memory bandwidth, the encoder from a compute estimate of FLOP per byte of bandwidth, calibrated against
+          published whisper-large throughput. Both are tunable in Advanced settings, as is the number of text tokens a
+          second of speech is taken to be worth.
+        } @else {
+          The 1B and 2B columns are scaled from the source's
+          single 1–4B figure; everything else not measured is modelled from memory bandwidth. Every figure is charged for a
+          {{ model.contextLabel }} context, a realised bandwidth of {{ realisedRangeLabel }} of rated peak depending on the
+          machine, and a fixed per-token overhead of
+          {{ model.overheadMsPerToken[segments[0]] }}–{{ model.overheadMsPerToken[segments[segments.length - 1]] }} ms —
+          all tunable in Advanced settings.
+        }
+        Figures marked [E] in the source are estimates; treat single-digit precision as
         decorative. The Horizon projections are trend extrapolation, not roadmap knowledge.
         @if (dataset.foldedDevices.length) {
           <span class="block mt-1.5">

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.scss
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.scss
@@ -21,6 +21,8 @@
   color-scheme: light;
 
   --chw-label-width: 208px;
+  /* one column per model size shown — five when transcribing, eight when reading */
+  --chw-columns: 8;
   --chw-surface: light-dark(#ffffff, #161616);
   --chw-ink: light-dark(#0f172a, #f1f5f9);
   --chw-ink-2: light-dark(#475569, #94a3b8);
@@ -190,7 +192,7 @@
 
 .chw-matrix-row {
   display: grid;
-  grid-template-columns: var(--chw-label-width) repeat(8, minmax(0, 1fr));
+  grid-template-columns: var(--chw-label-width) repeat(var(--chw-columns), minmax(0, 1fr));
   gap: 3px;
 }
 
@@ -313,4 +315,91 @@
 
 @media (prefers-reduced-motion: reduce) {
   * { transition: none !important; }
+}
+
+/* ── the long-form explainer ──────────────────────────────────────────────── */
+
+.chw-article {
+  h2 {
+    font-size: clamp(25px, 2.7vw, 34px);
+    letter-spacing: -0.03em;
+    line-height: 1.08;
+    font-weight: 800;
+    margin: 0 0 18px;
+    color: var(--chw-ink);
+  }
+
+  h3 {
+    font-size: 19px;
+    letter-spacing: -0.015em;
+    font-weight: 600;
+    margin: 40px 0 10px;
+    color: var(--chw-ink);
+  }
+
+  p, ol {
+    font-size: 16.5px;
+    line-height: 1.62;
+    color: var(--chw-ink-2);
+    margin: 0 0 15px;
+  }
+
+  ol {
+    padding-left: 20px;
+
+    li { margin-bottom: 9px; }
+  }
+
+  b { font-weight: 600; color: var(--chw-ink); }
+
+  em { color: var(--chw-accent); font-style: italic; }
+
+  .chw-standfirst {
+    font-size: 18.5px;
+    line-height: 1.55;
+    margin-bottom: 6px;
+  }
+
+  /* The arithmetic itself, set apart from the prose that argues about it. */
+  .chw-calc {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace;
+    font-size: 12.5px;
+    line-height: 1.9;
+    color: var(--chw-ink);
+    background: var(--chw-empty);
+    border-left: 2px solid var(--chw-axis);
+    border-radius: 0 8px 8px 0;
+    padding: 12px 14px;
+    margin: 0 0 18px;
+  }
+
+  .chw-worked {
+    width: 100%;
+    border-collapse: collapse;
+    margin: 0 0 18px;
+    font-size: 12.5px;
+    font-variant-numeric: tabular-nums;
+
+    th {
+      text-align: left;
+      font-size: 10px;
+      letter-spacing: 0.08em;
+      text-transform: uppercase;
+      color: var(--chw-ink-3);
+      padding: 0 12px 7px;
+      border-bottom: 1px solid var(--chw-grid);
+      white-space: nowrap;
+    }
+
+    td {
+      padding: 9px 12px;
+      border-bottom: 1px solid var(--chw-grid);
+      white-space: nowrap;
+      color: var(--chw-ink-2);
+    }
+
+    tr:last-child td { border-bottom: 0; }
+
+    td:first-child { font-weight: 500; color: var(--chw-ink); }
+  }
 }

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.ts
@@ -1,5 +1,8 @@
-import {Component, DOCUMENT, Inject, OnInit} from '@angular/core';
+import {Component, DOCUMENT, Inject, OnInit, PLATFORM_ID} from '@angular/core';
+import {isPlatformBrowser} from '@angular/common';
 import {Title} from '@angular/platform-browser';
+import {ActivatedRoute, Router} from '@angular/router';
+import {Subject, debounceTime} from 'rxjs';
 
 import {BasePage} from '../../base-page';
 import {
@@ -24,9 +27,13 @@ import {
 } from './constants/speed-bands.constant';
 import {
   CONTEXT_STEPS,
+  DEFAULT_CONTEXT_TOKENS,
+  DEFAULT_REALISED_BANDWIDTH,
+  DEFAULT_TOKEN_OVERHEAD_MS,
   REALISED_BANDWIDTH_RANGE,
   TOKEN_OVERHEAD_RANGE,
 } from './constants/throughput-model.constant';
+import {DEFAULT_BAND_EDGES} from './constants/speed-bands.constant';
 import {
   HARDWARE_SEGMENT_LABELS as SEGMENT_LABELS,
 } from './constants/hardware-segments.constant';
@@ -39,12 +46,14 @@ import {ModelClassEnum} from './enums/model-class.enum';
 import {ThroughputSourceEnum} from './enums/throughput-source.enum';
 import {BandConflictInterface} from './interfaces/band-conflict.interface';
 import {HardwareDatasetInterface} from './interfaces/hardware-dataset.interface';
+import {DashboardViewStateInterface} from './interfaces/dashboard-view-state.interface';
 import {HardwareDeviceInterface} from './interfaces/hardware-device.interface';
 import {LogTrendInterface} from './interfaces/log-trend.interface';
 import {ModelClassInterface} from './interfaces/model-class.interface';
 import {SpeedBandInterface} from './interfaces/speed-band.interface';
 import {HardwareDatasetService} from './services/hardware-dataset.service';
 import {BandwidthLawCalculator} from './util/bandwidth-law.calculator';
+import {DashboardUrlSerialiser} from './util/dashboard-url.serialiser';
 import {LogTrendCalculator} from './util/log-trend.calculator';
 import {ThroughputModel} from './util/throughput-model';
 import {SpeedBandScale} from './util/speed-band.scale';
@@ -165,6 +174,9 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
 
   hoverCard?: HoverCardViewModel;
 
+  /** Coalesces URL writes: a slider drag fires input events far faster than history. */
+  private readonly urlSync = new Subject<void>();
+
   // hero
   heroRows: HeroRowViewModel[] = [];
   yearTicks: YearTickViewModel[] = [];
@@ -211,6 +223,9 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
 
   constructor(@Inject(DOCUMENT) document: Document,
               title: Title,
+              @Inject(PLATFORM_ID) private readonly platformId: Object,
+              private readonly router: Router,
+              private readonly route: ActivatedRoute,
               private readonly datasetService: HardwareDatasetService) {
     super(document, title);
     this.setTitle('Consumer Hardware Analysis');
@@ -219,14 +234,144 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   override ngOnInit() {
     super.ngOnInit();
 
+    // Read the shared view before the data lands, so the first paint is already the view
+    // the link described rather than the default flashing past.
+    this.applyUrlState();
+
+    this.subscriptions.push(this.urlSync.pipe(debounceTime(200)).subscribe(() => this.writeUrlState()));
+
     this.subscriptions.push(this.datasetService.load().subscribe({
       next: dataset => {
         this.dataset = dataset;
-        this.year = dataset.years[dataset.years.length - 1] ?? this.currentYear;
+        this.year = this.clampYear(this.requestedYear ?? dataset.years[dataset.years.length - 1] ?? this.currentYear);
         this.rebuildAll();
       },
       error: () => this.loadFailed = true,
     }));
+  }
+
+  // ── shareable view ──────────────────────────────────────────────────────────
+
+  /** A year asked for by the URL, held until the dataset says which years exist. */
+  private requestedYear: number | null = null;
+
+  /** The view as it would be with nothing changed. The year's default is the dataset's
+   *  newest, so it is only known once the file has loaded. */
+  private get defaultState(): DashboardViewStateInterface {
+    return {
+      tab: ConsumerHardwareTabEnum.Horizon,
+      year: this.dataset?.years[this.dataset.years.length - 1] ?? this.currentYear,
+      showModelledValues: true,
+      advancedOpen: false,
+      bandLows: [...DEFAULT_BAND_EDGES],
+      bandHighs: [...DEFAULT_BAND_EDGES],
+      contextTokens: DEFAULT_CONTEXT_TOKENS,
+      realisedBandwidth: this.asPercent(DEFAULT_REALISED_BANDWIDTH),
+      overheadMsPerToken: {...DEFAULT_TOKEN_OVERHEAD_MS},
+      matrixGrouping: MatrixGroupingEnum.Type,
+      matrixFilter: 'all',
+      matrixSearch: '',
+      explorerSearch: '',
+      sortColumn: 'bandwidth',
+      sortDirection: -1,
+      horizonClass: ModelClassEnum.Nano2B,
+      horizonYears: HORIZON_HORIZONS[HORIZON_HORIZONS.length - 1],
+      horizonCategories: [...HORIZON_DEFAULT_CATEGORIES],
+    };
+  }
+
+  private get currentState(): DashboardViewStateInterface {
+    return {
+      tab: this.activeTab,
+      year: this.year,
+      showModelledValues: this.showModelledValues,
+      advancedOpen: this.advancedOpen,
+      bandLows: this.scale.lowEdges,
+      bandHighs: this.scale.highEdges,
+      contextTokens: this.model.contextTokens,
+      realisedBandwidth: this.asPercent(this.model.realisedBandwidth),
+      overheadMsPerToken: {...this.model.overheadMsPerToken},
+      matrixGrouping: this.matrixGrouping,
+      matrixFilter: this.matrixFilter,
+      matrixSearch: this.matrixSearch,
+      explorerSearch: this.explorerSearch,
+      sortColumn: this.sortColumn,
+      sortDirection: this.sortDirection,
+      horizonClass: this.horizonClass,
+      horizonYears: this.horizonYears,
+      horizonCategories: [...this.horizonCategories],
+    };
+  }
+
+  private applyUrlState() {
+    const params: Record<string, string> = {};
+    for (const key of this.route.snapshot.queryParamMap.keys) {
+      params[key] = this.route.snapshot.queryParamMap.get(key) ?? '';
+    }
+    if (!Object.keys(params).length) {
+      return;
+    }
+
+    const state = DashboardUrlSerialiser.fromParams(params, this.defaultState);
+
+    this.activeTab = state.tab;
+    this.requestedYear = state.year;
+    this.showModelledValues = state.showModelledValues;
+    this.advancedOpen = state.advancedOpen;
+    this.scale.setEdges(state.bandLows, state.bandHighs);
+    this.model.contextTokens = state.contextTokens;
+    this.model.realisedBandwidth = this.asFraction(state.realisedBandwidth);
+    this.model.overheadMsPerToken = {...state.overheadMsPerToken};
+    this.matrixGrouping = state.matrixGrouping;
+    this.matrixFilter = state.matrixFilter;
+    this.matrixSearch = state.matrixSearch;
+    this.explorerSearch = state.explorerSearch;
+    this.sortColumn = state.sortColumn;
+    this.sortDirection = state.sortDirection;
+    this.horizonClass = state.horizonClass;
+    this.horizonYears = state.horizonYears;
+    this.horizonCategories = new Set(state.horizonCategories);
+  }
+
+  /** Queues the address bar to catch up with the view. */
+  private queueUrlSync() {
+    this.urlSync.next();
+  }
+
+  private writeUrlState() {
+    if (!isPlatformBrowser(this.platformId)) {
+      return;
+    }
+    // A whole object replaces the query string, so returning a control to its default
+    // removes its parameter rather than leaving a stale one behind.
+    this.router.navigate([], {
+      relativeTo: this.route,
+      queryParams: DashboardUrlSerialiser.toParams(this.currentState, this.defaultState),
+      replaceUrl: true,
+    });
+  }
+
+  private clampYear(year: number): number {
+    if (!this.dataset?.years.length) {
+      return year;
+    }
+    const first = this.dataset.years[0];
+    const last = this.dataset.years[this.dataset.years.length - 1];
+    return Math.min(last, Math.max(first, Math.round(year)));
+  }
+
+  private asPercent(bySegment: Record<HardwareSegmentEnum, number>): Record<HardwareSegmentEnum, number> {
+    return HARDWARE_SEGMENT_ORDER.reduce((map, segment) => {
+      map[segment] = Math.round(bySegment[segment] * 100);
+      return map;
+    }, {} as Record<HardwareSegmentEnum, number>);
+  }
+
+  private asFraction(bySegment: Record<HardwareSegmentEnum, number>): Record<HardwareSegmentEnum, number> {
+    return HARDWARE_SEGMENT_ORDER.reduce((map, segment) => {
+      map[segment] = bySegment[segment] / 100;
+      return map;
+    }, {} as Record<HardwareSegmentEnum, number>);
   }
 
   // ── reader controls ─────────────────────────────────────────────────────────
@@ -234,10 +379,12 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   onTabChange(tab: ConsumerHardwareTabEnum) {
     this.activeTab = tab;
     this.hideHoverCard();
+    this.queueUrlSync();
   }
 
   toggleAdvanced() {
     this.advancedOpen = !this.advancedOpen;
+    this.queueUrlSync();
   }
 
   onYearInput(event: Event) {
@@ -255,6 +402,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     const last = this.dataset.years[this.dataset.years.length - 1];
     this.year = Math.min(last, Math.max(first, Math.round(year)));
     this.buildHero();
+    this.queueUrlSync();
   }
 
   get yearFloor(): number {
@@ -314,11 +462,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
 
   /** Every view reads the adjusted figures, so all of them rebuild. */
   private onModelChanged() {
-    this.buildHeadlines();
-    this.buildHero();
-    this.buildMatrix();
-    this.buildExplorer();
-    this.buildHorizonChart();
+    this.onBandsChanged();
   }
 
   onModelledToggle(event: Event) {
@@ -327,16 +471,19 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     this.buildMatrix();
     this.buildExplorer();
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   onHorizonClass(modelClass: ModelClassEnum) {
     this.horizonClass = modelClass;
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   onHorizonYears(years: number) {
     this.horizonYears = years;
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   toggleCategory(type: ConsumerTypeEnum) {
@@ -346,42 +493,50 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       this.horizonCategories.add(type);
     }
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   showAllCategories() {
     this.horizonCategories = new Set(HORIZON_CATEGORY_ORDER);
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   clearCategories() {
     this.horizonCategories = new Set();
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   resetCategories() {
     this.horizonCategories = new Set(HORIZON_DEFAULT_CATEGORIES);
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   onGroupingChange(grouping: MatrixGroupingEnum) {
     this.matrixGrouping = grouping;
     this.matrixFilter = 'all';
     this.buildMatrix();
+    this.queueUrlSync();
   }
 
   onMatrixFilter(key: string) {
     this.matrixFilter = key;
     this.buildMatrix();
+    this.queueUrlSync();
   }
 
   onMatrixSearch(event: Event) {
     this.matrixSearch = (event.target as HTMLInputElement).value;
     this.buildMatrix();
+    this.queueUrlSync();
   }
 
   onExplorerSearch(event: Event) {
     this.explorerSearch = (event.target as HTMLInputElement).value;
     this.buildExplorer();
+    this.queueUrlSync();
   }
 
   sortBy(column: ExplorerColumnViewModel) {
@@ -392,6 +547,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       this.sortDirection = column.numeric ? -1 : 1;
     }
     this.buildExplorer();
+    this.queueUrlSync();
   }
 
   sortDirectionFor(column: ExplorerColumnViewModel): 'ascending' | 'descending' | 'none' {
@@ -401,12 +557,15 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     return this.sortDirection === 1 ? 'ascending' : 'descending';
   }
 
+  /** Rebuilds every view that reads the bands or the loss model, then queues the URL. */
   private onBandsChanged() {
     this.buildBandSliders();
+    this.buildHeadlines();
     this.buildHero();
     this.buildMatrix();
     this.buildExplorer();
     this.buildHorizonChart();
+    this.queueUrlSync();
   }
 
   // ── hover card ──────────────────────────────────────────────────────────────

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/consumer-hardware-analysis.page.ts
@@ -16,15 +16,18 @@ import {
   HARDWARE_SEGMENT_ORDER,
 } from './constants/hardware-segments.constant';
 import {
-  MODEL_CLASSES,
+  DEFAULT_HORIZON_CLASS_BY_MODE,
+  MODEL_CLASSES_BY_MODE,
   MODEL_CLASS_BY_KEY,
   PROJECTED_MODEL_CLASSES,
   isDerivedModelClass,
 } from './constants/model-classes.constant';
 import {
-  BAND_SLIDER_MAX,
-  DEFAULT_REFERENCE_BAND_INDEX,
-} from './constants/speed-bands.constant';
+  DEFAULT_FLOP_PER_BYTE,
+  DEFAULT_TOKENS_PER_SECOND_OF_AUDIO,
+  FLOP_PER_BYTE_RANGE,
+  TOKENS_PER_SECOND_RANGE,
+} from './constants/speech-model.constant';
 import {
   CONTEXT_STEPS,
   DEFAULT_CONTEXT_TOKENS,
@@ -33,7 +36,8 @@ import {
   REALISED_BANDWIDTH_RANGE,
   TOKEN_OVERHEAD_RANGE,
 } from './constants/throughput-model.constant';
-import {DEFAULT_BAND_EDGES} from './constants/speed-bands.constant';
+import {BAND_EDGES_BY_MODE, DEFAULT_REFERENCE_BAND_INDEX} from './constants/speed-bands.constant';
+import {TASK_COPY, TaskCopyInterface} from './constants/task-copy.constant';
 import {
   HARDWARE_SEGMENT_LABELS as SEGMENT_LABELS,
 } from './constants/hardware-segments.constant';
@@ -43,6 +47,7 @@ import {ConsumerTypeEnum} from './enums/consumer-type.enum';
 import {HardwareSegmentEnum} from './enums/hardware-segment.enum';
 import {MatrixGroupingEnum} from './enums/matrix-grouping.enum';
 import {ModelClassEnum} from './enums/model-class.enum';
+import {TaskModeEnum} from './enums/task-mode.enum';
 import {ThroughputSourceEnum} from './enums/throughput-source.enum';
 import {BandConflictInterface} from './interfaces/band-conflict.interface';
 import {HardwareDatasetInterface} from './interfaces/hardware-dataset.interface';
@@ -123,7 +128,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   readonly tabEnum = ConsumerHardwareTabEnum;
   readonly sourceEnum = ThroughputSourceEnum;
   readonly groupingEnum = MatrixGroupingEnum;
-  readonly modelClasses = MODEL_CLASSES;
+  readonly modeEnum = TaskModeEnum;
   readonly horizonHorizons = HORIZON_HORIZONS;
   readonly projectedClasses = PROJECTED_MODEL_CLASSES;
   readonly sliderMax = SLIDER_POSITIONS;
@@ -132,6 +137,12 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   loadFailed = false;
 
   activeTab = ConsumerHardwareTabEnum.Horizon;
+
+  /**
+   * Which task the page describes. It is not a filter over the same numbers: transcription
+   * has its own model sizes, its own arithmetic, its own unit and its own idea of fast.
+   */
+  mode = TaskModeEnum.Text;
 
   /** The five speed bands and the four edges the reader can drag. */
   readonly scale = new SpeedBandScale();
@@ -142,6 +153,8 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   readonly contextSteps = CONTEXT_STEPS;
   readonly realisedRange = REALISED_BANDWIDTH_RANGE;
   readonly overheadRange = TOKEN_OVERHEAD_RANGE;
+  readonly audioTokensRange = TOKENS_PER_SECOND_RANGE;
+  readonly flopPerByteRange = FLOP_PER_BYTE_RANGE;
   readonly segments = HARDWARE_SEGMENT_ORDER;
   readonly segmentLabels = SEGMENT_LABELS;
 
@@ -168,7 +181,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   sortDirection: 1 | -1 = -1;
 
   /** Horizon: which model size the lines describe, and how far the trend is drawn. */
-  horizonClass = ModelClassEnum.Nano2B;
+  horizonClass = DEFAULT_HORIZON_CLASS_BY_MODE[TaskModeEnum.Text];
   horizonYears = HORIZON_HORIZONS[HORIZON_HORIZONS.length - 1];
   horizonCategories = new Set<ConsumerTypeEnum>(HORIZON_DEFAULT_CATEGORIES);
 
@@ -255,33 +268,47 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   /** A year asked for by the URL, held until the dataset says which years exist. */
   private requestedYear: number | null = null;
 
-  /** The view as it would be with nothing changed. The year's default is the dataset's
-   *  newest, so it is only known once the file has loaded. */
-  private get defaultState(): DashboardViewStateInterface {
+  /**
+   * The view as it would be with nothing changed.
+   *
+   * Two of these defaults are not constants. The year's is the dataset's newest, so it is
+   * only known once the file has loaded; and the bands and the starting model size belong
+   * to the task, so they are the defaults *for the task the reader is currently in*. That
+   * keeps a shared URL carrying only what its sender actually changed.
+   */
+  private defaultStateFor(mode: TaskModeEnum): DashboardViewStateInterface {
     return {
+      mode: TaskModeEnum.Text,
       tab: ConsumerHardwareTabEnum.Horizon,
       year: this.dataset?.years[this.dataset.years.length - 1] ?? this.currentYear,
       showModelledValues: true,
       advancedOpen: false,
-      bandLows: [...DEFAULT_BAND_EDGES],
-      bandHighs: [...DEFAULT_BAND_EDGES],
+      bandLows: [...BAND_EDGES_BY_MODE[mode]],
+      bandHighs: [...BAND_EDGES_BY_MODE[mode]],
       contextTokens: DEFAULT_CONTEXT_TOKENS,
       realisedBandwidth: this.asPercent(DEFAULT_REALISED_BANDWIDTH),
       overheadMsPerToken: {...DEFAULT_TOKEN_OVERHEAD_MS},
+      tokensPerSecondOfAudio: DEFAULT_TOKENS_PER_SECOND_OF_AUDIO,
+      flopPerByte: {...DEFAULT_FLOP_PER_BYTE},
       matrixGrouping: MatrixGroupingEnum.Type,
       matrixFilter: 'all',
       matrixSearch: '',
       explorerSearch: '',
       sortColumn: 'bandwidth',
       sortDirection: -1,
-      horizonClass: ModelClassEnum.Nano2B,
+      horizonClass: DEFAULT_HORIZON_CLASS_BY_MODE[mode],
       horizonYears: HORIZON_HORIZONS[HORIZON_HORIZONS.length - 1],
       horizonCategories: [...HORIZON_DEFAULT_CATEGORIES],
     };
   }
 
+  private get defaultState(): DashboardViewStateInterface {
+    return this.defaultStateFor(this.mode);
+  }
+
   private get currentState(): DashboardViewStateInterface {
     return {
+      mode: this.mode,
       tab: this.activeTab,
       year: this.year,
       showModelledValues: this.showModelledValues,
@@ -291,6 +318,8 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       contextTokens: this.model.contextTokens,
       realisedBandwidth: this.asPercent(this.model.realisedBandwidth),
       overheadMsPerToken: {...this.model.overheadMsPerToken},
+      tokensPerSecondOfAudio: this.model.tokensPerSecondOfAudio,
+      flopPerByte: {...this.model.flopPerByte},
       matrixGrouping: this.matrixGrouping,
       matrixFilter: this.matrixFilter,
       matrixSearch: this.matrixSearch,
@@ -312,7 +341,13 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       return;
     }
 
-    const state = DashboardUrlSerialiser.fromParams(params, this.defaultState);
+    // The task has to be settled first: it decides what the band edges and the starting
+    // model size are measured against, so everything else is parsed relative to it.
+    const requestedMode = DashboardUrlSerialiser
+      .fromParams(params, this.defaultStateFor(TaskModeEnum.Text)).mode;
+    const state = DashboardUrlSerialiser.fromParams(params, this.defaultStateFor(requestedMode));
+
+    this.applyMode(state.mode);
 
     this.activeTab = state.tab;
     this.requestedYear = state.year;
@@ -322,6 +357,8 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     this.model.contextTokens = state.contextTokens;
     this.model.realisedBandwidth = this.asFraction(state.realisedBandwidth);
     this.model.overheadMsPerToken = {...state.overheadMsPerToken};
+    this.model.tokensPerSecondOfAudio = state.tokensPerSecondOfAudio;
+    this.model.flopPerByte = {...state.flopPerByte};
     this.matrixGrouping = state.matrixGrouping;
     this.matrixFilter = state.matrixFilter;
     this.matrixSearch = state.matrixSearch;
@@ -331,6 +368,10 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     this.horizonClass = state.horizonClass;
     this.horizonYears = state.horizonYears;
     this.horizonCategories = new Set(state.horizonCategories);
+
+    // A link may name a size or a column belonging to the other task; the task in the URL
+    // wins, and anything that does not exist under it falls back rather than blanking.
+    this.settleSelectionsForMode();
   }
 
   /** Queues the address bar to catch up with the view. */
@@ -374,7 +415,89 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     }, {} as Record<HardwareSegmentEnum, number>);
   }
 
+  // ── the task ────────────────────────────────────────────────────────────────
+
+  /** The sizes this task is shown in, in column order. */
+  get modelClasses(): ModelClassInterface[] {
+    return MODEL_CLASSES_BY_MODE[this.mode];
+  }
+
+  get isAudio(): boolean {
+    return this.mode === TaskModeEnum.Audio;
+  }
+
+  /** What a figure is counted in: "tok/s" reading, "×" transcribing. */
+  get unit(): string {
+    return this.scale.unit;
+  }
+
+  get unitLong(): string {
+    return this.scale.unitLong;
+  }
+
+  get taskCopy(): TaskCopyInterface {
+    return TASK_COPY[this.mode];
+  }
+
+  taskCopyFor(mode: TaskModeEnum): TaskCopyInterface {
+    return TASK_COPY[mode];
+  }
+
+  onModeChange(mode: TaskModeEnum) {
+    if (mode === this.mode) {
+      return;
+    }
+    if (!this.isAudio) {
+      this.modelledValuesInText = this.showModelledValues;
+    }
+    this.applyMode(mode);
+    this.showModelledValues = this.modelledValuesInText;
+    this.settleSelectionsForMode();
+    this.hideHoverCard();
+    this.rebuildAll();
+    this.queueUrlSync();
+  }
+
+  /**
+   * Switches the task itself. The bands go back to that task's own defaults rather than
+   * carrying across: 50 tok/s and 50× realtime are not the same request, and keeping the
+   * numbers would silently reinterpret them.
+   */
+  private applyMode(mode: TaskModeEnum) {
+    this.mode = mode;
+    this.scale.useMode(mode);
+  }
+
+  /** What the reader chose for text, kept while speech has the switch held down. */
+  private modelledValuesInText = true;
+
+  /**
+   * Drops any selection that belonged to the task the reader just left: a size that does
+   * not exist here, a sort on a column that is gone, and the gap-filling switch, which
+   * has nothing to act on when nothing was measured in the first place.
+   */
+  private settleSelectionsForMode() {
+    if (this.isAudio) {
+      this.showModelledValues = true;
+    }
+    if (!this.modelClasses.some(modelClass => modelClass.key === this.horizonClass)) {
+      this.horizonClass = DEFAULT_HORIZON_CLASS_BY_MODE[this.mode];
+    }
+    if (this.sortColumn.startsWith('class:')
+      && !this.modelClasses.some(modelClass => `class:${modelClass.key}` === this.sortColumn)) {
+      this.sortColumn = 'bandwidth';
+      this.sortDirection = -1;
+    }
+  }
+
   // ── reader controls ─────────────────────────────────────────────────────────
+
+  tabLabel(tab: ConsumerHardwareTabEnum): string {
+    if (tab === ConsumerHardwareTabEnum.Explorer) {
+      return 'Data Explorer';
+    }
+    return tab === ConsumerHardwareTabEnum.Notes ? 'How it works' : tab;
+  }
 
   onTabChange(tab: ConsumerHardwareTabEnum) {
     this.activeTab = tab;
@@ -451,6 +574,22 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     const milliseconds = Number.parseFloat((event.target as HTMLInputElement).value);
     if (milliseconds >= this.overheadRange.min && milliseconds <= this.overheadRange.max) {
       this.model.overheadMsPerToken[segment] = milliseconds;
+      this.onModelChanged();
+    }
+  }
+
+  onAudioTokens(event: Event) {
+    const tokens = Number.parseFloat((event.target as HTMLInputElement).value);
+    if (tokens >= this.audioTokensRange.min && tokens <= this.audioTokensRange.max) {
+      this.model.tokensPerSecondOfAudio = tokens;
+      this.onModelChanged();
+    }
+  }
+
+  onFlopPerByte(segment: HardwareSegmentEnum, event: Event) {
+    const flopPerByte = Number.parseFloat((event.target as HTMLInputElement).value);
+    if (flopPerByte >= this.flopPerByteRange.min && flopPerByte <= this.flopPerByteRange.max) {
+      this.model.flopPerByte[segment] = flopPerByte;
       this.onModelChanged();
     }
   }
@@ -618,6 +757,16 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     return `${(value * 100).toFixed(digits)}%`;
   }
 
+  /** A figure with its unit attached the way that unit reads: "12 tok/s", "66×". */
+  formatValue(value: number): string {
+    return this.withUnit(this.formatRate(value));
+  }
+
+  /** The same, for something already formatted — a band's range, say. */
+  withUnit(label: string): string {
+    return this.isAudio ? `${label}${this.unit}` : `${label} ${this.unit}`;
+  }
+
   get bands(): SpeedBandInterface[] {
     return this.scale.bands;
   }
@@ -636,7 +785,15 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
 
   /** Footnote for the value legends: what every figure in the view is charged for. */
   get chargedNote(): string {
-    return `Q4 weights · ${this.model.contextLabel} context${this.model.isTuned ? ' · losses tuned' : ''}`;
+    const charged = this.isAudio
+      ? `Q4 decoder · estimated compute · ${this.audioContextCap}-token window`
+      : `Q4 weights · ${this.model.contextLabel} context`;
+    return `${charged}${this.model.isTuned ? ' · losses tuned' : ''}`;
+  }
+
+  /** The window a speech model actually works in, whatever context the reader asks for. */
+  get audioContextCap(): number {
+    return this.modelClasses[0]?.contextCapTokens ?? 0;
   }
 
   /** How much of its no-context speed each size keeps at the current context. */
@@ -644,7 +801,16 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     if (this.model.contextTokens === 0) {
       return 'no KV cache charged — the figures as the source reports them';
     }
+
     const at = (key: ModelClassEnum) => this.model.contextCostPercent(MODEL_CLASS_BY_KEY[key]);
+
+    if (this.isAudio) {
+      // A speech model cannot be asked to hold more than its own 30-second window, so the
+      // slider stops mattering here long before it runs out.
+      return `capped at ${this.audioContextCap} tokens, the window these models work in — `
+        + `costs ${at(ModelClassEnum.WhisperTiny)}% at Tiny, ${at(ModelClassEnum.WhisperLarge)}% at Large`;
+    }
+
     return `costs ${at(ModelClassEnum.Nano1B)}% at 1B, ${at(ModelClassEnum.Light)}% at 8B, `
       + `${at(ModelClassEnum.Xl)}% at 70B`;
   }
@@ -658,11 +824,12 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   }
 
   private positionToValue(position: number): number {
-    return Math.round(Math.pow(position / SLIDER_POSITIONS, 2) * BAND_SLIDER_MAX * 2) / 2;
+    return Math.round(Math.pow(position / SLIDER_POSITIONS, 2) * this.scale.sliderMax * 2) / 2;
   }
 
   private valueToPosition(value: number): number {
-    return Math.round(Math.sqrt(Math.min(value, BAND_SLIDER_MAX) / BAND_SLIDER_MAX) * SLIDER_POSITIONS);
+    const max = this.scale.sliderMax;
+    return Math.round(Math.sqrt(Math.min(value, max) / max) * SLIDER_POSITIONS);
   }
 
   /**
@@ -674,11 +841,23 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
   private throughputFor(device: HardwareDeviceInterface,
                         modelClass: ModelClassInterface,
                         allowModelled = this.showModelledValues): Throughput {
-    const figure = device.throughput[modelClass.sourceColumn];
     // The requirement moves with the context the reader chose, so a machine that held a
     // model at no context can fall out of range at 32K.
     const fitsInMemory = device.maxMemoryGb === null
       || device.maxMemoryGb >= this.model.memoryNeededGb(modelClass);
+
+    // A size with no column in the file has nothing to read: transcription is modelled
+    // from bandwidth and compute, every machine, every size.
+    if (!modelClass.sourceColumn) {
+      if (device.bandwidthGbps === null) {
+        return null;
+      }
+      return fitsInMemory
+        ? this.adjusted(device.bandwidthGbps * this.dataset!.fits[modelClass.key].tokensPerGbps, modelClass, device)
+        : 'wont-fit';
+    }
+
+    const figure = device.throughput[modelClass.sourceColumn];
 
     if (figure.tokensPerSecond !== null) {
       // Half the weights, twice the tokens, for a size scaled off the shared bucket.
@@ -699,27 +878,35 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     return this.adjusted(device.bandwidthGbps * this.dataset!.fits[modelClass.key].tokensPerGbps, modelClass, device);
   }
 
-  /** Charges a raw figure for realised bandwidth, KV cache and per-token overhead. */
+  /**
+   * Charges a raw figure for realised bandwidth, KV cache and per-token overhead — and,
+   * when transcribing, spends the resulting token rate on the handful of decode steps a
+   * second of audio needs, after the encoder has taken its fixed share of that second.
+   */
   private adjusted(tokensPerSecond: number,
                    modelClass: ModelClassInterface,
                    device: HardwareDeviceInterface): number {
-    return this.model.adjust(
-      tokensPerSecond,
-      modelClass,
-      device.segment,
-      this.dataset!.fits[modelClass.key].bandwidthEfficiency,
-    );
+    const sourceEfficiency = this.dataset!.fits[modelClass.key].bandwidthEfficiency;
+
+    if (this.isAudio) {
+      return this.model.realtimeFactor(
+        tokensPerSecond, modelClass, device.segment, sourceEfficiency, device.bandwidthGbps ?? 0);
+    }
+
+    return this.model.adjust(tokensPerSecond, modelClass, device.segment, sourceEfficiency);
   }
 
   /** True only when the number comes straight from the source, at its own size. */
   private isMeasured(device: HardwareDeviceInterface, modelClass: ModelClassInterface): boolean {
-    return modelClass.multiplier === 1
+    return modelClass.sourceColumn !== undefined
+      && modelClass.multiplier === 1
       && device.throughput[modelClass.sourceColumn].tokensPerSecond !== null;
   }
 
   /** True when the figure was read off the 1–4B bucket and scaled to this size. */
   private isScaledFromBucket(device: HardwareDeviceInterface, modelClass: ModelClassInterface): boolean {
-    return modelClass.multiplier !== 1
+    return modelClass.sourceColumn !== undefined
+      && modelClass.multiplier !== 1
       && device.throughput[modelClass.sourceColumn].tokensPerSecond !== null;
   }
 
@@ -741,7 +928,9 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     }
 
     const lawful = PROJECTED_MODEL_CLASSES.map(modelClass => this.dataset!.fits[modelClass.key]);
-    const rSquaredValues = lawful.map(fit => fit.rSquared);
+    const rSquaredValues = lawful
+      .map(fit => fit.rSquared)
+      .filter((rSquared): rSquared is number => rSquared !== null);
     this.rSquaredRangeLabel = `${Math.min(...rSquaredValues).toFixed(2)}–${Math.max(...rSquaredValues).toFixed(2)}`;
 
     const years = this.dataset.years;
@@ -790,7 +979,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     this.bandSliders = this.scale.bands.map(band => {
       const conflicted = this.bandConflicts.some(conflict =>
         conflict.index === band.index || conflict.neighbourIndex === band.index);
-      const highValue = band.index === this.scale.topIndex ? BAND_SLIDER_MAX : band.high;
+      const highValue = band.index === this.scale.topIndex ? this.scale.sliderMax : band.high;
 
       return {
         index: band.index,
@@ -805,7 +994,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
         conflicted,
         tooltipTitle: band.name,
         tooltipLines: [
-          `${band.rangeLabel} tok/s`,
+          this.withUnit(band.rangeLabel),
           ...(band.index === 0 ? ['starts at zero — drag the right handle'] : []),
           ...(band.index === this.scale.topIndex ? ['no upper limit — drag the left handle'] : []),
         ],
@@ -895,7 +1084,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       if (!this.isMeasured(device, modelClass)) {
         modelledCount++;
       }
-      sources.push(`${device.name} ${this.formatRate(value)}`);
+      sources.push(`${device.name} ${this.formatValue(value)}`);
     }
 
     return {
@@ -927,7 +1116,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
           label,
           detail: 'none yet',
           present: false,
-          cells: MODEL_CLASSES.map(() => ({
+          cells: this.modelClasses.map(() => ({
             rampStep: null, display: '', modelled: false, wontFit: false,
             tooltipTitle: label, tooltipLines: [`nothing of this kind in the dataset by ${this.year}`],
           })),
@@ -944,7 +1133,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
         label,
         detail: `${bucket.year} · ${bucket.devices.length} machine${bucket.devices.length > 1 ? 's' : ''}`,
         present: true,
-        cells: MODEL_CLASSES.map(modelClass => this.buildHeroCell(bucket, modelClass, label)),
+        cells: this.modelClasses.map(modelClass => this.buildHeroCell(bucket, modelClass, label)),
         tooltipTitle: label,
         tooltipLines: [
           CONSUMER_TYPE_BLURBS[type],
@@ -993,7 +1182,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       wontFit: false,
       tooltipTitle: title,
       tooltipLines: [
-        `${this.formatRate(summary.mean)} tok/s — ${band.name}`,
+        `${this.formatValue(summary.mean)} — ${band.name}`,
         ...(summary.values.length > 1
           ? [`mean of ${summary.values.length} machines (${this.formatRate(Math.min(...summary.values))}–${this.formatRate(Math.max(...summary.values))})`]
           : []),
@@ -1093,7 +1282,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       bandwidthLabel: device.bandwidthGbps !== null ? `${this.formatNumber(device.bandwidthGbps)} GB/s` : 'bus n/a',
       memoryLabel: this.memoryLabelFor(device),
       bandwidthBarPercent: Math.round(100 * (device.bandwidthGbps ?? 0) / widestBus),
-      cells: MODEL_CLASSES.map(modelClass => this.buildMatrixCell(device, modelClass)),
+      cells: this.modelClasses.map(modelClass => this.buildMatrixCell(device, modelClass)),
       tooltipTitle: device.name,
       tooltipLines: [
         `${device.manufacturer} · ${device.year ?? 'year not listed'}`,
@@ -1105,10 +1294,43 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
     };
   }
 
+  /**
+   * The line that says where the time went: streaming versus overhead for a token, and
+   * encoder versus decoder for a second of audio. It is the whole point of the model, so
+   * every cell carries it.
+   */
+  private costBreakdownLines(device: HardwareDeviceInterface,
+                             modelClass: ModelClassInterface,
+                             measured: boolean,
+                             scaled: boolean): string[] {
+    if (!modelClass.followsBandwidthLaw || device.bandwidthGbps === null) {
+      return [];
+    }
+
+    const fit = this.dataset!.fits[modelClass.key];
+    const raw = (measured || scaled) && modelClass.sourceColumn
+      ? (device.throughput[modelClass.sourceColumn].tokensPerSecond as number) * modelClass.multiplier
+      : device.bandwidthGbps * fit.tokensPerGbps;
+    const streaming = this.model.streamMilliseconds(raw, modelClass, device.segment, fit.bandwidthEfficiency);
+    const overhead = this.model.overheadMsPerToken[device.segment];
+
+    if (!this.isAudio) {
+      return [`${this.formatRate(streaming)} ms streaming + ${overhead} ms overhead`];
+    }
+
+    const encoder = this.model.encoderMilliseconds(modelClass, device.segment, device.bandwidthGbps);
+    const decoder = this.model.decoderMilliseconds(1000 / (streaming + overhead));
+    return [
+      `per second of audio: ${this.formatRate(encoder)} ms encoder + ${this.formatRate(decoder)} ms decoder`,
+      `${this.formatRate(this.model.effectiveGflops(device.segment, device.bandwidthGbps) / 1000)} TFLOPS assumed`
+        + ` (${this.model.flopPerByte[device.segment]} FLOP per byte of bandwidth)`,
+    ];
+  }
+
   private buildMatrixCell(device: HardwareDeviceInterface, modelClass: ModelClassInterface): MatrixCellViewModel {
     const title = `${device.name} · ${modelClass.name} ${modelClass.sizeLabel}`;
     const value = this.throughputFor(device, modelClass);
-    const figure = device.throughput[modelClass.sourceColumn];
+    const figure = modelClass.sourceColumn ? device.throughput[modelClass.sourceColumn] : null;
 
     if (value === 'wont-fit') {
       return {
@@ -1154,25 +1376,20 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       source: measured ? ThroughputSourceEnum.Measured : ThroughputSourceEnum.Modelled,
       tokensPerSecond: value,
       display: band.name,
-      detail: `${this.formatRate(value)} tok/s`,
+      detail: this.formatValue(value),
       rampStep: band.index,
       tooltipTitle: title,
       tooltipLines: [
-        `${this.formatRate(value)} tok/s — ${band.name} (${band.rangeLabel})`,
+        `${this.formatValue(value)} — ${band.name} (${this.withUnit(band.rangeLabel)})`,
         measured
           ? 'measured figure from the source dataset'
           : scaled
             ? `scaled from this machine's 1–4B figure (×${modelClass.multiplier})`
-            : `modelled: ${this.formatNumber(device.bandwidthGbps as number)} GB/s × ${fit.tokensPerGbps.toFixed(3)} tok/s per GB/s`,
-        ...(modelClass.followsBandwidthLaw && device.bandwidthGbps !== null
-          ? [`${this.formatRate(this.model.streamMilliseconds(
-              measured || scaled
-                ? (device.throughput[modelClass.sourceColumn].tokensPerSecond as number) * modelClass.multiplier
-                : device.bandwidthGbps * fit.tokensPerGbps,
-              modelClass, device.segment, fit.bandwidthEfficiency))} ms streaming`
-            + ` + ${this.model.overheadMsPerToken[device.segment]} ms overhead`]
-          : []),
-        ...(figure.sourceRange
+            : this.isAudio
+              ? 'modelled — nothing in the source was benchmarked on transcription'
+              : `modelled: ${this.formatNumber(device.bandwidthGbps as number)} GB/s × ${fit.tokensPerGbps.toFixed(3)} tok/s per GB/s`,
+        ...this.costBreakdownLines(device, modelClass, measured, scaled),
+        ...(figure?.sourceRange
           ? [`source publishes a ${this.formatRate(figure.sourceRange[0])}–${this.formatRate(figure.sourceRange[1])} tok/s spread`]
           : []),
       ],
@@ -1204,7 +1421,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       {key: 'memory', label: 'Memory GB', numeric: true, throughput: false},
       {key: 'memoryType', label: 'Memory type', numeric: false, throughput: false},
       {key: 'bandwidth', label: 'GB/s', numeric: true, throughput: false},
-      ...MODEL_CLASSES.map(modelClass => ({
+      ...this.modelClasses.map(modelClass => ({
         key: `class:${modelClass.key}`,
         label: `${modelClass.name} ${modelClass.sizeLabel}`,
         numeric: true,
@@ -1312,12 +1529,12 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       const scaled = this.isScaledFromBucket(device, modelClass);
       return {
         columnKey: column.key,
-        display: `${band.name} ${this.formatRate(value)}`,
+        display: `${band.name} ${this.isAudio ? this.formatValue(value) : this.formatRate(value)}`,
         numeric: true,
         rampStep: band.index,
         muted: false,
         modelled: !measured,
-        title: `${this.formatRate(value)} tok/s — ${band.name}`
+        title: `${this.formatValue(value)} — ${band.name}`
           + (measured ? '' : scaled ? `, scaled ×${modelClass.multiplier} from the 1–4B figure` : ', modelled from bandwidth'),
       };
     }
@@ -1484,7 +1701,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
         cy: y(measured.value),
         tooltipTitle: `${measured.year} · ${entry.label}`,
         tooltipLines: [
-          `${this.formatRate(measured.value)} tok/s — ${this.scale.bandFor(measured.value).name}`,
+          `${this.formatValue(measured.value)} — ${this.scale.bandFor(measured.value).name}`,
           `mean of ${measured.machineCount} machine${measured.machineCount > 1 ? 's' : ''}`
             + (measured.spread ? ` (${measured.spread})` : ''),
           ...(measured.modelled
@@ -1514,7 +1731,7 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
         points,
         labelX: HORIZON.width - HORIZON.rightMargin + 9,
         labelY: y(Math.min(endValue, high)),
-        labelDetail: `${this.formatRate(endValue)} tok/s${rate ? ' · ' + rate : ''}`,
+        labelDetail: `${this.formatValue(endValue)}${rate ? ' · ' + rate : ''}`,
       };
     });
 
@@ -1587,10 +1804,13 @@ export class ConsumerHardwareAnalysisPage extends BasePage implements OnInit {
       notYet.length ? `Not by ${endYear} — ${notYet.join(', ')}.` : '',
     ].filter(Boolean).join(' ');
 
-    this.horizonCaveat = !modelClass.followsBandwidthLaw
-      ? 'Measured figures only — models this small do not follow the bandwidth law, so nothing here is modelled and the lines are sparser.'
-      : isDerivedModelClass(modelClass)
-        ? `Derived: the source measures the 1–4B bucket as a whole, and this size is scaled from it by weight (×${modelClass.multiplier}).`
-        : '';
+    this.horizonCaveat = this.isAudio
+      ? 'Modelled throughout — no machine in this dataset was benchmarked on transcription, and the '
+        + 'encoder half rests on a compute estimate rather than a measurement.'
+      : !modelClass.followsBandwidthLaw
+        ? 'Measured figures only — models this small do not follow the bandwidth law, so nothing here is modelled and the lines are sparser.'
+        : isDerivedModelClass(modelClass)
+          ? `Derived: the source measures the 1–4B bucket as a whole, and this size is scaled from it by weight (×${modelClass.multiplier}).`
+          : '';
   }
 }

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/consumer-hardware-tab.enum.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/consumer-hardware-tab.enum.ts
@@ -1,6 +1,7 @@
-/** The three views of the Consumer Hardware Analysis dashboard. */
+/** The four views of the Consumer Hardware Analysis dashboard. */
 export enum ConsumerHardwareTabEnum {
   Matrix = 'matrix',
   Explorer = 'explorer',
   Horizon = 'horizon',
+  Notes = 'notes',
 }

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/model-class.enum.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/model-class.enum.ts
@@ -12,4 +12,11 @@ export enum ModelClassEnum {
   Mid = 'mid',
   Large = 'large',
   Xl = 'xl',
+
+  /** Speech models, by the Whisper size they are named for. */
+  WhisperTiny = 'whisper-tiny',
+  WhisperBase = 'whisper-base',
+  WhisperSmall = 'whisper-small',
+  WhisperMedium = 'whisper-medium',
+  WhisperLarge = 'whisper-large',
 }

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/task-mode.enum.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/enums/task-mode.enum.ts
@@ -1,0 +1,7 @@
+/** What the reader is asking the hardware to do. */
+export enum TaskModeEnum {
+  /** Generating text: one memory-bound decode step per token. */
+  Text = 'text',
+  /** Transcribing speech: a compute-bound encoder pass, then a short decode. */
+  Audio = 'audio',
+}

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/dashboard-view-state.interface.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/dashboard-view-state.interface.ts
@@ -1,0 +1,56 @@
+import {ConsumerHardwareTabEnum} from '../enums/consumer-hardware-tab.enum';
+import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
+import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
+import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
+import {ModelClassEnum} from '../enums/model-class.enum';
+
+/**
+ * Everything a reader can change about the view. This is the whole contract for the
+ * shareable URL: anything here that differs from the default appears as a query
+ * parameter, and anything absent from the URL falls back to the default.
+ */
+export interface DashboardViewStateInterface {
+  tab: ConsumerHardwareTabEnum;
+
+  /** The hero's "as of" year. Its default depends on the dataset, not on the page. */
+  year: number;
+
+  showModelledValues: boolean;
+
+  advancedOpen: boolean;
+
+  /** Lower edge of every band but the slowest, which is pinned to zero. */
+  bandLows: number[];
+
+  /** Upper edge of every band but the fastest, which has no ceiling. Kept separately
+   *  because the reader is allowed to leave neighbours disagreeing. */
+  bandHighs: number[];
+
+  contextTokens: number;
+
+  /** Percent of rated peak, per hardware family. */
+  realisedBandwidth: Record<HardwareSegmentEnum, number>;
+
+  /** Milliseconds per token, per hardware family. */
+  overheadMsPerToken: Record<HardwareSegmentEnum, number>;
+
+  matrixGrouping: MatrixGroupingEnum;
+
+  /** A group key, or 'all'. */
+  matrixFilter: string;
+
+  matrixSearch: string;
+
+  explorerSearch: string;
+
+  sortColumn: string;
+
+  sortDirection: 1 | -1;
+
+  horizonClass: ModelClassEnum;
+
+  /** How many years past the last measured one the projection runs. */
+  horizonYears: number;
+
+  horizonCategories: ConsumerTypeEnum[];
+}

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/dashboard-view-state.interface.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/dashboard-view-state.interface.ts
@@ -3,6 +3,7 @@ import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
 import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
 import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
 import {ModelClassEnum} from '../enums/model-class.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 
 /**
  * Everything a reader can change about the view. This is the whole contract for the
@@ -10,6 +11,10 @@ import {ModelClassEnum} from '../enums/model-class.enum';
  * parameter, and anything absent from the URL falls back to the default.
  */
 export interface DashboardViewStateInterface {
+  /** Which task the page is describing. It moves several other defaults with it, so it is
+   *  read out of the URL before anything else. */
+  mode: TaskModeEnum;
+
   tab: ConsumerHardwareTabEnum;
 
   /** The hero's "as of" year. Its default depends on the dataset, not on the page. */
@@ -33,6 +38,12 @@ export interface DashboardViewStateInterface {
 
   /** Milliseconds per token, per hardware family. */
   overheadMsPerToken: Record<HardwareSegmentEnum, number>;
+
+  /** Text tokens a second of speech is worth. Speech mode only. */
+  tokensPerSecondOfAudio: number;
+
+  /** Compute per byte of bandwidth, per hardware family. Speech mode only. */
+  flopPerByte: Record<HardwareSegmentEnum, number>;
 
   matrixGrouping: MatrixGroupingEnum;
 

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/model-class-fit.interface.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/model-class-fit.interface.ts
@@ -8,8 +8,9 @@ import {SourceColumnEnum} from '../enums/source-column.enum';
 export interface ModelClassFitInterface {
   modelClass: ModelClassEnum;
 
-  /** The column the fit was made on. Three sizes share one column. */
-  sourceColumn: SourceColumnEnum;
+  /** The column the fit was made on. Three sizes share one column, and a size with no
+   *  column has no fit of its own — its law is stated rather than measured. */
+  sourceColumn?: SourceColumnEnum;
 
   /** True when this size is scaled off its column rather than measured directly. */
   derived: boolean;
@@ -20,8 +21,9 @@ export interface ModelClassFitInterface {
   /** Tokens per second per GB/s of memory bandwidth. */
   tokensPerGbps: number;
 
-  /** Coefficient of determination of the through-origin fit on the source column. */
-  rSquared: number;
+  /** Coefficient of determination of the through-origin fit on the source column, or null
+   *  where there was nothing to fit. */
+  rSquared: number | null;
 
   /** Bytes moved per generated token, in GB — the reciprocal of the slope. */
   gbPerToken: number;

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/model-class.interface.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/interfaces/model-class.interface.ts
@@ -10,8 +10,12 @@ export interface ModelClassInterface {
   /** Parameter range the size covers, e.g. "7–9B". */
   sizeLabel: string;
 
-  /** Which column of the source this size reads from. */
-  sourceColumn: SourceColumnEnum;
+  /**
+   * Which column of the source this size reads from. Absent when no column measures it —
+   * nothing in the file was benchmarked on transcription — in which case every figure the
+   * page shows for the size is modelled.
+   */
+  sourceColumn?: SourceColumnEnum;
 
   /**
    * How the source figure scales to this size. 1 means the column *is* this size; 2 and
@@ -42,4 +46,21 @@ export interface ModelClassInterface {
    * source measured it and never modelled or projected from bandwidth.
    */
   followsBandwidthLaw: boolean;
+
+  /**
+   * Encoder parameters in billions, for a speech model. The encoder runs once over a fixed
+   * number of frames per second of audio and never generates a token, so it is compute-bound
+   * rather than memory-bound — the half of transcription the bandwidth law does not describe.
+   * Absent on a text size.
+   */
+  encoderParamsB?: number;
+
+  /**
+   * The model's own context window, in tokens. A speech model's cache cannot grow past the
+   * 30-second slice it works in, however wide a context the reader asks for.
+   */
+  contextCapTokens?: number;
+
+  /** A model a reader would recognise at this size. */
+  exampleName?: string;
 }

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/services/hardware-dataset.service.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/services/hardware-dataset.service.ts
@@ -10,8 +10,10 @@ import {
   CSV_TINY_MIN_COLUMN,
   HARDWARE_DATASET_URL,
 } from '../constants/csv-columns.constant';
+import {AUDIO_MODEL_CLASSES} from '../constants/audio-model-classes.constant';
 import {FOLDED_DEVICE_NAMES} from '../constants/folded-devices.constant';
 import {MODEL_CLASSES} from '../constants/model-classes.constant';
+import {SPEECH_DECODER_EFFICIENCY} from '../constants/speech-model.constant';
 import {ModelClassEnum} from '../enums/model-class.enum';
 import {SourceColumnEnum} from '../enums/source-column.enum';
 import {HardwareDatasetInterface} from '../interfaces/hardware-dataset.interface';
@@ -152,7 +154,7 @@ export class HardwareDatasetService {
   private fitModelClasses(devices: HardwareDeviceInterface[]): Record<ModelClassEnum, ModelClassFitInterface> {
     const columnFits = new Map<SourceColumnEnum, {slope: number, rSquared: number, sampleCount: number}>();
 
-    for (const sourceColumn of new Set(MODEL_CLASSES.map(modelClass => modelClass.sourceColumn))) {
+    for (const sourceColumn of new Set(MODEL_CLASSES.map(modelClass => modelClass.sourceColumn!))) {
       const points = devices
         .filter(device => device.bandwidthGbps !== null && device.throughput[sourceColumn].tokensPerSecond !== null)
         .map(device => ({x: device.bandwidthGbps as number, y: device.throughput[sourceColumn].tokensPerSecond as number}));
@@ -168,7 +170,7 @@ export class HardwareDatasetService {
     const fits = {} as Record<ModelClassEnum, ModelClassFitInterface>;
 
     for (const modelClass of MODEL_CLASSES) {
-      const columnFit = columnFits.get(modelClass.sourceColumn)!;
+      const columnFit = columnFits.get(modelClass.sourceColumn!)!;
       const tokensPerGbps = columnFit.slope * modelClass.multiplier;
       const gbPerToken = tokensPerGbps > 0 ? 1 / tokensPerGbps : 0;
 
@@ -181,6 +183,24 @@ export class HardwareDatasetService {
         rSquared: columnFit.rSquared,
         gbPerToken,
         bandwidthEfficiency: gbPerToken > 0 ? modelClass.quantisedWeightsGb / gbPerToken : 0,
+      };
+    }
+
+    // No source measures a speech model, so there is no fit to make: the decode half is
+    // stated to convert the same share of realised bandwidth the text sizes settle at,
+    // divided by the weights it has to stream. Nothing here is evidence, and the sample
+    // count of zero is what says so.
+    for (const modelClass of AUDIO_MODEL_CLASSES) {
+      const tokensPerGbps = SPEECH_DECODER_EFFICIENCY / modelClass.quantisedWeightsGb;
+
+      fits[modelClass.key] = {
+        modelClass: modelClass.key,
+        derived: true,
+        sampleCount: 0,
+        tokensPerGbps,
+        rSquared: null,
+        gbPerToken: 1 / tokensPerGbps,
+        bandwidthEfficiency: SPEECH_DECODER_EFFICIENCY,
       };
     }
 

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.spec.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.spec.ts
@@ -1,0 +1,206 @@
+import {DEFAULT_BAND_EDGES} from '../constants/speed-bands.constant';
+import {
+  DEFAULT_CONTEXT_TOKENS,
+  DEFAULT_REALISED_BANDWIDTH,
+  DEFAULT_TOKEN_OVERHEAD_MS,
+} from '../constants/throughput-model.constant';
+import {ConsumerHardwareTabEnum} from '../enums/consumer-hardware-tab.enum';
+import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
+import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
+import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
+import {ModelClassEnum} from '../enums/model-class.enum';
+import {DashboardViewStateInterface} from '../interfaces/dashboard-view-state.interface';
+import {DashboardUrlSerialiser} from './dashboard-url.serialiser';
+
+describe('DashboardUrlSerialiser', () => {
+
+  const defaults: DashboardViewStateInterface = {
+    tab: ConsumerHardwareTabEnum.Horizon,
+    year: 2025,
+    showModelledValues: true,
+    advancedOpen: false,
+    bandLows: [...DEFAULT_BAND_EDGES],
+    bandHighs: [...DEFAULT_BAND_EDGES],
+    contextTokens: DEFAULT_CONTEXT_TOKENS,
+    realisedBandwidth: {
+      [HardwareSegmentEnum.DiscreteGpu]: DEFAULT_REALISED_BANDWIDTH[HardwareSegmentEnum.DiscreteGpu] * 100,
+      [HardwareSegmentEnum.AppleSoc]: DEFAULT_REALISED_BANDWIDTH[HardwareSegmentEnum.AppleSoc] * 100,
+      [HardwareSegmentEnum.CpuIntegrated]: DEFAULT_REALISED_BANDWIDTH[HardwareSegmentEnum.CpuIntegrated] * 100,
+      [HardwareSegmentEnum.Edge]: DEFAULT_REALISED_BANDWIDTH[HardwareSegmentEnum.Edge] * 100,
+    },
+    overheadMsPerToken: {...DEFAULT_TOKEN_OVERHEAD_MS},
+    matrixGrouping: MatrixGroupingEnum.Type,
+    matrixFilter: 'all',
+    matrixSearch: '',
+    explorerSearch: '',
+    sortColumn: 'bandwidth',
+    sortDirection: -1,
+    horizonClass: ModelClassEnum.Nano2B,
+    horizonYears: 5,
+    horizonCategories: [
+      ConsumerTypeEnum.MainstreamLaptop,
+      ConsumerTypeEnum.ProLaptop,
+      ConsumerTypeEnum.MidRangeGraphicsCard,
+      ConsumerTypeEnum.FlagshipGraphicsCard,
+    ],
+  };
+
+  /** Serialise a change, parse it back, and hand over what came out. */
+  function roundTrip(change: Partial<DashboardViewStateInterface>): DashboardViewStateInterface {
+    const state = {...defaults, ...change};
+    return DashboardUrlSerialiser.fromParams(DashboardUrlSerialiser.toParams(state, defaults), defaults);
+  }
+
+  it('writes nothing at all for a default view', () => {
+    expect(DashboardUrlSerialiser.toParams(defaults, defaults)).toEqual({});
+  });
+
+  it('reads a bare URL as the default view', () => {
+    expect(DashboardUrlSerialiser.fromParams({}, defaults)).toEqual(defaults);
+  });
+
+  it('writes only what the reader changed', () => {
+    const params = DashboardUrlSerialiser.toParams({...defaults, horizonClass: ModelClassEnum.Xl}, defaults);
+
+    expect(params).toEqual({size: ModelClassEnum.Xl});
+  });
+
+  describe('round trips', () => {
+
+    it('the tab, the year and the two toggles', () => {
+      const back = roundTrip({
+        tab: ConsumerHardwareTabEnum.Matrix,
+        year: 2019,
+        showModelledValues: false,
+        advancedOpen: true,
+      });
+
+      expect(back.tab).toBe(ConsumerHardwareTabEnum.Matrix);
+      expect(back.year).toBe(2019);
+      expect(back.showModelledValues).toBeFalse();
+      expect(back.advancedOpen).toBeTrue();
+    });
+
+    it('band edges, including half steps', () => {
+      const back = roundTrip({bandLows: [8, 16.5, 30, 44], bandHighs: [8, 16.5, 30, 44]});
+
+      expect(back.bandLows).toEqual([8, 16.5, 30, 44]);
+      expect(back.bandHighs).toEqual([8, 16.5, 30, 44]);
+    });
+
+    it('a scale the reader deliberately left in conflict', () => {
+      // conversational's ceiling dragged below its own floor: the shared view has to show
+      // the same conflict, not a tidied-up version of it
+      const back = roundTrip({bandLows: [10, 20, 35, 50], bandHighs: [10, 20, 35, 24.5]});
+
+      expect(back.bandLows).toEqual([10, 20, 35, 50]);
+      expect(back.bandHighs).toEqual([10, 20, 35, 24.5]);
+    });
+
+    it('the context window and both tunable losses', () => {
+      const back = roundTrip({
+        contextTokens: 16384,
+        realisedBandwidth: {
+          [HardwareSegmentEnum.DiscreteGpu]: 95,
+          [HardwareSegmentEnum.AppleSoc]: 80,
+          [HardwareSegmentEnum.CpuIntegrated]: 40,
+          [HardwareSegmentEnum.Edge]: 30,
+        },
+        overheadMsPerToken: {
+          [HardwareSegmentEnum.DiscreteGpu]: 1,
+          [HardwareSegmentEnum.AppleSoc]: 12,
+          [HardwareSegmentEnum.CpuIntegrated]: 60,
+          [HardwareSegmentEnum.Edge]: 120,
+        },
+      });
+
+      expect(back.contextTokens).toBe(16384);
+      expect(back.realisedBandwidth[HardwareSegmentEnum.CpuIntegrated]).toBe(40);
+      expect(back.overheadMsPerToken[HardwareSegmentEnum.Edge]).toBe(120);
+    });
+
+    it('the matrix controls and the table sort', () => {
+      const back = roundTrip({
+        matrixGrouping: MatrixGroupingEnum.Family,
+        matrixFilter: HardwareSegmentEnum.AppleSoc,
+        matrixSearch: 'RTX',
+        explorerSearch: 'LPDDR5',
+        sortColumn: 'class:light',
+        sortDirection: 1,
+      });
+
+      expect(back.matrixGrouping).toBe(MatrixGroupingEnum.Family);
+      expect(back.matrixFilter).toBe(HardwareSegmentEnum.AppleSoc);
+      expect(back.matrixSearch).toBe('RTX');
+      expect(back.explorerSearch).toBe('LPDDR5');
+      expect(back.sortColumn).toBe('class:light');
+      expect(back.sortDirection).toBe(1);
+    });
+
+    it('the horizon selection, whatever order the categories were listed in', () => {
+      const back = roundTrip({
+        horizonClass: ModelClassEnum.Tiny,
+        horizonYears: 3,
+        horizonCategories: [ConsumerTypeEnum.BoardOrPhone, ConsumerTypeEnum.FlagshipGraphicsCard],
+      });
+
+      expect(back.horizonClass).toBe(ModelClassEnum.Tiny);
+      expect(back.horizonYears).toBe(3);
+      expect(back.horizonCategories).toEqual([
+        ConsumerTypeEnum.FlagshipGraphicsCard,
+        ConsumerTypeEnum.BoardOrPhone,
+      ]);
+    });
+
+    it('an empty category selection, which is a choice and not an absence', () => {
+      const params = DashboardUrlSerialiser.toParams({...defaults, horizonCategories: []}, defaults);
+      expect(params['cats']).toBe('none');
+
+      expect(DashboardUrlSerialiser.fromParams(params, defaults).horizonCategories).toEqual([]);
+    });
+  });
+
+  describe('when the URL cannot be trusted', () => {
+
+    it('falls back to the default for an unknown enum value', () => {
+      const state = DashboardUrlSerialiser.fromParams(
+        {view: 'wharever', size: 'gpt5', group: 'nonsense', only: 'evil'}, defaults);
+
+      expect(state.tab).toBe(defaults.tab);
+      expect(state.horizonClass).toBe(defaults.horizonClass);
+      expect(state.matrixGrouping).toBe(defaults.matrixGrouping);
+      expect(state.matrixFilter).toBe(defaults.matrixFilter);
+    });
+
+    it('rejects a number list of the wrong length or out of range', () => {
+      expect(DashboardUrlSerialiser.fromParams({bands: '10,20'}, defaults).bandLows).toEqual(defaults.bandLows);
+      expect(DashboardUrlSerialiser.fromParams({bands: '10,20,35,9999'}, defaults).bandLows).toEqual(defaults.bandLows);
+      expect(DashboardUrlSerialiser.fromParams({realised: '95,80,40,5'}, defaults).realisedBandwidth)
+        .toEqual(defaults.realisedBandwidth);
+      expect(DashboardUrlSerialiser.fromParams({overhead: 'a,b,c,d'}, defaults).overheadMsPerToken)
+        .toEqual(defaults.overheadMsPerToken);
+    });
+
+    it('rejects a context length that is not one of the steps', () => {
+      expect(DashboardUrlSerialiser.fromParams({ctx: '3000'}, defaults).contextTokens).toBe(defaults.contextTokens);
+      expect(DashboardUrlSerialiser.fromParams({ctx: '8192'}, defaults).contextTokens).toBe(8192);
+    });
+
+    it('rejects a sort on a column that does not exist', () => {
+      const state = DashboardUrlSerialiser.fromParams({sort: '-drop table'}, defaults);
+
+      expect(state.sortColumn).toBe(defaults.sortColumn);
+      expect(state.sortDirection).toBe(defaults.sortDirection);
+    });
+
+    it('caps a search string rather than carrying a payload', () => {
+      const long = 'x'.repeat(500);
+      expect(DashboardUrlSerialiser.fromParams({q: long}, defaults).matrixSearch.length).toBe(80);
+    });
+
+    it('ignores an implausible year', () => {
+      expect(DashboardUrlSerialiser.fromParams({year: '1'}, defaults).year).toBe(defaults.year);
+      expect(DashboardUrlSerialiser.fromParams({year: '2019'}, defaults).year).toBe(2019);
+    });
+  });
+});

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.spec.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.spec.ts
@@ -1,4 +1,5 @@
-import {DEFAULT_BAND_EDGES} from '../constants/speed-bands.constant';
+import {DEFAULT_AUDIO_BAND_EDGES, DEFAULT_BAND_EDGES} from '../constants/speed-bands.constant';
+import {DEFAULT_FLOP_PER_BYTE, DEFAULT_TOKENS_PER_SECOND_OF_AUDIO} from '../constants/speech-model.constant';
 import {
   DEFAULT_CONTEXT_TOKENS,
   DEFAULT_REALISED_BANDWIDTH,
@@ -9,12 +10,14 @@ import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
 import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
 import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
 import {ModelClassEnum} from '../enums/model-class.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 import {DashboardViewStateInterface} from '../interfaces/dashboard-view-state.interface';
 import {DashboardUrlSerialiser} from './dashboard-url.serialiser';
 
 describe('DashboardUrlSerialiser', () => {
 
   const defaults: DashboardViewStateInterface = {
+    mode: TaskModeEnum.Text,
     tab: ConsumerHardwareTabEnum.Horizon,
     year: 2025,
     showModelledValues: true,
@@ -29,6 +32,8 @@ describe('DashboardUrlSerialiser', () => {
       [HardwareSegmentEnum.Edge]: DEFAULT_REALISED_BANDWIDTH[HardwareSegmentEnum.Edge] * 100,
     },
     overheadMsPerToken: {...DEFAULT_TOKEN_OVERHEAD_MS},
+    tokensPerSecondOfAudio: DEFAULT_TOKENS_PER_SECOND_OF_AUDIO,
+    flopPerByte: {...DEFAULT_FLOP_PER_BYTE},
     matrixGrouping: MatrixGroupingEnum.Type,
     matrixFilter: 'all',
     matrixSearch: '',
@@ -119,6 +124,23 @@ describe('DashboardUrlSerialiser', () => {
       expect(back.overheadMsPerToken[HardwareSegmentEnum.Edge]).toBe(120);
     });
 
+    it('the task, and the two figures only transcription uses', () => {
+      const back = roundTrip({
+        mode: TaskModeEnum.Audio,
+        tokensPerSecondOfAudio: 2.5,
+        flopPerByte: {
+          [HardwareSegmentEnum.DiscreteGpu]: 40,
+          [HardwareSegmentEnum.AppleSoc]: 12,
+          [HardwareSegmentEnum.CpuIntegrated]: 3,
+          [HardwareSegmentEnum.Edge]: 1.5,
+        },
+      });
+
+      expect(back.mode).toBe(TaskModeEnum.Audio);
+      expect(back.tokensPerSecondOfAudio).toBe(2.5);
+      expect(back.flopPerByte[HardwareSegmentEnum.Edge]).toBe(1.5);
+    });
+
     it('the matrix controls and the table sort', () => {
       const back = roundTrip({
         matrixGrouping: MatrixGroupingEnum.Family,
@@ -160,6 +182,40 @@ describe('DashboardUrlSerialiser', () => {
     });
   });
 
+  describe('when the task moves the baseline', () => {
+
+    /** The defaults the page hands over once it has read the task out of the URL. */
+    const audioDefaults: DashboardViewStateInterface = {
+      ...defaults,
+      bandLows: [...DEFAULT_AUDIO_BAND_EDGES],
+      bandHighs: [...DEFAULT_AUDIO_BAND_EDGES],
+      horizonClass: ModelClassEnum.WhisperSmall,
+    };
+
+    it('writes only the task when a speech view is otherwise untouched', () => {
+      const params = DashboardUrlSerialiser.toParams(
+        {...audioDefaults, mode: TaskModeEnum.Audio}, audioDefaults);
+
+      expect(params).toEqual({task: TaskModeEnum.Audio});
+    });
+
+    it('reads speech band edges back against the speech defaults', () => {
+      const params = DashboardUrlSerialiser.toParams(
+        {...audioDefaults, mode: TaskModeEnum.Audio, bandLows: [0.5, 2, 8, 25], bandHighs: [0.5, 2, 8, 25]},
+        audioDefaults);
+
+      expect(params['bands']).toBe('0.5,2,8,25');
+      expect(DashboardUrlSerialiser.fromParams(params, audioDefaults).bandLows).toEqual([0.5, 2, 8, 25]);
+    });
+
+    it('accepts a sort on a speech column', () => {
+      const state = DashboardUrlSerialiser.fromParams({sort: '-class:whisper-large'}, audioDefaults);
+
+      expect(state.sortColumn).toBe('class:whisper-large');
+      expect(state.sortDirection).toBe(-1);
+    });
+  });
+
   describe('when the URL cannot be trusted', () => {
 
     it('falls back to the default for an unknown enum value', () => {
@@ -184,6 +240,19 @@ describe('DashboardUrlSerialiser', () => {
     it('rejects a context length that is not one of the steps', () => {
       expect(DashboardUrlSerialiser.fromParams({ctx: '3000'}, defaults).contextTokens).toBe(defaults.contextTokens);
       expect(DashboardUrlSerialiser.fromParams({ctx: '8192'}, defaults).contextTokens).toBe(8192);
+    });
+
+    it('rejects a task that is not one of the two', () => {
+      expect(DashboardUrlSerialiser.fromParams({task: 'video'}, defaults).mode).toBe(defaults.mode);
+    });
+
+    it('rejects speech figures outside their range', () => {
+      expect(DashboardUrlSerialiser.fromParams({asrTok: '400'}, defaults).tokensPerSecondOfAudio)
+        .toBe(defaults.tokensPerSecondOfAudio);
+      expect(DashboardUrlSerialiser.fromParams({flopByte: '30,10,4'}, defaults).flopPerByte)
+        .toEqual(defaults.flopPerByte);
+      expect(DashboardUrlSerialiser.fromParams({flopByte: '30,10,4,2.5'}, defaults)
+        .flopPerByte[HardwareSegmentEnum.Edge]).toBe(2.5);
     });
 
     it('rejects a sort on a column that does not exist', () => {

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.ts
@@ -1,0 +1,307 @@
+import {URL_PARAMS} from '../constants/url-params.constant';
+import {CONSUMER_TYPE_ORDER} from '../constants/consumer-types.constant';
+import {HARDWARE_SEGMENT_ORDER} from '../constants/hardware-segments.constant';
+import {MODEL_CLASSES} from '../constants/model-classes.constant';
+import {
+  CONTEXT_STEPS,
+  REALISED_BANDWIDTH_RANGE,
+  TOKEN_OVERHEAD_RANGE,
+} from '../constants/throughput-model.constant';
+import {ConsumerHardwareTabEnum} from '../enums/consumer-hardware-tab.enum';
+import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
+import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
+import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
+import {ModelClassEnum} from '../enums/model-class.enum';
+import {DashboardViewStateInterface} from '../interfaces/dashboard-view-state.interface';
+
+/** Highest speed a band edge may be set to, matching the sliders. */
+const MAX_BAND_EDGE = 1000;
+
+/**
+ * Turns the view into query parameters and back.
+ *
+ * Two rules shape the whole thing:
+ *
+ *  - **Only differences travel.** A parameter appears only when its value differs from
+ *    the default, so a default view has a clean URL and a shared one carries exactly
+ *    what the sender changed.
+ *  - **The URL is untrusted input.** Every value is checked against the enum, list
+ *    length or numeric range it belongs to; anything unparseable is dropped in favour of
+ *    the default rather than allowed to produce a broken view.
+ */
+export class DashboardUrlSerialiser {
+
+  /** The parameters that describe `state`, given the defaults it is measured against. */
+  static toParams(state: DashboardViewStateInterface,
+                  defaults: DashboardViewStateInterface): Record<string, string> {
+    const params: Record<string, string> = {};
+    const put = (name: string, value: string) => params[name] = value;
+
+    if (state.tab !== defaults.tab) {
+      put(URL_PARAMS.tab, state.tab);
+    }
+    if (state.year !== defaults.year) {
+      put(URL_PARAMS.year, String(state.year));
+    }
+    if (state.showModelledValues !== defaults.showModelledValues) {
+      put(URL_PARAMS.modelled, state.showModelledValues ? '1' : '0');
+    }
+    if (state.advancedOpen !== defaults.advancedOpen) {
+      put(URL_PARAMS.advanced, state.advancedOpen ? '1' : '0');
+    }
+
+    if (!this.sameNumbers(state.bandLows, defaults.bandLows)) {
+      put(URL_PARAMS.bandLows, this.joinNumbers(state.bandLows));
+    }
+    // The ceilings only need saying when the reader has left them disagreeing with the
+    // floors they sit against — otherwise they are implied.
+    if (!this.sameNumbers(state.bandHighs, state.bandLows)) {
+      put(URL_PARAMS.bandHighs, this.joinNumbers(state.bandHighs));
+    }
+
+    if (state.contextTokens !== defaults.contextTokens) {
+      put(URL_PARAMS.context, String(state.contextTokens));
+    }
+    const realised = this.segmentValues(state.realisedBandwidth);
+    if (!this.sameNumbers(realised, this.segmentValues(defaults.realisedBandwidth))) {
+      put(URL_PARAMS.realised, this.joinNumbers(realised));
+    }
+    const overhead = this.segmentValues(state.overheadMsPerToken);
+    if (!this.sameNumbers(overhead, this.segmentValues(defaults.overheadMsPerToken))) {
+      put(URL_PARAMS.overhead, this.joinNumbers(overhead));
+    }
+
+    if (state.matrixGrouping !== defaults.matrixGrouping) {
+      put(URL_PARAMS.grouping, state.matrixGrouping);
+    }
+    if (state.matrixFilter !== defaults.matrixFilter) {
+      put(URL_PARAMS.matrixFilter, state.matrixFilter);
+    }
+    if (state.matrixSearch.trim() !== defaults.matrixSearch.trim()) {
+      put(URL_PARAMS.matrixSearch, state.matrixSearch.trim());
+    }
+    if (state.explorerSearch.trim() !== defaults.explorerSearch.trim()) {
+      put(URL_PARAMS.explorerSearch, state.explorerSearch.trim());
+    }
+    if (state.sortColumn !== defaults.sortColumn || state.sortDirection !== defaults.sortDirection) {
+      put(URL_PARAMS.sort, `${state.sortDirection === -1 ? '-' : ''}${state.sortColumn}`);
+    }
+
+    if (state.horizonClass !== defaults.horizonClass) {
+      put(URL_PARAMS.horizonClass, state.horizonClass);
+    }
+    if (state.horizonYears !== defaults.horizonYears) {
+      put(URL_PARAMS.horizonYears, String(state.horizonYears));
+    }
+    if (!this.sameCategories(state.horizonCategories, defaults.horizonCategories)) {
+      // an explicit marker, because "no categories" is a real choice and an empty string
+      // would be indistinguishable from an absent parameter
+      put(URL_PARAMS.horizonCategories, state.horizonCategories.length ? state.horizonCategories.join(',') : 'none');
+    }
+
+    return params;
+  }
+
+  /**
+   * The state a URL describes: the defaults, overridden by whatever the parameters say
+   * and can be trusted to mean.
+   */
+  static fromParams(params: Record<string, string | null | undefined>,
+                    defaults: DashboardViewStateInterface): DashboardViewStateInterface {
+    const state: DashboardViewStateInterface = {
+      ...defaults,
+      bandLows: [...defaults.bandLows],
+      bandHighs: [...defaults.bandHighs],
+      realisedBandwidth: {...defaults.realisedBandwidth},
+      overheadMsPerToken: {...defaults.overheadMsPerToken},
+      horizonCategories: [...defaults.horizonCategories],
+    };
+
+    const tab = this.oneOf(params[URL_PARAMS.tab], Object.values(ConsumerHardwareTabEnum));
+    if (tab) {
+      state.tab = tab;
+    }
+
+    const year = this.integer(params[URL_PARAMS.year], 1970, 2200);
+    if (year !== null) {
+      state.year = year;
+    }
+
+    const modelled = this.boolean(params[URL_PARAMS.modelled]);
+    if (modelled !== null) {
+      state.showModelledValues = modelled;
+    }
+    const advanced = this.boolean(params[URL_PARAMS.advanced]);
+    if (advanced !== null) {
+      state.advancedOpen = advanced;
+    }
+
+    const lows = this.numberList(params[URL_PARAMS.bandLows], defaults.bandLows.length, 0, MAX_BAND_EDGE);
+    if (lows) {
+      state.bandLows = lows;
+      // an aligned scale by default: the ceilings follow the floors unless told otherwise
+      state.bandHighs = [...lows];
+    }
+    const highs = this.numberList(params[URL_PARAMS.bandHighs], defaults.bandHighs.length, 0, MAX_BAND_EDGE);
+    if (highs) {
+      state.bandHighs = highs;
+    }
+
+    const context = this.integer(params[URL_PARAMS.context], 0, CONTEXT_STEPS[CONTEXT_STEPS.length - 1]);
+    if (context !== null && CONTEXT_STEPS.includes(context)) {
+      state.contextTokens = context;
+    }
+
+    const realised = this.numberList(
+      params[URL_PARAMS.realised], HARDWARE_SEGMENT_ORDER.length,
+      REALISED_BANDWIDTH_RANGE.min, REALISED_BANDWIDTH_RANGE.max);
+    if (realised) {
+      state.realisedBandwidth = this.bySegment(realised);
+    }
+    const overhead = this.numberList(
+      params[URL_PARAMS.overhead], HARDWARE_SEGMENT_ORDER.length,
+      TOKEN_OVERHEAD_RANGE.min, TOKEN_OVERHEAD_RANGE.max);
+    if (overhead) {
+      state.overheadMsPerToken = this.bySegment(overhead);
+    }
+
+    const grouping = this.oneOf(params[URL_PARAMS.grouping], Object.values(MatrixGroupingEnum));
+    if (grouping) {
+      state.matrixGrouping = grouping;
+    }
+    const filter = this.oneOf(params[URL_PARAMS.matrixFilter], [
+      'all',
+      ...Object.values(ConsumerTypeEnum) as string[],
+      ...Object.values(HardwareSegmentEnum) as string[],
+    ]);
+    if (filter) {
+      state.matrixFilter = filter;
+    }
+    const matrixSearch = this.text(params[URL_PARAMS.matrixSearch]);
+    if (matrixSearch !== null) {
+      state.matrixSearch = matrixSearch;
+    }
+    const explorerSearch = this.text(params[URL_PARAMS.explorerSearch]);
+    if (explorerSearch !== null) {
+      state.explorerSearch = explorerSearch;
+    }
+
+    const sort = (params[URL_PARAMS.sort] ?? '').trim();
+    if (sort) {
+      const descending = sort.startsWith('-');
+      const column = descending ? sort.slice(1) : sort;
+      if (this.isSortableColumn(column)) {
+        state.sortColumn = column;
+        state.sortDirection = descending ? -1 : 1;
+      }
+    }
+
+    const horizonClass = this.oneOf(params[URL_PARAMS.horizonClass], Object.values(ModelClassEnum));
+    if (horizonClass) {
+      state.horizonClass = horizonClass;
+    }
+    const horizonYears = this.integer(params[URL_PARAMS.horizonYears], 1, 50);
+    if (horizonYears !== null) {
+      state.horizonYears = horizonYears;
+    }
+
+    const categories = (params[URL_PARAMS.horizonCategories] ?? '').trim();
+    if (categories === 'none') {
+      state.horizonCategories = [];
+    } else if (categories) {
+      const wanted = categories.split(',')
+        .map(part => part.trim())
+        .filter((part): part is ConsumerTypeEnum => (Object.values(ConsumerTypeEnum) as string[]).includes(part)) as ConsumerTypeEnum[];
+      if (wanted.length) {
+        // keep the page's own order, whatever order the URL listed them in
+        state.horizonCategories = CONSUMER_TYPE_ORDER.filter(type => wanted.includes(type));
+      }
+    }
+
+    return state;
+  }
+
+  // ── validation helpers ──────────────────────────────────────────────────────
+
+  private static oneOf<T extends string>(value: string | null | undefined, allowed: T[]): T | null {
+    const candidate = (value ?? '').trim();
+    return (allowed as string[]).includes(candidate) ? candidate as T : null;
+  }
+
+  private static boolean(value: string | null | undefined): boolean | null {
+    const candidate = (value ?? '').trim();
+    if (candidate === '1' || candidate === 'true') {
+      return true;
+    }
+    if (candidate === '0' || candidate === 'false') {
+      return false;
+    }
+    return null;
+  }
+
+  private static integer(value: string | null | undefined, min: number, max: number): number | null {
+    const candidate = (value ?? '').trim();
+    if (!/^-?\d+$/.test(candidate)) {
+      return null;
+    }
+    const parsed = Number.parseInt(candidate, 10);
+    return parsed >= min && parsed <= max ? parsed : null;
+  }
+
+  /** A list of exactly `length` numbers in range, or null if any part fails. */
+  private static numberList(value: string | null | undefined,
+                            length: number,
+                            min: number,
+                            max: number): number[] | null {
+    const candidate = (value ?? '').trim();
+    if (!candidate) {
+      return null;
+    }
+    const parts = candidate.split(',').map(part => Number.parseFloat(part.trim()));
+    if (parts.length !== length) {
+      return null;
+    }
+    if (parts.some(part => !Number.isFinite(part) || part < min || part > max)) {
+      return null;
+    }
+    return parts;
+  }
+
+  private static text(value: string | null | undefined): string | null {
+    if (value === null || value === undefined) {
+      return null;
+    }
+    // long enough for any machine name in the file, short enough not to be a payload
+    return value.trim().slice(0, 80);
+  }
+
+  private static isSortableColumn(column: string): boolean {
+    const fixed = ['manufacturer', 'name', 'type', 'year', 'memory', 'memoryType', 'bandwidth'];
+    return fixed.includes(column)
+      || MODEL_CLASSES.some(modelClass => `class:${modelClass.key}` === column);
+  }
+
+  private static segmentValues(bySegment: Record<HardwareSegmentEnum, number>): number[] {
+    return HARDWARE_SEGMENT_ORDER.map(segment => bySegment[segment]);
+  }
+
+  private static bySegment(values: number[]): Record<HardwareSegmentEnum, number> {
+    return HARDWARE_SEGMENT_ORDER.reduce((map, segment, index) => {
+      map[segment] = values[index];
+      return map;
+    }, {} as Record<HardwareSegmentEnum, number>);
+  }
+
+  private static sameNumbers(left: number[], right: number[]): boolean {
+    return left.length === right.length && left.every((value, index) => value === right[index]);
+  }
+
+  private static sameCategories(left: ConsumerTypeEnum[], right: ConsumerTypeEnum[]): boolean {
+    return left.length === right.length && left.every(type => right.includes(type));
+  }
+
+  /** Half-steps read better than long decimals in a URL. */
+  private static joinNumbers(values: number[]): string {
+    return values.map(value => Number.isInteger(value) ? String(value) : value.toFixed(1)).join(',');
+  }
+}

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/dashboard-url.serialiser.ts
@@ -1,7 +1,8 @@
 import {URL_PARAMS} from '../constants/url-params.constant';
 import {CONSUMER_TYPE_ORDER} from '../constants/consumer-types.constant';
 import {HARDWARE_SEGMENT_ORDER} from '../constants/hardware-segments.constant';
-import {MODEL_CLASSES} from '../constants/model-classes.constant';
+import {ALL_MODEL_CLASSES} from '../constants/model-classes.constant';
+import {FLOP_PER_BYTE_RANGE, TOKENS_PER_SECOND_RANGE} from '../constants/speech-model.constant';
 import {
   CONTEXT_STEPS,
   REALISED_BANDWIDTH_RANGE,
@@ -12,6 +13,7 @@ import {ConsumerTypeEnum} from '../enums/consumer-type.enum';
 import {HardwareSegmentEnum} from '../enums/hardware-segment.enum';
 import {MatrixGroupingEnum} from '../enums/matrix-grouping.enum';
 import {ModelClassEnum} from '../enums/model-class.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 import {DashboardViewStateInterface} from '../interfaces/dashboard-view-state.interface';
 
 /** Highest speed a band edge may be set to, matching the sliders. */
@@ -20,7 +22,7 @@ const MAX_BAND_EDGE = 1000;
 /**
  * Turns the view into query parameters and back.
  *
- * Two rules shape the whole thing:
+ * Three rules shape the whole thing:
  *
  *  - **Only differences travel.** A parameter appears only when its value differs from
  *    the default, so a default view has a clean URL and a shared one carries exactly
@@ -28,6 +30,9 @@ const MAX_BAND_EDGE = 1000;
  *  - **The URL is untrusted input.** Every value is checked against the enum, list
  *    length or numeric range it belongs to; anything unparseable is dropped in favour of
  *    the default rather than allowed to produce a broken view.
+ *  - **The task sets the baseline.** Speed bands and the starting model size mean
+ *    different things when transcribing, so the defaults handed in here are the defaults
+ *    *for the task in the URL* — the caller reads the task first and builds them.
  */
 export class DashboardUrlSerialiser {
 
@@ -37,6 +42,9 @@ export class DashboardUrlSerialiser {
     const params: Record<string, string> = {};
     const put = (name: string, value: string) => params[name] = value;
 
+    if (state.mode !== defaults.mode) {
+      put(URL_PARAMS.mode, state.mode);
+    }
     if (state.tab !== defaults.tab) {
       put(URL_PARAMS.tab, state.tab);
     }
@@ -69,6 +77,14 @@ export class DashboardUrlSerialiser {
     const overhead = this.segmentValues(state.overheadMsPerToken);
     if (!this.sameNumbers(overhead, this.segmentValues(defaults.overheadMsPerToken))) {
       put(URL_PARAMS.overhead, this.joinNumbers(overhead));
+    }
+
+    if (state.tokensPerSecondOfAudio !== defaults.tokensPerSecondOfAudio) {
+      put(URL_PARAMS.audioTokens, String(state.tokensPerSecondOfAudio));
+    }
+    const flopPerByte = this.segmentValues(state.flopPerByte);
+    if (!this.sameNumbers(flopPerByte, this.segmentValues(defaults.flopPerByte))) {
+      put(URL_PARAMS.flopPerByte, this.joinNumbers(flopPerByte));
     }
 
     if (state.matrixGrouping !== defaults.matrixGrouping) {
@@ -114,8 +130,16 @@ export class DashboardUrlSerialiser {
       bandHighs: [...defaults.bandHighs],
       realisedBandwidth: {...defaults.realisedBandwidth},
       overheadMsPerToken: {...defaults.overheadMsPerToken},
+      flopPerByte: {...defaults.flopPerByte},
       horizonCategories: [...defaults.horizonCategories],
     };
+
+    // The caller has already read the task out of the parameters to build these defaults,
+    // since the task decides what several of them are; this only confirms it.
+    const mode = this.oneOf(params[URL_PARAMS.mode], Object.values(TaskModeEnum));
+    if (mode) {
+      state.mode = mode;
+    }
 
     const tab = this.oneOf(params[URL_PARAMS.tab], Object.values(ConsumerHardwareTabEnum));
     if (tab) {
@@ -163,6 +187,18 @@ export class DashboardUrlSerialiser {
       TOKEN_OVERHEAD_RANGE.min, TOKEN_OVERHEAD_RANGE.max);
     if (overhead) {
       state.overheadMsPerToken = this.bySegment(overhead);
+    }
+
+    const audioTokens = this.decimal(
+      params[URL_PARAMS.audioTokens], TOKENS_PER_SECOND_RANGE.min, TOKENS_PER_SECOND_RANGE.max);
+    if (audioTokens !== null) {
+      state.tokensPerSecondOfAudio = audioTokens;
+    }
+    const flopPerByte = this.numberList(
+      params[URL_PARAMS.flopPerByte], HARDWARE_SEGMENT_ORDER.length,
+      FLOP_PER_BYTE_RANGE.min, FLOP_PER_BYTE_RANGE.max);
+    if (flopPerByte) {
+      state.flopPerByte = this.bySegment(flopPerByte);
     }
 
     const grouping = this.oneOf(params[URL_PARAMS.grouping], Object.values(MatrixGroupingEnum));
@@ -239,6 +275,11 @@ export class DashboardUrlSerialiser {
     return null;
   }
 
+  private static decimal(value: string | null | undefined, min: number, max: number): number | null {
+    const parsed = Number.parseFloat((value ?? '').trim());
+    return Number.isFinite(parsed) && parsed >= min && parsed <= max ? parsed : null;
+  }
+
   private static integer(value: string | null | undefined, min: number, max: number): number | null {
     const candidate = (value ?? '').trim();
     if (!/^-?\d+$/.test(candidate)) {
@@ -278,7 +319,7 @@ export class DashboardUrlSerialiser {
   private static isSortableColumn(column: string): boolean {
     const fixed = ['manufacturer', 'name', 'type', 'year', 'memory', 'memoryType', 'bandwidth'];
     return fixed.includes(column)
-      || MODEL_CLASSES.some(modelClass => `class:${modelClass.key}` === column);
+      || ALL_MODEL_CLASSES.some(modelClass => `class:${modelClass.key}` === column);
   }
 
   private static segmentValues(bySegment: Record<HardwareSegmentEnum, number>): number[] {

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.spec.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.spec.ts
@@ -1,12 +1,14 @@
 import {BandConflictKindEnum} from '../enums/band-conflict-kind.enum';
 import {SpeedBandEnum} from '../enums/speed-band.enum';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 import {SpeedBandScale} from './speed-band.scale';
 
 describe('SpeedBandScale', () => {
 
   let scale: SpeedBandScale;
 
-  beforeEach(() => scale = new SpeedBandScale([10, 20, 35, 50]));
+  // the text task's own defaults: 10 · 20 · 35 · 50 tok/s
+  beforeEach(() => scale = new SpeedBandScale());
 
   it('pins the slowest band to zero and leaves the fastest open-ended', () => {
     expect(scale.bandAt(0).low).toBe(0);
@@ -110,5 +112,38 @@ describe('SpeedBandScale', () => {
     scale.reset();
     expect(scale.edgeSummary).toBe('10 · 20 · 35 · 50');
     expect(scale.isDefault).toBeTrue();
+  });
+
+  describe('when the task changes', () => {
+
+    it('takes the new task\'s edges and unit, dropping the old ones', () => {
+      scale.setEdges([8, 16, 30, 44], [8, 16, 30, 44]);
+
+      scale.useMode(TaskModeEnum.Audio);
+
+      expect(scale.lowEdges).toEqual([1, 3, 10, 30]);
+      expect(scale.unit).toBe('\u00d7');
+      expect(scale.unitLong).toBe('\u00d7 realtime');
+      expect(scale.sliderMax).toBe(60);
+      expect(scale.isDefault).toBeTrue();
+    });
+
+    it('measures "default" against the task it is in', () => {
+      scale.useMode(TaskModeEnum.Audio);
+      scale.setEdges([10, 20, 35, 50], [10, 20, 35, 50]);
+
+      // the text defaults, which are not the speech ones
+      expect(scale.isDefault).toBeFalse();
+
+      scale.reset();
+      expect(scale.lowEdges).toEqual([1, 3, 10, 30]);
+    });
+
+    it('names a gap in the unit the task counts in', () => {
+      scale.useMode(TaskModeEnum.Audio);
+      scale.setHigh(1, 2);
+
+      expect(scale.conflicts()[0].message).toContain('\u00d7 belongs to no band');
+    });
   });
 });

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.ts
@@ -1,5 +1,12 @@
 import {BandConflictKindEnum} from '../enums/band-conflict-kind.enum';
-import {DEFAULT_BAND_EDGES, SPEED_BAND_META} from '../constants/speed-bands.constant';
+import {
+  BAND_EDGES_BY_MODE,
+  BAND_SLIDER_MAX_BY_MODE,
+  BAND_UNIT_BY_MODE,
+  BAND_UNIT_LONG_BY_MODE,
+  SPEED_BAND_META,
+} from '../constants/speed-bands.constant';
+import {TaskModeEnum} from '../enums/task-mode.enum';
 import {BandConflictInterface} from '../interfaces/band-conflict.interface';
 import {SpeedBandInterface} from '../interfaces/speed-band.interface';
 
@@ -9,6 +16,9 @@ import {SpeedBandInterface} from '../interfaces/speed-band.interface';
  * Each band owns *both* ends of its interval, so neighbours are allowed to disagree.
  * Nothing is auto-corrected: an overlap or a gap is reported, and only reconciled when
  * the reader asks. That way dragging one handle never silently moves another.
+ *
+ * The bands keep their names whatever the task; only the scale behind them moves, because
+ * "fast enough" means 50 tokens a second when reading and 30× realtime when transcribing.
  */
 export class SpeedBandScale {
 
@@ -18,8 +28,35 @@ export class SpeedBandScale {
   /** Exclusive upper edge per band. The top band is pinned to Infinity. */
   private high: number[] = [];
 
-  constructor(edges: number[] = DEFAULT_BAND_EDGES) {
-    this.applyEdges(edges);
+  private mode = TaskModeEnum.Text;
+
+  constructor(mode: TaskModeEnum = TaskModeEnum.Text) {
+    this.useMode(mode);
+  }
+
+  /** The task's own defaults, replacing whatever the reader had set for the other one. */
+  useMode(mode: TaskModeEnum) {
+    this.mode = mode;
+    this.applyEdges(this.defaultEdges);
+  }
+
+  /** What a figure on this scale is counted in — "tok/s", or "×" for realtime. */
+  get unit(): string {
+    return BAND_UNIT_BY_MODE[this.mode];
+  }
+
+  /** The same unit written out, for a legend or an axis. */
+  get unitLong(): string {
+    return BAND_UNIT_LONG_BY_MODE[this.mode];
+  }
+
+  /** Top of the slider range, in this task's unit. */
+  get sliderMax(): number {
+    return BAND_SLIDER_MAX_BY_MODE[this.mode];
+  }
+
+  private get defaultEdges(): number[] {
+    return BAND_EDGES_BY_MODE[this.mode];
   }
 
   /** Index of the fastest band. */
@@ -142,7 +179,7 @@ export class SpeedBandScale {
           kind: BandConflictKindEnum.Gap,
           index,
           neighbourIndex: index + 1,
-          message: `${SpeedBandScale.format(upper)}–${SpeedBandScale.format(nextLower)} tok/s belongs to no band`,
+          message: `${SpeedBandScale.format(upper)}–${SpeedBandScale.format(nextLower)} ${this.unit} belongs to no band`,
         });
       } else if (upper > nextLower) {
         found.push({
@@ -181,12 +218,13 @@ export class SpeedBandScale {
   }
 
   reset() {
-    this.applyEdges(DEFAULT_BAND_EDGES);
+    this.applyEdges(this.defaultEdges);
   }
 
   get isDefault(): boolean {
-    return this.low.slice(1).every((value, index) => value === DEFAULT_BAND_EDGES[index])
-      && this.high.slice(0, this.topIndex).every((value, index) => value === DEFAULT_BAND_EDGES[index]);
+    const edges = this.defaultEdges;
+    return this.low.slice(1).every((value, index) => value === edges[index])
+      && this.high.slice(0, this.topIndex).every((value, index) => value === edges[index]);
   }
 
   private applyEdges(edges: number[]) {

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/speed-band.scale.ts
@@ -98,6 +98,28 @@ export class SpeedBandScale {
     }
   }
 
+  /** The movable lower edges: every band's floor but the slowest, which is pinned to zero. */
+  get lowEdges(): number[] {
+    return this.low.slice(1);
+  }
+
+  /** The movable upper edges: every band's ceiling but the fastest, which has none. */
+  get highEdges(): number[] {
+    return this.high.slice(0, this.topIndex);
+  }
+
+  /**
+   * Restores both sets of edges at once — how a shared URL puts the scale back, including
+   * a scale the sender left deliberately in conflict.
+   */
+  setEdges(lows: number[], highs: number[]) {
+    if (lows.length !== this.topIndex || highs.length !== this.topIndex) {
+      return;
+    }
+    this.low = [0, ...lows.map(value => Math.max(0, value))];
+    this.high = [...highs.map(value => Math.max(0, value)), Number.POSITIVE_INFINITY];
+  }
+
   /** Everything the reader's edges currently disagree about. */
   conflicts(): BandConflictInterface[] {
     const found: BandConflictInterface[] = [];

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/throughput-model.spec.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/throughput-model.spec.ts
@@ -1,4 +1,5 @@
 import {MODEL_CLASS_BY_KEY} from '../constants/model-classes.constant';
+import {SPEECH_DECODER_EFFICIENCY} from '../constants/speech-model.constant';
 import {
   DEFAULT_REALISED_BANDWIDTH,
   DEFAULT_TOKEN_OVERHEAD_MS,
@@ -139,5 +140,78 @@ describe('ThroughputModel', () => {
     expect(model.overheadMsPerToken[gpu]).toBe(DEFAULT_TOKEN_OVERHEAD_MS[gpu]);
     expect(model.realisedBandwidth[gpu]).toBe(DEFAULT_REALISED_BANDWIDTH[gpu]);
     expect(model.contextTokens).toBe(4096);
+  });
+
+  describe('transcribing', () => {
+
+    const whisperLarge = MODEL_CLASS_BY_KEY[ModelClassEnum.WhisperLarge];
+    const whisperSmall = MODEL_CLASS_BY_KEY[ModelClassEnum.WhisperSmall];
+
+    /** The decode half is stated, not fitted: the same share every text size settles at. */
+    const speechSlope = SPEECH_DECODER_EFFICIENCY / whisperLarge.quantisedWeightsGb;
+
+    it('caps the cache at the model\'s own window, however wide the context asked for', () => {
+      model.contextTokens = 32768;
+
+      // 448 tokens is the 30-second window, not the 32K the reader dragged to
+      expect(model.contextGb(whisperLarge)).toBeCloseTo(448 * 24 / 1048576, 6);
+      expect(model.contextGb(whisperLarge)).toBeLessThan(model.contextGb(light));
+    });
+
+    it('spends a second of audio on an encoder pass and a few decode steps', () => {
+      const bandwidth = 1008;
+      const tokensPerSecond = model.adjust(bandwidth * speechSlope, whisperLarge, gpu, SPEECH_DECODER_EFFICIENCY);
+
+      const encoder = model.encoderMilliseconds(whisperLarge, gpu, bandwidth);
+      const decoder = model.decoderMilliseconds(tokensPerSecond);
+
+      expect(model.realtimeFactor(bandwidth * speechSlope, whisperLarge, gpu, SPEECH_DECODER_EFFICIENCY, bandwidth))
+        .toBeCloseTo(1000 / (encoder + decoder), 6);
+    });
+
+    it('puts a graphics card far above realtime and a small board just above it', () => {
+      const card = model.realtimeFactor(
+        1008 * speechSlope, whisperLarge, gpu, SPEECH_DECODER_EFFICIENCY, 1008);
+      const board = model.realtimeFactor(
+        17 * SPEECH_DECODER_EFFICIENCY / whisperSmall.quantisedWeightsGb,
+        whisperSmall, HardwareSegmentEnum.Edge, SPEECH_DECODER_EFFICIENCY, 17);
+
+      expect(card).toBeGreaterThan(20);
+      expect(board).toBeGreaterThan(1);
+      expect(board).toBeLessThan(card);
+    });
+
+    it('charges the encoder nothing but compute: halving the assumed FLOP per byte doubles its cost', () => {
+      const before = model.encoderMilliseconds(whisperLarge, gpu, 1008);
+
+      model.flopPerByte[gpu] = model.flopPerByte[gpu] / 2;
+
+      expect(model.encoderMilliseconds(whisperLarge, gpu, 1008)).toBeCloseTo(before * 2, 6);
+    });
+
+    it('counts a longer transcript as more decode steps', () => {
+      const bandwidth = 546;
+      const raw = bandwidth * speechSlope;
+      const atFive = model.realtimeFactor(raw, whisperLarge, gpu, SPEECH_DECODER_EFFICIENCY, bandwidth);
+
+      model.tokensPerSecondOfAudio = 10;
+
+      expect(model.realtimeFactor(raw, whisperLarge, gpu, SPEECH_DECODER_EFFICIENCY, bandwidth))
+        .toBeLessThan(atFive);
+    });
+
+    it('counts either speech figure as a tuned model', () => {
+      expect(model.isTuned).toBeFalse();
+
+      model.tokensPerSecondOfAudio = 3;
+      expect(model.isTuned).toBeTrue();
+
+      model.reset();
+      model.flopPerByte[gpu] = 12;
+      expect(model.isTuned).toBeTrue();
+
+      model.reset();
+      expect(model.isTuned).toBeFalse();
+    });
   });
 });

--- a/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/throughput-model.ts
+++ b/webapp/src/app/pages/dashboards/consumer-hardware-analysis/util/throughput-model.ts
@@ -1,4 +1,9 @@
 import {
+  DEFAULT_FLOP_PER_BYTE,
+  DEFAULT_TOKENS_PER_SECOND_OF_AUDIO,
+  ENCODER_FRAMES_PER_SECOND,
+} from '../constants/speech-model.constant';
+import {
   CONTEXT_STEPS,
   DEFAULT_CONTEXT_TOKENS,
   DEFAULT_REALISED_BANDWIDTH,
@@ -33,9 +38,20 @@ export class ThroughputModel {
 
   overheadMsPerToken: Record<HardwareSegmentEnum, number> = {...DEFAULT_TOKEN_OVERHEAD_MS};
 
-  /** KV cache held at the current context, in GB. */
+  /** Text tokens a second of speech turns into — the length of the decode half. */
+  tokensPerSecondOfAudio = DEFAULT_TOKENS_PER_SECOND_OF_AUDIO;
+
+  /** Compute per byte of bandwidth, the stand-in for the FLOPS this dataset does not carry. */
+  flopPerByte: Record<HardwareSegmentEnum, number> = {...DEFAULT_FLOP_PER_BYTE};
+
+  /**
+   * KV cache held at the current context, in GB. A model's own window is the ceiling: a
+   * speech model works in 30-second slices and cannot hold a 32K conversation whatever
+   * context the reader asks for.
+   */
   contextGb(modelClass: ModelClassInterface): number {
-    return this.contextTokens * modelClass.kvCacheKbPerToken / 1048576;
+    const tokens = Math.min(this.contextTokens, modelClass.contextCapTokens ?? this.contextTokens);
+    return tokens * modelClass.kvCacheKbPerToken / 1048576;
   }
 
   /**
@@ -86,6 +102,52 @@ export class ThroughputModel {
     return 1000 / (streaming + this.overheadMsPerToken[segment]);
   }
 
+  /**
+   * Effective compute, in GFLOP/s, estimated from the memory bandwidth this dataset does
+   * carry. It is the one figure on the page derived from neither the file nor the fit.
+   */
+  effectiveGflops(segment: HardwareSegmentEnum, bandwidthGbps: number): number {
+    return bandwidthGbps * this.realisedBandwidth[segment] * this.flopPerByte[segment];
+  }
+
+  /**
+   * Milliseconds the encoder spends on one second of audio. It runs once over a fixed
+   * number of frames, in a single forward pass, so it costs the same whatever the machine
+   * is doing afterwards — and nothing about it depends on memory bandwidth.
+   */
+  encoderMilliseconds(modelClass: ModelClassInterface,
+                      segment: HardwareSegmentEnum,
+                      bandwidthGbps: number): number {
+    const gflops = this.effectiveGflops(segment, bandwidthGbps);
+    if (gflops <= 0) {
+      return Number.POSITIVE_INFINITY;
+    }
+    // two floating-point operations per parameter per position
+    return 2 * (modelClass.encoderParamsB ?? 0) * ENCODER_FRAMES_PER_SECOND / gflops * 1000;
+  }
+
+  /** Milliseconds the decoder spends on one second of audio, at a given token rate. */
+  decoderMilliseconds(tokensPerSecond: number): number {
+    return tokensPerSecond > 0
+      ? this.tokensPerSecondOfAudio / tokensPerSecond * 1000
+      : Number.POSITIVE_INFINITY;
+  }
+
+  /**
+   * How many times faster than the recording a machine transcribes: a compute-bound
+   * encoder pass over one second of audio, then the handful of memory-bound decode steps
+   * that second is worth. 1× keeps up with the speaker.
+   */
+  realtimeFactor(tokensPerSecond: number,
+                 modelClass: ModelClassInterface,
+                 segment: HardwareSegmentEnum,
+                 sourceEfficiency: number,
+                 bandwidthGbps: number): number {
+    const decoding = this.decoderMilliseconds(
+      this.adjust(tokensPerSecond, modelClass, segment, sourceEfficiency));
+    return 1000 / (this.encoderMilliseconds(modelClass, segment, bandwidthGbps) + decoding);
+  }
+
   /** "4K", "512", or "no" when the cache is switched off. */
   get contextLabel(): string {
     if (this.contextTokens === 0) {
@@ -102,16 +164,20 @@ export class ThroughputModel {
     this.contextTokens = CONTEXT_STEPS[Math.min(Math.max(index, 0), CONTEXT_STEPS.length - 1)];
   }
 
-  /** True once the reader has moved either loss away from its default. */
+  /** True once the reader has moved any of the losses away from its default. */
   get isTuned(): boolean {
-    return Object.values(HardwareSegmentEnum).some(segment =>
-      this.realisedBandwidth[segment] !== DEFAULT_REALISED_BANDWIDTH[segment]
-      || this.overheadMsPerToken[segment] !== DEFAULT_TOKEN_OVERHEAD_MS[segment]);
+    return this.tokensPerSecondOfAudio !== DEFAULT_TOKENS_PER_SECOND_OF_AUDIO
+      || Object.values(HardwareSegmentEnum).some(segment =>
+        this.realisedBandwidth[segment] !== DEFAULT_REALISED_BANDWIDTH[segment]
+        || this.overheadMsPerToken[segment] !== DEFAULT_TOKEN_OVERHEAD_MS[segment]
+        || this.flopPerByte[segment] !== DEFAULT_FLOP_PER_BYTE[segment]);
   }
 
   reset() {
     this.contextTokens = DEFAULT_CONTEXT_TOKENS;
     this.realisedBandwidth = {...DEFAULT_REALISED_BANDWIDTH};
     this.overheadMsPerToken = {...DEFAULT_TOKEN_OVERHEAD_MS};
+    this.tokensPerSecondOfAudio = DEFAULT_TOKENS_PER_SECOND_OF_AUDIO;
+    this.flopPerByte = {...DEFAULT_FLOP_PER_BYTE};
   }
 }


### PR DESCRIPTION
Two commits: the shareable-URL work (which missed the #109 merge) and the speech mode built on top.

## Shareable URLs (`41b1dc4`)

Every control that moves away from its default appears as a query parameter, so a pasted link reproduces the exact view. A default view has a clean URL. The URL is treated as untrusted input — every value is checked against the enum, list length or range it belongs to, and anything unparseable falls back to the default rather than producing a broken view.

## Speech → text (`672b386`)

The same machines, asked a second question. Transcription is a different workload, not a filter over the same numbers: an encoder pass over a fixed 50 frames per second of audio is compute-bound and never generates a token, while the decoder that does only needs a handful of tokens per second of speech.

```
encoder    = 2 × encoder params × 50 frames ÷ effective FLOPS
decoder    = tokens × [ (weights + cache) ÷ (bandwidth × realised) + overhead ]
× realtime = 1000 ÷ (encoder ms + decoder ms)
```

**Verified against published whisper-large throughput.** The built page reproduces all four reference figures:

| Machine | Model | Encoder | Decoder | Result |
| --- | --- | --- | --- | --- |
| RTX 4090 | large-v3 | 2.5 ms | 12.7 ms | **66×** |
| M4 Max | large-v3 | 13.7 ms | 55.1 ms | **15×** |
| Lunar Lake laptop | large-v3 | 231.8 ms | 259.3 ms | **2.0×** |
| Raspberry Pi 5 | small | 460.1 ms | 453.2 ms | **1.1×** |

The split is the interesting column: the 4090 spends five times as long in the decoder as in the encoder, while the laptop and the Pi spend about the same in each — the two are bottlenecked at opposite ends of one model, so an optimisation that transforms one does nothing for the other.

### The bands keep their names

`crawling / slow / readable / conversational / instant` in both modes. Only the numbers behind them change — 10·20·35·50 tok/s reading, 1·3·10·30 × realtime transcribing. Switching modes resets the edges, because 50 tok/s and 50× realtime are not the same request and carrying the number across would quietly reinterpret it.

### Nothing here is measured, and the page says so

No machine in the dataset was benchmarked on transcription. Accordingly: the speech sizes name no source column; their fits carry `sampleCount: 0` and `rSquared: null`; every cell is marked modelled; and the gap-filling switch is held on and disabled (with its label unchanged — it is the same control, not a different one) because there is nothing measured to fall back to. The encoder needs compute, which this dataset does not carry, so it is estimated as FLOP per byte of bandwidth — the one figure on the page derived from neither the file nor a fit, and tunable like the rest.

### Also in this commit

- A **How it works** tab carrying the long-form explainer for whichever mode is showing.
- The mode and its two tunables in the shareable URL, with per-mode defaults, so a speech link still carries only what its sender changed.
- Hero and matrix grids take their column count from the size list instead of a hard-coded 8 — with five columns they were laying out three phantom ones.

## Verification

- 225 specs pass; new coverage for the realtime model, the per-mode band scale, and the widened URL contract.
- `ng build` clean. `anyComponentStyle` budget raised 6 kB → 8 kB for the article styles.
- Both modes checked in a headless browser across all four tabs.